### PR TITLE
usbstick: use only basename if the destination is not specified

### DIFF
--- a/labgrid/external/usbstick.py
+++ b/labgrid/external/usbstick.py
@@ -81,7 +81,7 @@ class USBStick(object):
         Puts a file onto the USB Stick, raises a StateError if it is not
         mounted on the host computer."""
         if not destination:
-            destination = filename
+            destination = os.path.basename(filename)
         if self.status != USBStatus.unplugged:
             raise StateError("Device still plugged in, can't upload image")
         self.command.run_check(


### PR DESCRIPTION
The USBStick.put_file() call supports a default destination parameter, if no
explicit destination is set, use only the basename of the uploadded file to copy
it to the root of the virtual usbstick.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>