### PR TITLE
Remove cleanup function

### DIFF
--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -86,5 +86,5 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         self._child.stdin.flush()
         return result
 
-    def cleanup(self):
+    def on_deactivate(self):
         self.close()

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -202,5 +202,5 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         )
 
         if res != 0:
-            raise CleanUpError("Could not cleanup ControlMaster")
+            self.logger.info("Socket already closed")
         shutil.rmtree(self.tmpdir)

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -38,6 +38,9 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             self.control
         ) if self.control else ""
 
+    def on_deactivate(self):
+        self._cleanup_own_master()
+
     def _start_own_master(self):
         """Starts a controlmaster connection in a temporary directory."""
         self.tmpdir = tempfile.mkdtemp(prefix='labgrid-ssh-tmp-')

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -207,8 +207,6 @@ class Target:
     def cleanup(self):
         """Clean up conntected drivers and resources in reversed order"""
         for drv in reversed(self.drivers):
-            if hasattr(drv, 'cleanup') and callable(getattr(drv, 'cleanup')):
-                drv.cleanup()
+            self.deactivate(drv)
         for res in reversed(self.resources):
-            if hasattr(res, 'cleanup') and callable(getattr(res, 'cleanup')):
-                res.cleanup()
+            self.deactivate(res)


### PR DESCRIPTION
This removes the cleanup function and uses on_deactivate instead.
Do we deactivate the targets drivers after a successful test?