### PR TITLE
coveralls: exclude lines via .coveragerc and use it for travis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[report]
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - pip install -r dev-requirements.txt
   - pip install -e .
 script:
-  - pytest --cov=labgrid
+  - pytest --cov-config .coveragerc --cov=labgrid
 after_success:
   - coveralls


### PR DESCRIPTION
Remove labgrid/protocols/* from coverage.