### PR TITLE
remote: enable TCP_NODELAY for asyncio sessions

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -15,7 +15,7 @@ from collections import defaultdict
 
 from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 
-from .common import ResourceEntry, ResourceMatch, Place
+from .common import ResourceEntry, ResourceMatch, Place, enable_tcp_nodelay
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -45,6 +45,7 @@ class ClientSession(ApplicationSession):
         self.loop = self.config.extra['loop']
         self.args = self.config.extra.get('args')
         self.func = self.config.extra.get('func') or self.args.func
+        enable_tcp_nodelay(self)
         self.join(
             self.config.realm, ["ticket"],
             "client/{}/{}".format(gethostname(), getuser())

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -1,3 +1,4 @@
+import socket
 import time
 from datetime import datetime
 from fnmatch import fnmatchcase
@@ -113,3 +114,11 @@ class Place:
 
     def touch(self):
         self.changed = time.time()
+
+def enable_tcp_nodelay(session):
+    """
+    asyncio/autobahn does not set TCP_NODELAY by default, so we need to do it
+    like this for now.
+    """
+    s = session._transport.transport.get_extra_info('socket')
+    s.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, True)

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -12,7 +12,7 @@ from autobahn import wamp
 from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 from autobahn.wamp.types import RegisterOptions, SubscribeOptions
 
-from .common import ResourceEntry, ResourceMatch, Place
+from .common import ResourceEntry, ResourceMatch, Place, enable_tcp_nodelay
 
 
 class Action(Enum):
@@ -99,6 +99,7 @@ class CoordinatorComponent(ApplicationSession):
 
         yield from self.load()
 
+        enable_tcp_nodelay(self)
         self.join(self.config.realm, ["ticket"], "coordinator")
 
     def onChallenge(self, challenge):

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -14,7 +14,7 @@ import attr
 from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 
 from .config import ResourceConfig
-from .common import ResourceEntry
+from .common import ResourceEntry, enable_tcp_nodelay
 
 logging.basicConfig(
     level=logging.DEBUG,
@@ -143,6 +143,7 @@ class ExporterSession(ApplicationSession):
 
         self.groups = {}
 
+        enable_tcp_nodelay(self)
         self.join(self.config.realm, ["ticket"], self.authid)
 
     def onChallenge(self, challenge):


### PR DESCRIPTION
This is fixed upstream in Python 3.5.3 and 3.6.0.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>