### PR TITLE
strategy/common: open ConsoleProtocol on creation

### DIFF
--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -34,6 +34,10 @@ class BareboxStrategy(Strategy):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        # Open the ConsoleProtocol to not race the output after reset
+        # FIXME: If we have more than one Driver that implements this protocol
+        # we need to iterate over all of them
+        self.target.activate(self.target.get_driver(ConsoleProtocol))
 
     @step(args=['status'])
     def transition(self, status, *, step):

--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -33,6 +33,10 @@ class UBootStrategy(Strategy):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        # Open the ConsoleProtocol to not race the output after reset
+        # FIXME: If we have more than one Driver that implements this protocol
+        # we need to iterate over all of them
+        self.target.activate(self.target.get_driver(ConsoleProtocol))
 
     def transition(self, status):
         if not isinstance(status, Status):


### PR DESCRIPTION
If we do not open the ConsoleProtocol implementation class before starting the
first transition we have a race between the device sending out it's first
bytes (which we want to match) and the ConsoleProtocol implementation
connection. Circumvent this by opening the implementation after creating the
strategy.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>