### PR TITLE
Fix/dev-requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -15,3 +15,4 @@ onewire
 pyudev
 yapf
 requests
+autobahn

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         'pyudev',
         'onewire',
         'requests',
+        'autobahn'
     ],
     packages=[
         'labgrid',


### PR DESCRIPTION
Do we need the txaio library as well? It is used in remote/remote.py:22-24