### PR TITLE
setup: require pyserial 3.3

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,7 @@ Sphinx
 attrs>=16.3
 crossbar
 pexpect
-pyserial
+pyserial>=3.3
 pytest
 pytest-cache
 pytest-cov

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         'attrs',
         'jinja2',
         'pexpect',
-        'pyserial',
+        'pyserial>=3.3',
         'pytest',
         'pyyaml',
         'pyudev',


### PR DESCRIPTION
This includes the fix for the Python 3 releated bug in the RFC2217
support (pyserial/pyserial#180).

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>