### PR TITLE
setup: make onewire an extras_require dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ setup(
     license='LGPL-2.1',
     use_scm_version=True,
     url='https://github.com/labgrid-project',
+    extras_require={
+        'onewire': ['onewire']
+    },
     setup_requires=['pytest-runner', 'setuptools_scm'],
     tests_require=['pytest-mock', ],
     install_requires=[
@@ -21,7 +24,6 @@ setup(
         'pytest',
         'pyyaml',
         'pyudev',
-        'onewire',
         'requests',
         'autobahn'
     ],


### PR DESCRIPTION
This commit makes onewire an extra feature, installable via

pip install -e .[onewire]

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>