### PR TITLE
labgrid/driver: resolve relative paths in bootstrap and fastboot drivers

### DIFF
--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -1,6 +1,8 @@
 import attr
+import subprocess
 
 from ..binding import BindingError, BindingMixin
+from .exception import ExecutionError
 
 
 @attr.s
@@ -22,3 +24,8 @@ class Driver(BindingMixin):
         super().__attrs_post_init__()
         if self.target is None:
             raise BindingError("Drivers can only be created on a valid target")
+
+
+def check_file(filename, *, command_prefix=[]):
+    if subprocess.call(command_prefix + ['test', '-r', filename]) != 0:
+        raise ExecutionError("File {} is not readable".format(filename))

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -1,12 +1,13 @@
 # pylint: disable=no-member
 import attr
 import subprocess
+import os.path
 
 from ..factory import target_factory
 from ..resource.remote import NetworkAndroidFastboot
 from ..resource.udev import AndroidFastboot
 from ..step import step
-from .common import Driver
+from .common import Driver, check_file
 from .exception import ExecutionError
 
 
@@ -44,8 +45,12 @@ class AndroidFastbootDriver(Driver):
 
     @step(args=['filename'])
     def boot(self, filename):
+        filename = os.path.abspath(filename)
+        check_file(filename, command_prefix=self.prefix)
         self("boot", filename)
 
     @step(args=['partition', 'filename'])
     def flash(self, partition, filename):
+        filename = os.path.abspath(filename)
+        check_file(filename, command_prefix=self.prefix)
         self("flash", partition, filename)

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -1,13 +1,14 @@
 # pylint: disable=no-member
 import attr
 import subprocess
+import os.path
 
 from ..factory import target_factory
 from ..protocol import BootstrapProtocol
 from ..resource.remote import NetworkMXSUSBLoader, NetworkIMXUSBLoader
 from ..resource.udev import MXSUSBLoader, IMXUSBLoader
 from ..step import step
-from .common import Driver
+from .common import Driver, check_file
 from .exception import ExecutionError
 
 
@@ -38,6 +39,8 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
     def load(self, filename=None):
         if filename is None and self.image is not None:
             filename = self.target.env.config.get_image_path(self.image)
+        filename = os.path.abspath(filename)
+        check_file(filename, command_prefix=self.loader.command_prefix)
         subprocess.check_call(
             self.loader.command_prefix+[self.tool, "0", filename]
         )
@@ -60,7 +63,6 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
         else:
             self.tool = 'imx-usb-loader'
 
-
     def on_activate(self):
         pass
 
@@ -71,6 +73,8 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
     def load(self, filename=None):
         if filename is None and self.image is not None:
             filename = self.target.env.config.get_image_path(self.image)
+        filename = os.path.abspath(filename)
+        check_file(filename, command_prefix=self.loader.command_prefix)
         subprocess.check_call(
             self.loader.command_prefix+[self.tool, "-p", str(self.loader.path), "-c", filename]
         )


### PR DESCRIPTION
This fixes issue #26.