### PR TITLE
driver/onewiredriver: import onewire when creating a new instance

### DIFF
--- a/labgrid/driver/onewiredriver.py
+++ b/labgrid/driver/onewiredriver.py
@@ -1,5 +1,4 @@
 import logging
-import onewire
 
 import attr
 
@@ -15,6 +14,7 @@ class OneWirePIODriver(Driver, DigitalOutputProtocol):
     bindings = {"port": OneWirePIO, }
 
     def __attrs_post_init__(self):
+        import onewire
         super().__attrs_post_init__()
         self.onewire = onewire.Onewire(self.port.host)
 


### PR DESCRIPTION
Since onewire is going to be an extra in labgrid, we can't import it into the
global scope of the onewiredriver module, since it gets loaded by the reg_driver
call. Fix it by only importing onewire when we create a OneWirePIODriver.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>