### PR TITLE
driver/powerdriver: use shlex to split cmd

### DIFF
--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -1,3 +1,4 @@
+import shlex
 import subprocess
 import time
 from importlib import import_module
@@ -56,18 +57,21 @@ class ExternalPowerDriver(Driver, PowerProtocol):
     @Driver.check_active
     @step()
     def on(self):
-        subprocess.check_call(self.cmd_on)
+        cmd = shlex.split(self.cmd_on)
+        subprocess.check_call(cmd)
 
     @Driver.check_active
     @step()
     def off(self):
-        subprocess.check_call(self.cmd_off)
+        cmd = shlex.split(self.cmd_off)
+        subprocess.check_call(cmd)
 
     @Driver.check_active
     @step()
     def cycle(self):
         if self.cmd_cycle is not None:
-            subprocess.check_call(self.cmd_cycle)
+            cmd = shlex.split(self.cmd_cycle)
+            subprocess.check_call(cmd)
         else:
             self.off()
             time.sleep(self.delay)
@@ -130,12 +134,14 @@ class DigitalOutputPowerDriver(Driver, PowerProtocol):
     @Driver.check_active
     @step()
     def on(self):
-        subprocess.check_call(self.cmd_on)
+        cmd = shlex.split(self.cmd_on)
+        subprocess.check_call(cmd)
 
     @Driver.check_active
     @step()
     def off(self):
-        subprocess.check_call(self.cmd_off)
+        cmd = shlex.split(self.cmd_off)
+        subprocess.check_call(cmd)
 
     @Driver.check_active
     @step()

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -57,7 +57,7 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.on()
 
-        m.assert_called_once_with('set -1 foo-board')
+        m.assert_called_once_with(['set', '-1', 'foo-board'])
 
     def test_off(self, target, mocker):
         m = mocker.patch('subprocess.check_call')
@@ -68,7 +68,7 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.off()
 
-        m.assert_called_once_with('set -0 foo-board')
+        m.assert_called_once_with(['set', '-0', 'foo-board'])
 
     def test_cycle(self, target, mocker):
         m_sleep = mocker.patch('time.sleep')
@@ -81,8 +81,8 @@ class TestExternalPowerDriver:
         d.cycle()
 
         assert m.call_args_list == [
-            mocker.call('set -0 foo-board'),
-            mocker.call('set -1 foo-board'),
+            mocker.call(['set', '-0', 'foo-board']),
+            mocker.call(['set', '-1', 'foo-board']),
         ]
         m_sleep.assert_called_once_with(2.0)
 
@@ -99,7 +99,7 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.cycle()
 
-        m.assert_called_once_with('set -c foo-board')
+        m.assert_called_once_with(['set', '-c', 'foo-board'])
         m_sleep.assert_not_called()
 
 class TestNetworkPowerDriver:


### PR DESCRIPTION
Convert the cmd_ str from config to a list for subprocess.check_call

Signed-off-by: Jan Remmet <j.remmet@phytec.de>