### PR TITLE
shelldriver: expect empty password login despite password is provided

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -97,10 +97,13 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol):
             self.status = 1
             return  # already logged in
         self.console.sendline(self.username)
-        if self.password:
-            self.console.expect("Password: ")
-            self.console.sendline(self.password)
-        self.console.expect(self.prompt, timeout=5)
+        index, _, _, _ = self.console.expect([self.prompt, "Password: "], timeout=5)
+        if index == 1:
+            if self.password:
+                self.console.sendline(self.password)
+                self.console.expect(self.prompt, timeout=5)
+            else:
+                raise Exception("Password entry needed but no password set")
         self._check_prompt()
 
     @step(args=['cmd'], result=True)


### PR DESCRIPTION
When a system was configured to not expect a password (maybe for
debugging purpose) but the shelldriver configuration had a password set,
login failed as the shelldriver only expected a "Password: " line.

This is handled now by also matching for a prompt even when a password
is configured. Additionally, an explicit Exception will be raised now
when no password is configured but the system expects one.