### PR TITLE
dev-requirements: pin autobahn and crossbar to a specific version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 PyYAML
 attrs>=16.3
-crossbar
+crossbar==17.3.1
 pexpect
 pyserial>=3.3
 pytest
@@ -14,5 +14,5 @@ onewire
 pyudev
 yapf
 requests
-autobahn
+autobahn==0.18.1
 -r doc-requirements.txt


### PR DESCRIPTION
A recent autobahn update broke our tests since crossbar has not been updated to
use the new version yet. Pin our autobahn and crossbar version, we'll update
them by hand in the future.

Signed-off-by: Rouven Czerwinski  <r.czerwinski@pengutronix.de>