### PR TITLE
remote: prefer place aliases in user namespace for full matches

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -247,6 +247,8 @@ class ClientSession(ApplicationSession):
                     namespace, alias = alias.split(':', 1)
                     if namespace != getuser():
                         continue
+                    elif alias == pattern:  # prefer user namespace
+                        return [ name ]
                 if pattern in alias:
                     result.add(name)
         return list(result)


### PR DESCRIPTION
Suppose we have the following places:

```
$ labgrid-client places
1003 (rhi:nitrogen6x)
4009 (nitrogen6x-a)
4011 (nitrogen6x-b)
```

Currently, the pattern "nitrogen6x" would match multiple places, even for user rhi:

```
$ whoami
rhi
$ labgrid-client -p nitrogen6x show
labgrid-client: error: pattern nitrogen6x matches multiple places (4011, 1003, 4009)
```

I prefer having short aliases so I dont have to type (and remember) so many characters. But even if I specify the exact alias for the place, it also matches for other places which are not in my namespace, and which I usually need don't work with.

This patch prefers matching the user namespace if the full pattern matches the alias, so that "nitrogen6x" now matches place 1003 for user rhi.