### PR TITLE
ShellDriver: implement file transfer support via XMODEM

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'pyyaml',
         'pyudev',
         'requests',
+        'xmodem>=0.4.5',
         'autobahn'
     ],
     packages=[


### PR DESCRIPTION
This implementation starts the respective sender or receiver on the target and then uses tehmaze's [xmodem][] Python implementation to transfer files over the serial console. It can work with busybox's `rx` (only for receiving on the target) or `lrz`/`lsz` from [lrzsz][] on the target, and autodetects which commands are available.

XMODEM is a very simple, but also very historic protocol with some quirks. See the comment in `labgrid.driver.ShellDriver._put()` for some insight and workarounds.

Unfortunately, after the peer on the target has been started, there is no way to stop it if the transfer fails and get back to a shell prompt, since the peer on the target interprets everything on the console as XMODEM messages. lsz's `--min-bps` option does not seem to work very good (but are included nevertheless), so powercycling the target is possibly the best way to get rid of such situations.

[xmodem]: https://github.com/tehmaze/xmodem
[lrzsz]: https://ohse.de/uwe/software/lrzsz.html