### PR TITLE
doc: UBootStrategy has state 'uboot', not 'barebox'

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -844,7 +844,7 @@ UBootStrategy
 A UBootStrategy has three states:
 
 - unknown
-- barebox
+- uboot
 - shell
 
 


### PR DESCRIPTION
See labgrid/strategy/ubootstrategy.py, line 28