### PR TITLE
fixtures: save env information as xml properties

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -297,6 +297,20 @@ They can also be converted to other formats, such as HTML with `junit2html tool
   $ pytest --lg-env shell-example.yaml --junit-xml=report.xml
   $ junit2html report.xml
 
+
+Labgrid adds additional xml properties to a test run, these are:
+
+- ENV_CONFIG: Name of the configuration file
+- TARGETS: List of target names
+- TARGET_{NAME}_REMOTE: optional, if the target uses a RemotePlace
+  resource, its name is recorded here
+- PATH_{NAME}: optional, labgrid records the name and path
+- PATH_{NAME}_GIT_COMMIT: optional, labgrid tries to record git sha1 values for every
+  path 
+- IMAGE_{NAME}: optional, labgrid records the name and path to the image 
+- IMAGE_{NAME}_GIT_COMMIT: optional, labgrid tries to record git sha1 values for every
+  image 
+
 Command-Line
 ------------
 

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -141,3 +141,29 @@ class Config:
             imports.append(self.resolve_path(user_import))
 
         return imports
+
+    def get_paths(self):
+        """Helper function that returns the subdict of all paths
+
+        Returns:
+            Dict: Dictionary containing all path definitions
+        """
+        paths = []
+
+        for path in self.data.get('paths', []):
+            paths.append(self.resolve_path(path))
+
+        return paths
+
+    def get_images(self):
+        """Helper function that returns the subdict of all images
+
+        Returns:
+            Dict: Dictionary containing all image definitions
+        """
+        images = []
+
+        for image in self.data.get('images', []):
+            images.append(self.resolve_path(image))
+
+        return images

--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -1,7 +1,8 @@
+import os
 import pytest
+import subprocess
 
 from .. import Environment
-
 
 # pylint: disable=redefined-outer-name
 
@@ -12,21 +13,18 @@ def pytest_addoption(parser):
         '--env-config',
         action='store',
         dest='env_config',
-        help='labgrid environment config file (deprecated).'
-    )
+        help='labgrid environment config file (deprecated).')
     group.addoption(
         '--lg-env',
         action='store',
         dest='lg_env',
-        help='labgrid environment config file.'
-    )
+        help='labgrid environment config file.')
     group.addoption(
         '--lg-coordinator',
         action='store',
         dest='lg_coordinator',
         metavar='CROSSBAR_URL',
-        help='labgrid coordinator websocket URL.'
-    )
+        help='labgrid coordinator websocket URL.')
 
 
 @pytest.fixture('session')
@@ -43,8 +41,7 @@ def env(request):
             request.config.warn(
                 'LG-C1',
                 "deprecated option --env-config (use --lg-env instead)",
-                __file__
-            )
+                __file__)
             lg_env = env_config
 
     if lg_env is None:
@@ -52,6 +49,49 @@ def env(request):
     env = Environment(config_file=lg_env)
     if lg_coordinator is not None:
         env.config.set_option('crossbar_url', lg_coordinator)
+
+    if pytest.config.pluginmanager.hasplugin('junitxml'):
+        my_junit = getattr(pytest.config, '_xml', None)
+
+        my_junit.add_global_property('ENV_CONFIG', env.config_file)
+        targets = list(env.config.get_targets().keys())
+        my_junit.add_global_property('TARGETS', targets)
+
+        for target, config in env.config.get_targets().items():
+            try:
+                remote_name = config['resources']['RemotePlace']['name']
+                my_junit.add_global_property(
+                    'TARGET_{}_REMOTE'.format(target.upper()), remote_name)
+            except KeyError:
+                pass
+
+        for name, path in env.config.get_paths().items():
+            my_junit.add_global_property('PATH_{}'.format(name.upper()), path)
+            try:
+                sha = subprocess.check_output(
+                    "git rev-parse HEAD".split(), cwd=path)
+            except subprocess.CalledProcessError:
+                continue
+            except FileNotFoundError:
+                continue
+            my_junit.add_global_property(
+                'PATH_{}_GIT_COMMIT'.format(name.upper()),
+                sha.decode("utf-8").strip("\n"))
+
+        for name, image in env.config.get_images().items():
+            my_junit.add_global_property(
+                'IMAGE_{}'.format(name.upper()), image)
+            try:
+                sha = subprocess.check_output(
+                    "git rev-parse HEAD".split(), cwd=os.path.dirname(image))
+            except subprocess.CalledProcessError:
+                continue
+            except FileNotFoundError:
+                continue
+            my_junit.add_global_property(
+                'IMAGE_{}_GIT_COMMIT'.format(name.upper()),
+                sha.decode("utf-8").strip("\n"))
+
     yield env
     env.cleanup()
 


### PR DESCRIPTION
This commit adds the ability to save environment information in the junit xml
file.

I'm not sure we want to do this in the env fixture, but the configuration gets not parsed beforehand and all the necessary information is available here.

TODO:
- [x] Documentation