### PR TITLE
bareboxdriver: add bootstring argument

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -532,6 +532,7 @@ Arguments:
   - prompt (regex): barebox prompt to match
   - autoboot (regex, default="stop autoboot"): autoboot message to match
   - interrupt (str, default="\\n"): string to interrupt autoboot (use "\\x03" for CTRL-C)
+  - bootstring (regex, default="Linux version \d"): succesfully jumped into the kernel 
 
 ExternalConsoleDriver
 ~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -29,6 +29,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     prompt = attr.ib(default="", validator=attr.validators.instance_of(str))
     autoboot = attr.ib(default="stop autoboot", validator=attr.validators.instance_of(str))
     interrupt = attr.ib(default="\n", validator=attr.validators.instance_of(str))
+    bootstring = attr.ib(default="Linux version \d", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -149,7 +150,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """Wait for the initial Linux version string to verify we succesfully
         jumped into the kernel.
         """
-        self.console.expect(r"Linux version \d")
+        self.console.expect(self.bootstring)
 
     @Driver.check_active
     def boot(self, name: str):


### PR DESCRIPTION
If 'quiet' is used as linux bootarg, you may adjust the bootstring.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>