### PR TITLE
config: retrieve absolute path before retrieving base

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -15,7 +15,7 @@ class Config:
     filename = attr.ib(validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
-        self.base = os.path.dirname(self.filename)
+        self.base = os.path.dirname(os.path.abspath(self.filename))
         try:
             with open(self.filename) as file:
                 self.data = load(file)


### PR DESCRIPTION
The Config class retrieves a base path to resolve paths. This allows a relative
specification in the yaml configuration. The caller can pass a non
absolute path, call abspath before retrieving the base path.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>