### PR TITLE
tests: properly skip tests at the module level

### DIFF
--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -3,8 +3,8 @@ from importlib.util import find_spec
 import pytest
 import pexpect
 
-if not find_spec('crossbar'):
-    pytest.skip("crossbar not found")
+pytestmark = pytest.mark.skipif(not find_spec("crossbar"),
+                              reason="crossbar required")
 
 def test_startup(crossbar):
     pass

--- a/tests/test_onewire.py
+++ b/tests/test_onewire.py
@@ -1,5 +1,7 @@
 import pytest
 
+pytest.importorskip("onewire")
+
 from labgrid.driver import OneWirePIODriver
 from labgrid.resource import OneWirePIO
 


### PR DESCRIPTION
pytest.skip() only works in individual test function, use the proper pytestmark
variable to skip unavailable tests at the module level. Also introduce this
mechanism for the onewire tests.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>