### PR TITLE
crossbar: enable pings to detect tcp timeouts

### DIFF
--- a/.crossbar/config.yaml
+++ b/.crossbar/config.yaml
@@ -51,6 +51,10 @@ workers:
           ticket:
             type: dynamic
             authenticator: org.labgrid.authenticate
+        options:
+          auto_ping_interval: 1000
+          auto_ping_timeout: 2000
+          auto_ping_size: 4
   components:
   - type: class
     classname: labgrid.remote.authenticator.AuthenticatorSession


### PR DESCRIPTION
The coordinator does not correctly detect a disconnected exporter as long as no
data is send over the connection. Enable auto_pings to detect a disconnected
exporter.

References: https://github.com/crossbario/crossbar/issues/980

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>