### PR TITLE
Add remote client state support

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -45,6 +45,9 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
             self.serial.baudrate = self.port.speed
         self.open()
 
+    def on_deactivate(self):
+        self.close()
+
     def _read(self, size: int=1, timeout: float=0.0):
         """
         Reads 'size' or more bytes from the serialport

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -723,6 +723,12 @@ def main():
         default=False,
         help="enable debug mode"
     )
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        action='count',
+        default=0
+    )
     subparsers = parser.add_subparsers(
         dest='command',
         title='available subcommands',
@@ -743,14 +749,12 @@ def main():
                                       help="list available resources")
     subparser.add_argument('-a', '--acquired', action='store_true')
     subparser.add_argument('-e', '--exporter')
-    subparser.add_argument('-v', '--verbose', action='count', default=0)
     subparser.add_argument('match', nargs='?')
     subparser.set_defaults(func=ClientSession.print_resources)
 
     subparser = subparsers.add_parser('places', aliases=('p',),
                                       help="list available places")
     subparser.add_argument('-a', '--acquired', action='store_true')
-    subparser.add_argument('-v', '--verbose', action='store_true')
     subparser.set_defaults(func=ClientSession.print_places)
 
     subparser = subparsers.add_parser('who',

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -269,6 +269,9 @@ class Target:
         # consistency check
         assert client in self.resources or client in self.drivers
 
+        for cli in client.clients:
+            self.deactivate(cli)
+
         # update state
         client.on_deactivate()
         client.state = BindingState.bound

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -57,6 +57,10 @@ the crossbar url of the coordinator
 .BI \-c \ CONFIG\fP,\fB \ \-\-config \ CONFIG
 set the configuration file
 .TP
+.BI \-s \ STATE\fP,\fB \ \-\-state \ STATE
+set an initial state before executing a command, requires a configuration
+file and strategy
+.TP
 .B \-d\fP,\fB  \-\-debug
 enable debugging
 .UNINDENT
@@ -69,6 +73,11 @@ Various labgrid\-client commands use the following environment variable:
 .SS PLACE
 .sp
 This variable can be used to specify a place without using the \fB\-p\fP option, the \fB\-p\fP option overrides it.
+.SS STATE
+.sp
+This variable can be used to specify a state which the device transitions into
+before executing a command. Requires a configuration file and a Strategy
+specified for the device.
 .SH MATCHES
 .sp
 Match patterns are used to assign a resource to a specific place. The format is:
@@ -113,6 +122,8 @@ matches anything.
 \fBfastboot\fP            Run fastboot
 .sp
 \fBbootstrap\fP           Start a bootloader
+.sp
+\fBio\fP                  Interact with Onewire devices
 .SH EXAMPLES
 .sp
 To retrieve a list of places run:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -9,10 +9,10 @@ labgrid-client interface to control boards
 :organization: Labgrid-Project
 :Date:   2017-04-15
 :Copyright: Copyright (C) 2016-2017 Pengutronix. This library is free software;
-            you can redistribute it and/or modify it under the terms of the GNU
-            Lesser General Public License as published by the Free Software
-            Foundation; either version 2.1 of the License, or (at your option)
-            any later version.
+	    you can redistribute it and/or modify it under the terms of the GNU
+	    Lesser General Public License as published by the Free Software
+	    Foundation; either version 2.1 of the License, or (at your option)
+	    any later version.
 :Version: 0.0.1
 :Manual section: 1
 :Manual group: embedded testing
@@ -20,11 +20,11 @@ labgrid-client interface to control boards
 SYNOPSIS
 --------
 
-``labgrid-client`` ``--help`` 
+``labgrid-client`` ``--help``
 
 ``labgrid-client`` -p <place> <command>
 
-``labgrid-client`` ``places|resources`` 
+``labgrid-client`` ``places|resources``
 
 DESCRIPTION
 -----------
@@ -42,6 +42,9 @@ OPTIONS
     the crossbar url of the coordinator
 -c CONFIG, --config CONFIG
     set the configuration file
+-s STATE, --state STATE
+    set an initial state before executing a command, requires a configuration
+    file and strategy
 -d, --debug
     enable debugging
 
@@ -56,6 +59,12 @@ Various labgrid-client commands use the following environment variable:
 PLACE
 ~~~~~
 This variable can be used to specify a place without using the ``-p`` option, the ``-p`` option overrides it.
+
+STATE
+~~~~~
+This variable can be used to specify a state which the device transitions into
+before executing a command. Requires a configuration file and a Strategy
+specified for the device.
 
 MATCHES
 -------
@@ -102,6 +111,8 @@ LABGRID-CLIENT COMMANDS
 ``fastboot``            Run fastboot
 
 ``bootstrap``           Start a bootloader
+
+``io``                  Interact with Onewire devices
 
 EXAMPLES
 --------


### PR DESCRIPTION
This adds support for strategy states to the labgrid client.

TODO:
- [x] Rework on_deactivate to actually work recursively