### PR TITLE
travis.yml: work around pypa/setuptools#1086

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y libow-dev
 install:
+  - pip install --upgrade setuptools
   - pip install --upgrade pytest pytest-mock pytest-cov coveralls codecov
   - pip install -r dev-requirements.txt
   - pip install -e .


### PR DESCRIPTION
The python3.6 archive from travis contains setuptools 36.2.0 which breaks if
additional packages are installed when setuptools is upgraded. Work around the
issue by explicitly upgrading setuptools before installing our packages.

More details in pypa/setuptools#1086

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>