### PR TITLE
driver/shelldriver: fix object has no attribute _put_file

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -355,7 +355,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             IOError: if the provided localfile could not be found
             ExecutionError: if something else went wrong
         """
-        self._put_file(localfile, remotefile)
+        self._put(localfile, remotefile)
 
     @step(title='get_bytes', args=['remotefile'])
     def _get_bytes(self, remotefile: str):


### PR DESCRIPTION
This was a typo in the original pull-request.

Fixes #94, again.

Signed-off-by: Roland Hieber <r.hieber@pengutronix.de>