### PR TITLE
remote: support named matches

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -388,7 +388,7 @@ class ClientSession(ApplicationSession):
         if place.acquired:
             raise UserError("can not change acquired place {}".format(place.name))
         for pattern in self.args.patterns:
-            if pattern in map(str, place.matches):
+            if pattern in map(repr, place.matches):
                 print("pattern '{}' exists, skipping".format(pattern))
                 continue
             if not (2 <= pattern.count("/") <= 3):
@@ -411,7 +411,7 @@ class ClientSession(ApplicationSession):
         if place.acquired:
             raise UserError("can not change acquired place {}".format(place.name))
         for pattern in self.args.patterns:
-            if pattern not in map(str, place.matches):
+            if pattern not in map(repr, place.matches):
                 print("pattern '{}' not found, skipping".format(pattern))
                 continue
             if not (2 <= pattern.count("/") <= 3):

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -47,7 +47,7 @@ class ResourceEntry:
         }
 
 
-@attr.s(cmp=True)
+@attr.s(cmp=True, repr=False, str=False)
 # This class requires cmp=True, since we put the matches into a list and require
 # the cmp functions to be able to remove the matches from the list later on.
 class ResourceMatch:
@@ -55,6 +55,8 @@ class ResourceMatch:
     group = attr.ib()
     cls = attr.ib()
     name = attr.ib(default=None)
+    # rename is just metadata, so don't use it for comparing matches
+    rename = attr.ib(default=None, cmp=False)
 
     @classmethod
     def fromstr(cls, pattern):
@@ -65,10 +67,16 @@ class ResourceMatch:
             )
         return cls(*pattern.split("/"))
 
-    def __str__(self):
+    def __repr__(self):
         result = "{}/{}/{}".format(self.exporter, self.group, self.cls)
         if self.name is not None:
             result += "/{}".format(self.name)
+        return result
+
+    def __str__(self):
+        result = repr(self)
+        if self.rename:
+            result += " → " + self.rename
         return result
 
     def ismatch(self, resource_path):
@@ -111,20 +119,32 @@ class Place:
             print(indent + "  {}".format(match))
         print(indent + "acquired: {}".format(self.acquired))
         print(indent + "acquired resources:")
-        for resource in self.acquired_resources:
-            print(indent + "  {}".format('/'.join(resource)))
+        for resource_path in self.acquired_resources:
+            match = self.getmatch(resource_path)
+            if match.rename:
+                print(indent + "  {} → {}".format(
+                    '/'.join(resource_path), match.rename))
+            else:
+                print(indent + "  {}".format(
+                    '/'.join(resource_path)))
         print(indent + "created: {}".format(datetime.fromtimestamp(self.created)))
         print(indent + "changed: {}".format(datetime.fromtimestamp(self.changed)))
+
+    def getmatch(self, resource_path):
+        """Return the ResourceMatch object for the given resource path or None if not found.
+
+        A resource_path has the structure (exporter, group, cls, name).
+        """
+        for match in self.matches:
+            if match.ismatch(resource_path):
+                return match
 
     def hasmatch(self, resource_path):
         """Return True if this place as a ResourceMatch object for the given resource path.
 
         A resource_path has the structure (exporter, group, cls, name).
         """
-        for match in self.matches:
-            if match.ismatch(resource_path):
-                return True
-        return False
+        return self.getmatch(resource_path) is not None
 
     def touch(self):
         self.changed = time.time()

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -360,12 +360,14 @@ class CoordinatorComponent(ApplicationSession):
         return True
 
     @asyncio.coroutine
-    def add_place_match(self, placename, pattern, details=None):
+    def add_place_match(self, placename, pattern, rename=None, details=None):
         try:
             place = self.places[placename]
         except KeyError:
             return False
-        match = ResourceMatch(*pattern.split('/'))
+        match = ResourceMatch(*pattern.split('/'), rename=rename)
+        if match in place.matches:
+            return False
         place.matches.append(match)
         place.touch()
         self.publish(
@@ -375,12 +377,12 @@ class CoordinatorComponent(ApplicationSession):
         return True
 
     @asyncio.coroutine
-    def del_place_match(self, placename, pattern, details=None):
+    def del_place_match(self, placename, pattern, rename=None, details=None):
         try:
             place = self.places[placename]
         except KeyError:
             return False
-        match = ResourceMatch(*pattern.split('/'))
+        match = ResourceMatch(*pattern.split('/'), rename=rename)
         try:
             place.matches.remove(match)
         except ValueError:


### PR DESCRIPTION
Matches can now have an optional name. When a resource matches a named
ResourceMatch, it will be made available on the client under that name.
This is useful when using multiple resources of the same class in one
target.

Note that clients and coordinator must be updated together, as the
older clients do not understand the 'rename' field.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>