### PR TITLE
multi-instance named resources and drivers

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -418,24 +418,6 @@ To remove this limitation, we should have a common way to make files available
 to the exporter, possibly by generating a hash locally and rsyncing new files to
 the exporter.
 
-Multiple Driver Instances
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For some Protocols, it seems useful to allow multiple instances.
-
-DigitalOutputProtocol:
-   A board may have two jumpers to control the boot mode in addition to a reset
-   GPIO.
-   Currently it's not possible to use these on a single target.
-
-ConsoleProtocol:
-   Some boards have multiple console interfaces or expose a login prompt via a
-   USB serial gadget.
-   In most cases, it would be enough to allow switching between them.
-
-PowerProtocol:
-   In some cases, multiple power ports need to be controled for one Target.
-
 Remote Target Reservation
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -157,6 +157,25 @@ A realistic sequence of activation might look like this:
 Any `ManagedResources` which become unavailable at runtime will automatically
 deactivate the dependent drivers.
 
+Multiple Drivers and Names
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Each driver and resource can have an optional name. This parameter is required
+for all manual creations of drivers and resources. To manually bind to a
+specific driver set a binding mapping before creating the driver:
+
+  >>> t = Target("Test")
+  >>> SerialPort(t, "First")
+  SerialPort(target=Target(name='Test', env=None), name='First', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
+  >>> SerialPort(t, "Second")
+  SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
+  >>> t.set_binding_map({"port": "Second"})
+  >>> sd = SerialDriver(t, "Driver")
+  >>> sd
+  SerialDriver(target=Target(name='Test', env=None), name='Driver', state=<BindingState.bound: 1>, txdelay=0.0)
+  >>> sd.port
+  SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
+
 Strategies
 ~~~~~~~~~~
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -22,18 +22,24 @@ At the lower level, a :any:`Target` can be created directly::
 Next, the required :any:`Resources <Resource>` can be created::
 
   >>> from labgrid.resource import RawSerialPort
-  >>> rsp = RawSerialPort(t, port='/dev/ttyUSB0')
+  >>> rsp = RawSerialPort(t, name=None, port='/dev/ttyUSB0')
+
+.. note::
+   Since we support multiple drivers of the same type, resources and drivers
+   have a required name attribute. If you don't require support for this
+   functionality set the name to `None`.
 
 Then, a :any:`Driver` needs to be created on the `Target`::
 
   >>> from labgrid.driver import SerialDriver
-  >>> sd = SerialDriver(t)
+  >>> sd = SerialDriver(t, name=None)
+
 
 As the `SerialDriver` declares a binding to a SerialPort, the target binds it
 to the resource created above::
 
   >>> sd.port
-  RawSerialPort(target=Target(name='example', env=None), state=<BindingState.active: 2>, avail=True, port='/dev/ttyUSB0', speed=115200)
+  RawSerialPort(target=Target(name='example', env=None), name=None, state=<BindingState.bound: 1>, avail=True, port='/dev/ttyUSB0', speed=115200)
   >>> sd.port is rsp
   True
 
@@ -41,6 +47,17 @@ Before the driver can be used, it needs to be activated::
 
   >>> t.activate(sd)
   >>> sd.write(b'test')
+
+Active drivers can be accessed by class (any `Driver` or `Protocol`) using some
+syntactic sugar::
+
+  >>> target = Target('main')
+  >>> console = FakeConsoleDriver(target, 'console')
+  >>> target.activate(console)
+  >>> target[FakeConsoleDriver]
+  FakeConsoleDriver(target=Target(name='main', …), name='console', …)
+  >>> target[FakeConsoleDriver, 'console']
+  FakeConsoleDriver(target=Target(name='main', …), name='console', …)
 
 Environments
 ^^^^^^^^^^^^
@@ -77,7 +94,7 @@ To access the target's console, the correct driver object can be found by using
   >>> from labgrid.protocol import ConsoleProtocol
   >>> cp = t.get_driver(ConsoleProtocol)
   >>> cp
-  SerialDriver(target=Target(name='example', env=Environment(config_file='example.yaml')), state=<BindingState.active: 2>)
+  SerialDriver(target=Target(name='example', env=Environment(config_file='example.yaml')), name=None, state=<BindingState.active: 2>, txdelay=0.0)
   >>> cp.write(b'test')
 
 When using the ``get_driver`` method, the driver is automatically activated.

--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -45,6 +45,7 @@ class BindingMixin:
     state = attr.ib(default=BindingState.idle, init=False)
 
     def __attrs_post_init__(self):
+        binding_names = {}
         self.suppliers = set()
         self.clients = set()
         target = self.target
@@ -89,3 +90,13 @@ class BindingMixin:
             return func(self, *_args, **_kwargs)
 
         return wrapper
+
+    class NamedBinding:
+        """
+        Marks a binding (or binding set) as requiring an explicit name.
+        """
+        def __init__(self, value):
+            self.value = value
+
+        def __repr__(self):
+            return "Binding.Named({})".format(repr(self.value))

--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -40,6 +40,8 @@ class BindingMixin:
 
     # these are controlled by the Target
     target = attr.ib()
+    name = attr.ib(
+        validator=attr.validators.optional(attr.validators.instance_of(str)))
     state = attr.ib(default=BindingState.idle, init=False)
 
     def __attrs_post_init__(self):

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -17,7 +17,6 @@ from .onewiredriver import OneWirePIODriver
 @attr.s(cmp=False)
 class ManualPowerDriver(Driver, PowerProtocol):
     """ManualPowerDriver - Driver to tell the user to control a target's power"""
-    name = attr.ib(validator=attr.validators.instance_of(str))
 
     @Driver.check_active
     @step()

--- a/labgrid/exceptions.py
+++ b/labgrid/exceptions.py
@@ -13,6 +13,11 @@ class NoSupplierFoundError(Exception):
 
 
 @attr.s(cmp=False)
+class InvalidConfigError(Exception):
+    msg = attr.ib(validator=attr.validators.instance_of(str))
+
+
+@attr.s(cmp=False)
 class NoDriverFoundError(NoSupplierFoundError):
     pass
 

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -76,17 +76,18 @@ class TargetFactory:
         else:
             raise InvalidConfigError("invalid type {} (should be dict or list)".format(type(data)))
         for item in result:
+            item.setdefault('name', None)
             assert 'cls' in item
         return result
 
-    def make_resource(self, target, resource, args):
+    def make_resource(self, target, resource, name, args):
         assert isinstance(args, dict)
-        r = self.resources[resource](target, **args)
+        r = self.resources[resource](target, name, **args)
         return r
 
-    def make_driver(self, target, driver, args):
+    def make_driver(self, target, driver, name, args):
         assert isinstance(args, dict)
-        d = self.drivers[driver](target, **args)
+        d = self.drivers[driver](target, name, **args)
         return d
 
     def make_target(self, name, config, *, env=None):
@@ -98,12 +99,12 @@ class TargetFactory:
             resource = item.pop('cls')
             name = item.pop('name', None)
             args = item # remaining args
-            r = self.make_resource(target, resource, args)
+            r = self.make_resource(target, resource, name, args)
         for item in self._convert_to_named_list(config.get('drivers', {})):
             driver = item.pop('cls')
             name = item.pop('name', None)
             args = item # remaining args
-            d = self.make_driver(target, driver, args)
+            d = self.make_driver(target, driver, name, args)
         return target
 
 

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -103,7 +103,9 @@ class TargetFactory:
         for item in self._convert_to_named_list(config.get('drivers', {})):
             driver = item.pop('cls')
             name = item.pop('name', None)
+            bindings = item.pop('bindings', {})
             args = item # remaining args
+            target.set_binding_map(bindings)
             d = self.make_driver(target, driver, name, args)
         return target
 

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -22,6 +22,11 @@ class TargetFactory:
         r = self.resources[resource](target, **args)
         return r
 
+    def make_driver(self, target, driver, args):
+        assert isinstance(args, dict)
+        d = self.drivers[driver](target, **args)
+        return d
+
     def make_target(self, name, config, *, env=None):
         from .target import Target
 
@@ -30,8 +35,7 @@ class TargetFactory:
         for resource, args in config.get('resources', {}).items():
             r = self.make_resource(target, resource, args)
         for driver, args in config.get('drivers', {}).items():
-            assert isinstance(args, dict)
-            d = self.drivers[driver](target, **args)
+            d = self.make_driver(target, driver, args)
         return target
 
 

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -1,3 +1,5 @@
+from .exceptions import InvalidConfigError
+
 class TargetFactory:
     def __init__(self):
         self.resources = {}
@@ -17,6 +19,66 @@ class TargetFactory:
         self.drivers[cls.__name__] = cls
         return cls
 
+    def _convert_to_named_list(self, data):
+        """Convert a tree of resources or drivers to a named list.
+
+        When using named resources or drivers, the config file uses a list of
+        dicts instead of simply nested dicts. This allows creating multiple
+        instances of the same class with different names.
+
+        resources: # or drivers
+          FooPort: {}
+          BarPort:
+            name: "bar"
+
+        or
+
+        resources: # or drivers
+        - FooPort: {}
+        - BarPort:
+            name: "bar"
+
+        should be transformed to
+
+        resources: # or drivers
+        - cls: "FooPort"
+        - cls: "BarPort"
+          name: "bar"
+        """
+
+        # resolve syntactic sugar (list of dicts each containing a dict of key -> args)
+        if isinstance(data, list):
+            for idx, item in enumerate(data):
+                if not isinstance(item, dict):
+                    raise InvalidConfigError(
+                        "invalid list item type {} (should be dict)".format(type(item)))
+                if len(item) < 1:
+                    raise InvalidConfigError("invalid empty dict as list item")
+                if len(item) > 1:
+                    if 'cls' in item:
+                        continue
+                    else:
+                        raise InvalidConfigError("missing 'cls' key in {}".format(item))
+                # only one pair left
+                (key, value), = item.items()
+                if key == 'cls':
+                    continue
+                else:
+                    item.clear()
+                    item['cls'] = key
+                    item.update(value)
+            result = data
+        elif isinstance(data, dict):
+            result = []
+            for cls, args in data.items():
+                args.setdefault('cls', cls)
+                result.append(args)
+        else:
+            raise InvalidConfigError("invalid type {} (should be dict or list)".format(type(data)))
+        for item in result:
+            assert 'cls' in item
+        return result
+
     def make_resource(self, target, resource, args):
         assert isinstance(args, dict)
         r = self.resources[resource](target, **args)
@@ -32,9 +94,15 @@ class TargetFactory:
 
         role = config.get('role', name)
         target = Target(name, env=env)
-        for resource, args in config.get('resources', {}).items():
+        for item in self._convert_to_named_list(config.get('resources', {})):
+            resource = item.pop('cls')
+            name = item.pop('name', None)
+            args = item # remaining args
             r = self.make_resource(target, resource, args)
-        for driver, args in config.get('drivers', {}).items():
+        for item in self._convert_to_named_list(config.get('drivers', {})):
+            driver = item.pop('cls')
+            name = item.pop('name', None)
+            args = item # remaining args
             d = self.make_driver(target, driver, args)
         return target
 

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -532,7 +532,7 @@ class ClientSession(ApplicationSession):
         try:
             drv = target.get_driver(NetworkPowerDriver)
         except NoDriverFoundError:
-            drv = NetworkPowerDriver(target, delay=delay)
+            drv = NetworkPowerDriver(target, name=None, delay=delay)
         target.await_resources([drv.port], timeout=1.0)
         target.activate(drv)
         res = getattr(drv, action)()
@@ -552,7 +552,7 @@ class ClientSession(ApplicationSession):
         try:
             drv = target.get_driver(OneWirePIODriver)
         except NoDriverFoundError:
-            drv = OneWirePIODriver(target)
+            drv = OneWirePIODriver(target, name=None)
         target.await_resources([drv.port], timeout=1.0)
         target.activate(drv)
         if action == 'get':
@@ -613,7 +613,7 @@ class ClientSession(ApplicationSession):
         try:
             drv = target.get_driver(AndroidFastbootDriver)
         except NoDriverFoundError:
-            drv = AndroidFastbootDriver(target)
+            drv = AndroidFastbootDriver(target, name=None)
         drv.fastboot.timeout = self.args.wait
         target.activate(drv)
         drv(*args)
@@ -631,14 +631,14 @@ class ClientSession(ApplicationSession):
                 try:
                     drv = target.get_driver(IMXUSBDriver)
                 except NoDriverFoundError:
-                    drv = IMXUSBDriver(target)
+                    drv = IMXUSBDriver(target, name=None)
                 drv.loader.timeout = self.args.wait
                 break
             elif isinstance(resource, NetworkMXSUSBLoader):
                 try:
                     drv = target.get_driver(MXUSBDriver)
                 except NoDriverFoundError:
-                    drv = MXSUSBDriver(target)
+                    drv = MXSUSBDriver(target, name=None)
                 drv.loader.timeout = self.args.wait
                 break
             elif isinstance(resource, NetworkAlteraUSBBlaster):
@@ -646,7 +646,7 @@ class ClientSession(ApplicationSession):
                 try:
                     drv = target.get_driver(OpenOCDDriver)
                 except NoDriverFoundError:
-                    drv = OpenOCDDriver(target, **args)
+                    drv = OpenOCDDriver(target, name=None, **args)
                 drv.interface.timeout = self.args.wait
                 break
         if not drv:

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -39,11 +39,10 @@ class RemotePlaceManager(ResourceManager):
             self._start()
         place = self.session.get_place(remote_place.name)
         resource_entries = self.session.get_target_resources(place)
-        # FIXME handle resource name here to support multiple resources of the same class
         expanded = []
         for resource_name, resource_entry in resource_entries.items():
             new = target_factory.make_resource(
-                remote_place.target, resource_entry.cls, resource_entry.args)
+                remote_place.target, resource_entry.cls, resource_name, resource_entry.args)
             new.avail = resource_entry.avail
             new._remote_entry = resource_entry
             expanded.append(new)
@@ -81,8 +80,6 @@ class RemotePlaceManager(ResourceManager):
 @attr.s(cmp=False)
 class RemotePlace(ManagedResource):
     manager_cls = RemotePlaceManager
-
-    name = attr.ib(validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         self.timeout = 5.0

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -104,8 +104,6 @@ class Target:
                 if isinstance(drv, Strategy):
                     found.append(drv) # don't activate strategies, they have conflicting bindings
                     continue
-                if activate:
-                    self.activate(drv)
                 found.append(drv)
         if len(found) == 0:
             raise NoDriverFoundError(
@@ -115,6 +113,8 @@ class Target:
             raise NoDriverFoundError(
                 "multiple drivers matching {} found in target {}".format(cls, self)
             )
+        if activate:
+            self.activate(found[0])
         return found[0]
 
     def get_active_driver(self, cls):

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -83,16 +83,24 @@ class Target:
         await -- wait for the resource to become available (default True)
         """
         found = []
+        other_names = []
         for res in self.resources:
             if not isinstance(res, cls):
                 continue
             if name and res.name != name:
+                other_names.append(res.name)
                 continue
             found.append(res)
         if len(found) == 0:
-            raise NoResourceFoundError(
-                "no resource matching {} found in target {}".format(cls, self)
-            )
+            if other_names:
+                raise NoResourceFoundError(
+                    "all resources matching {} found in target {} have other names: {}".format(
+                        cls, self, other_names)
+                )
+            else:
+                raise NoResourceFoundError(
+                    "no resource matching {} found in target {}".format(cls, self)
+                )
         elif len(found) > 1:
             raise NoResourceFoundError(
                 "multiple resources matching {} found in target {}".format(cls, self)
@@ -112,16 +120,24 @@ class Target:
         activate -- activate the driver (default True)
         """
         found = []
+        other_names = []
         for drv in self.drivers:
             if not isinstance(drv, cls):
                 continue
             if name and drv.name != name:
+                other_names.append(drv.name)
                 continue
             found.append(drv)
         if len(found) == 0:
-            raise NoDriverFoundError(
-                "no driver matching {} found in target {}".format(cls, self)
-            )
+            if other_names:
+                raise NoDriverFoundError(
+                    "all drivers matching {} found in target {} have other names: {}".format(
+                        cls, self, other_names)
+                )
+            else:
+                raise NoDriverFoundError(
+                    "no driver matching {} found in target {}".format(cls, self)
+                )
         elif len(found) > 1:
             raise NoDriverFoundError(
                 "multiple drivers matching {} found in target {}".format(cls, self)
@@ -140,21 +156,29 @@ class Target:
         name -- optional name to use as a filter
         """
         found = []
+        other_names = []
         for drv in self.drivers:
             if not isinstance(drv, cls):
                 continue
             if name and drv.name != name:
+                other_names.append(drv.name)
                 continue
             if drv.state != BindingState.active:
                 continue
             found.append(drv)
         if len(found) == 0:
-            raise NoDriverFoundError(
-                "no driver matching {} found in target {}".format(cls, self)
-            )
+            if other_names:
+                raise NoDriverFoundError(
+                    "all active drivers matching {} found in target {} have other names: {}".format(
+                        cls, self, other_names)
+                )
+            else:
+                raise NoDriverFoundError(
+                    "no active driver matching {} found in target {}".format(cls, self)
+                )
         elif len(found) > 1:
             raise NoDriverFoundError(
-                "multiple drivers matching {} found in target {}".format(cls, self)
+                "multiple active drivers matching {} found in target {}".format(cls, self)
             )
         return found[0]
 

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -1,6 +1,7 @@
 import abc
 import logging
 from time import monotonic
+from collections import Counter
 
 import attr
 
@@ -309,6 +310,12 @@ class Target:
             assert supplier.target is self
             assert client not in supplier.clients
             assert supplier not in client.suppliers
+
+        duplicates = {k for k, c in Counter(bound_suppliers).items() if c > 1}
+        if duplicates:
+            raise BindingError(
+                "duplicate bindings {} found in target {}".format(duplicates, self)
+            )
 
         # update relationship in both directions
         self.drivers.append(client)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,15 +18,15 @@ def target():
 
 @pytest.fixture(scope='function')
 def serial_port(target):
-    return RawSerialPort(target, 'serial' '/dev/test')
+    return RawSerialPort(target, 'serial', '/dev/test')
 
 @pytest.fixture(scope='function')
 def serial_rfc2711_port(target):
-    return NetworkSerialPort(target, host='localhost', port=8888)
+    return NetworkSerialPort(target, 'rfc2711', host='localhost', port=8888)
 
 @pytest.fixture(scope='function')
 def serial_raw_port(target):
-    return NetworkSerialPort(target, host='localhost', port=8888, protocol="raw")
+    return NetworkSerialPort(target, 'serialraw', host='localhost', port=8888, protocol="raw")
 
 
 @pytest.fixture(scope='function')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ def target():
 
 @pytest.fixture(scope='function')
 def serial_port(target):
-    return RawSerialPort(target, '/dev/test')
+    return RawSerialPort(target, 'serial' '/dev/test')
 
 @pytest.fixture(scope='function')
 def serial_rfc2711_port(target):
@@ -34,7 +34,7 @@ def serial_driver(target, serial_port, monkeypatch, mocker):
     serial_mock = mocker.MagicMock
     import serial
     monkeypatch.setattr(serial, 'Serial', serial_mock)
-    s = SerialDriver(target)
+    s = SerialDriver(target, 'serial')
     return s
 
 @pytest.fixture(scope='function')

--- a/tests/test_bareboxdriver.py
+++ b/tests/test_bareboxdriver.py
@@ -11,8 +11,8 @@ from labgrid.protocol import (CommandProtocol, ConsoleProtocol,
 class TestBareboxDriver:
     def test_create(self):
         t = Target('dummy')
-        cp = FakeConsoleDriver(t)
-        d = BareboxDriver(t)
+        cp = FakeConsoleDriver(t, "console")
+        d = BareboxDriver(t, "barebox")
         assert (isinstance(d, BareboxDriver))
         assert (isinstance(d, CommandProtocol))
         assert (isinstance(d, LinuxBootProtocol))

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,6 +1,7 @@
 import pytest
 
 from labgrid import Environment, NoConfigFoundError
+from labgrid.driver.fake import FakeConsoleDriver, FakePowerDriver
 
 
 class TestEnvironment:
@@ -76,3 +77,49 @@ imports:
         import myimport
         t = myimport.Test()
         assert (isinstance(t, myimport.Test))
+
+    def test_create_named_resources(self, tmpdir):
+        p = tmpdir.join("config.yaml")
+        p.write(
+            """
+        targets:
+          test1:
+            resources:
+            - AndroidFastboot:
+                name: "fastboot"
+                match: {}
+            - RawSerialPort:
+                port: "/dev/ttyUSB0"
+                speed: 115200
+        """
+        )
+        e = Environment(str(p))
+        t = e.get_target("test1")
+
+    def test_create_named_drivers(self, tmpdir):
+        p = tmpdir.join("config.yaml")
+        p.write(
+            """
+        targets:
+          test1:
+            resources:
+            - AndroidFastboot:
+                name: "fastboot"
+                match: {}
+            - RawSerialPort:
+                name: "serial_a"
+                port: "/dev/ttyUSB0"
+                speed: 115200
+            - cls: RawSerialPort
+              name: "serial_b"
+              port: "/dev/ttyUSB0"
+              speed: 115200
+            drivers:
+            - FakeConsoleDriver:
+                name: "serial_a"
+            - FakeConsoleDriver:
+                name: "serial_b"
+        """
+        )
+        e = Environment(str(p))
+        t = e.get_target("test1")

--- a/tests/test_externalconsoledriver.py
+++ b/tests/test_externalconsoledriver.py
@@ -7,12 +7,12 @@ from labgrid.driver import ExternalConsoleDriver
 
 class TestExternalConsoleDriver:
     def test_create(self, target):
-        d = ExternalConsoleDriver(target, 'cat')
+        d = ExternalConsoleDriver(target, 'console', cmd='cat')
         assert (isinstance(d, ExternalConsoleDriver))
 
     def test_communicate(self, target):
         data = b"test\ndata"
-        d = ExternalConsoleDriver(target, 'cat')
+        d = ExternalConsoleDriver(target, 'console', cmd='cat')
         target.activate(d)
         d.write(data)
         time.sleep(0.1)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,8 +1,12 @@
 from collections import OrderedDict
 
-from labgrid import Target, target_factory
-from labgrid.resource import SerialPort
+import pytest
 
+from labgrid import Target, target_factory
+from labgrid.driver.fake import FakeConsoleDriver
+from labgrid.exceptions import InvalidConfigError
+from labgrid.resource import SerialPort
+from labgrid.util.yaml import load
 
 class TestTargetFactory:
     def test_empty(self):
@@ -23,7 +27,7 @@ class TestTargetFactory:
         assert isinstance(t, Target)
         assert t.get_resource(SerialPort) is not None
 
-    def test_drivers(self, mocker):
+    def test_drivers(self):
         t = target_factory.make_target(
             'dummy', {
                 'resources': OrderedDict([
@@ -44,3 +48,77 @@ class TestTargetFactory:
         )
         assert isinstance(t, Target)
         assert t.get_resource(SerialPort) is not None
+
+    def test_convert_dict(self):
+        data = load("""
+        FooPort: {}
+        BarPort:
+          name: bar
+        """)
+        l = target_factory._convert_to_named_list(data)
+        assert l == [
+            {
+                'cls': 'FooPort',
+            },
+            {
+                'cls': 'BarPort',
+                'name': 'bar'
+            },
+        ]
+
+    def test_convert_simple_list(self):
+        data = load("""
+        - FooPort: {}
+        - BarPort:
+            name: bar
+        """)
+        l = target_factory._convert_to_named_list(data)
+        assert l == [
+            {
+                'cls': 'FooPort',
+            },
+            {
+                'cls': 'BarPort',
+                'name': 'bar'
+            },
+        ]
+
+    def test_convert_explicit_list(self):
+        data = load("""
+        - cls: FooPort
+        - cls: BarPort
+          name: bar
+        """)
+        l = target_factory._convert_to_named_list(data)
+        assert l == [
+            {
+                'cls': 'FooPort',
+            },
+            {
+                'cls': 'BarPort',
+                'name': 'bar'
+            },
+        ]
+
+    def test_convert_error(self):
+        with pytest.raises(InvalidConfigError) as excinfo:
+            data = load("""
+            - {}
+            """)
+            target_factory._convert_to_named_list(data)
+        assert "invalid empty dict as list item" in excinfo.value.msg
+
+        with pytest.raises(InvalidConfigError) as excinfo:
+            data = load("""
+            - "error"
+            """)
+            target_factory._convert_to_named_list(data)
+        assert "invalid list item type <class 'str'> (should be dict)" in excinfo.value.msg
+
+        with pytest.raises(InvalidConfigError) as excinfo:
+            data = load("""
+            - name: "bar"
+              extra: "baz"
+            """)
+            target_factory._convert_to_named_list(data)
+        assert "missing 'cls' key in OrderedDict(" in excinfo.value.msg

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -59,6 +59,7 @@ class TestTargetFactory:
         assert l == [
             {
                 'cls': 'FooPort',
+                'name': None,
             },
             {
                 'cls': 'BarPort',
@@ -76,6 +77,7 @@ class TestTargetFactory:
         assert l == [
             {
                 'cls': 'FooPort',
+                'name': None,
             },
             {
                 'cls': 'BarPort',
@@ -93,6 +95,7 @@ class TestTargetFactory:
         assert l == [
             {
                 'cls': 'FooPort',
+                'name': None,
             },
             {
                 'cls': 'BarPort',

--- a/tests/test_onewire.py
+++ b/tests/test_onewire.py
@@ -7,7 +7,7 @@ from labgrid.resource import OneWirePIO
 
 @pytest.fixture(scope='function')
 def onewire_port(target):
-    return OneWirePIO(target, "testhost", "path")
+    return OneWirePIO(target, "pio", "testhost", "path")
 
 @pytest.fixture(scope='function')
 def onewire_driver(target, onewire_port, monkeypatch, mocker):
@@ -16,12 +16,12 @@ def onewire_driver(target, onewire_port, monkeypatch, mocker):
     onewire_mock.get = mocker.MagicMock()
     import onewire
     monkeypatch.setattr(onewire, 'Onewire', onewire_mock)
-    s = OneWirePIODriver(target)
+    s = OneWirePIODriver(target, "pio")
     target.activate(s)
     return s
 
 def test_onewire_resource_instance(target):
-    o = OneWirePIO(target, "testhost", "path")
+    o = OneWirePIO(target, "pio", "testhost", "path")
     assert (isinstance(o, OneWirePIO))
 
 def test_onewire_driver_instance(target, onewire_driver):

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -6,13 +6,13 @@ from labgrid.driver.powerdriver import ExternalPowerDriver, ManualPowerDriver, N
 
 class TestManualPowerDriver:
     def test_create(self, target):
-        d = ManualPowerDriver(target, name='foo-board')
+        d = ManualPowerDriver(target, 'foo-board')
         assert (isinstance(d, ManualPowerDriver))
 
     def test_on(self, target, mocker):
         m = mocker.patch('builtins.input')
 
-        d = ManualPowerDriver(target, name='foo-board')
+        d = ManualPowerDriver(target, 'foo-board')
         target.activate(d)
         d.on()
 
@@ -23,7 +23,7 @@ class TestManualPowerDriver:
     def test_off(self, target, mocker):
         m = mocker.patch('builtins.input')
 
-        d = ManualPowerDriver(target, name='foo-board')
+        d = ManualPowerDriver(target, 'foo-board')
         target.activate(d)
         d.off()
 
@@ -34,7 +34,7 @@ class TestManualPowerDriver:
     def test_cycle(self, target, mocker):
         m = mocker.patch('builtins.input')
 
-        d = ManualPowerDriver(target, name='foo-board')
+        d = ManualPowerDriver(target, 'foo-board')
         target.activate(d)
         d.cycle()
 
@@ -44,7 +44,7 @@ class TestManualPowerDriver:
 class TestExternalPowerDriver:
     def test_create(self, target):
         d = ExternalPowerDriver(
-            target, cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
+            target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
         assert (isinstance(d, ExternalPowerDriver))
 
@@ -52,7 +52,7 @@ class TestExternalPowerDriver:
         m = mocker.patch('subprocess.check_call')
 
         d = ExternalPowerDriver(
-            target, cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
+            target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
         target.activate(d)
         d.on()
@@ -63,7 +63,7 @@ class TestExternalPowerDriver:
         m = mocker.patch('subprocess.check_call')
 
         d = ExternalPowerDriver(
-            target, cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
+            target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
         target.activate(d)
         d.off()
@@ -75,7 +75,7 @@ class TestExternalPowerDriver:
         m = mocker.patch('subprocess.check_call')
 
         d = ExternalPowerDriver(
-            target, cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
+            target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
         target.activate(d)
         d.cycle()
@@ -91,7 +91,7 @@ class TestExternalPowerDriver:
         m = mocker.patch('subprocess.check_call')
 
         d = ExternalPowerDriver(
-            target,
+            target, 'power',
             cmd_on='set -1 foo-board',
             cmd_off='set -0 foo-board',
             cmd_cycle='set -c foo-board',
@@ -104,8 +104,8 @@ class TestExternalPowerDriver:
 
 class TestNetworkPowerDriver:
     def test_create(self, target):
-        r = NetworkPowerPort(target, model='netio', host='dummy', index='1')
-        d = NetworkPowerDriver(target)
+        r = NetworkPowerPort(target, 'power', model='netio', host='dummy', index='1')
+        d = NetworkPowerDriver(target, 'power')
         assert isinstance(d, NetworkPowerDriver)
 
     def test_import_backends(self):

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -31,6 +31,7 @@ def qemu_driver(qemu_target):
     q = QEMUDriver(
         qemu_target,
         "qemu",
+        qemu_bin="qemu",
         machine='',
         cpu='',
         memory='',

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -2,20 +2,20 @@ from labgrid.resource import ManagedResource, Resource, ResourceManager
 
 
 def test_create_resource(target):
-    resource = Resource(target)
+    resource = Resource(target, "resource")
 
 def test_create_managed_resource(target):
-    resource_1 = ManagedResource(target)
-    resource_2 = ManagedResource(target)
+    resource_1 = ManagedResource(target, "managedr1")
+    resource_2 = ManagedResource(target, "managedr2")
     assert resource_1.manager is resource_2.manager
 
 def test_hash_is(target):
-    resource1 = Resource(target)
-    resource2 = Resource(target)
+    resource1 = Resource(target, "resource1")
+    resource2 = Resource(target, "resource2")
     assert resource1 is not resource2
 
 def test_hash_set(target):
-    resource1 = Resource(target)
+    resource1 = Resource(target, "resource")
     k = set()
     k.add(resource1)
     assert resource1 in k

--- a/tests/test_serialdriver.py
+++ b/tests/test_serialdriver.py
@@ -8,12 +8,12 @@ from labgrid.exceptions import NoSupplierFoundError
 class TestSerialDriver:
     def test_instanziation_fail_missing_port(self, target):
         with pytest.raises(NoSupplierFoundError):
-            SerialDriver(target)
+            SerialDriver(target, "serial")
 
     def test_instanziation(self, target, serial_port, monkeypatch, mocker):
         serial_mock = mocker.Mock()
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         assert (isinstance(s, SerialDriver))
         assert (target.drivers[0] == s)
 
@@ -21,7 +21,7 @@ class TestSerialDriver:
         serial_mock = mocker.Mock()
         serial_mock.write = mocker.MagicMock()
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         s.serial = serial_mock
         target.activate(s)
         s.write(b"testdata")
@@ -32,7 +32,7 @@ class TestSerialDriver:
         serial_mock.read = mocker.MagicMock()
         serial_mock.in_waiting = 0
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         s.serial = serial_mock
         target.activate(s)
         s.read()
@@ -42,7 +42,7 @@ class TestSerialDriver:
         serial_mock = mocker.Mock()
         serial_mock.close = mocker.MagicMock()
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         s.serial = serial_mock
         target.activate(s)
         s.close()

--- a/tests/test_serialdriver.py
+++ b/tests/test_serialdriver.py
@@ -52,7 +52,7 @@ class TestSerialDriver:
         serial_mock = mocker.Mock()
         serial_mock.close = mocker.MagicMock()
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         s.serial = serial_mock
         target.activate(s)
         target.deactivate(s)
@@ -61,13 +61,13 @@ class TestSerialDriver:
     def test_rfc2711_instanziation(self, target, serial_rfc2711_port, monkeypatch, mocker):
         serial_mock = mocker.Mock()
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         assert (isinstance(s, SerialDriver))
         assert (target.drivers[0] == s)
 
     def test_raw_instanziation(self, target, serial_raw_port, monkeypatch, mocker):
         serial_mock = mocker.Mock()
         monkeypatch.setattr(serial, 'Serial', serial_mock)
-        s = SerialDriver(target)
+        s = SerialDriver(target, "serial")
         assert (isinstance(s, SerialDriver))
         assert (target.drivers[0] == s)

--- a/tests/test_serialport.py
+++ b/tests/test_serialport.py
@@ -3,11 +3,11 @@ from labgrid.resource import RawSerialPort  # pylint: disable=import-error
 
 class TestSerialPort:
     def test_instanziation(self):
-        s = RawSerialPort(None, 'port')
+        s = RawSerialPort(None, 'serial', 'port')
         assert (s.port == 'port')
 
     def test_instanziation_with(self, target):
-        s = RawSerialPort(target, 'port', 115200)
+        s = RawSerialPort(target, 'serial', 'port', 115200)
         assert (s.port == 'port')
         assert (s.speed == 115200)
         assert s in target.resources

--- a/tests/test_shelldriver.py
+++ b/tests/test_shelldriver.py
@@ -6,9 +6,9 @@ from labgrid.exceptions import NoDriverFoundError
 
 class TestShellDriver:
     def test_instance(self, target, serial_driver):
-        s = ShellDriver(target, "", "", "")
+        s = ShellDriver(target, "shell", "", "", "")
         assert (isinstance(s, ShellDriver))
 
     def test_no_driver(self, target):
         with pytest.raises(NoDriverFoundError):
-            ShellDriver(target, "", "", "")
+            ShellDriver(target, "shell", "", "", "")

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -8,10 +8,10 @@ from labgrid.resource import NetworkService
 class TestSSHDriver:
     def test_create_fail_missing_resource(self, target):
         with pytest.raises(NoResourceFoundError):
-            SSHDriver(target)
+            SSHDriver(target, "ssh")
 
     def test_create(self, target, mocker):
-        NetworkService(target, "1.2.3.4", "root")
+        NetworkService(target, "service", "1.2.3.4", "root")
         call = mocker.patch('subprocess.call')
         call.return_value = 0
         popen = mocker.patch('subprocess.Popen', autospec=True)
@@ -20,5 +20,5 @@ class TestSSHDriver:
         instance_mock = mocker.MagicMock()
         popen.return_value = instance_mock
         instance_mock.wait = mocker.MagicMock(return_value=0)
-        s = SSHDriver(target)
+        s = SSHDriver(target, "ssh")
         assert (isinstance(s, SSHDriver))

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -10,11 +10,11 @@ from labgrid.exceptions import NoDriverFoundError
 
 
 def test_create_barebox(target):
-    console = FakeConsoleDriver(target)
-    power = FakePowerDriver(target)
-    barebox = BareboxDriver(target)
-    shell = ShellDriver(target, prompt='root@dummy', login_prompt='login:', username='root')
-    s = BareboxStrategy(target)
+    console = FakeConsoleDriver(target, "console")
+    power = FakePowerDriver(target, "power")
+    barebox = BareboxDriver(target, "barebox")
+    shell = ShellDriver(target, "shell", prompt='root@dummy', login_prompt='login:', username='root')
+    s = BareboxStrategy(target, "strategy")
 
     assert isinstance(s, Strategy)
     assert target.get_driver(BareboxStrategy) is s
@@ -23,11 +23,11 @@ def test_create_barebox(target):
     assert s.state is BindingState.bound
 
 def test_create_uboot(target):
-    console = FakeConsoleDriver(target)
-    power = FakePowerDriver(target)
-    barebox = UBootDriver(target)
-    shell = ShellDriver(target, prompt='root@dummy', login_prompt='login:', username='root')
-    s = UBootStrategy(target)
+    console = FakeConsoleDriver(target, "console")
+    power = FakePowerDriver(target, "power")
+    barebox = UBootDriver(target, "uboot")
+    shell = ShellDriver(target, "shell", prompt='root@dummy', login_prompt='login:', username='root')
+    s = UBootStrategy(target, "strategy")
 
     assert isinstance(s, Strategy)
     assert target.get_driver(UBootStrategy) is s

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -52,10 +52,18 @@ def test_getitem(target):
     assert target[AProtocol] is a
     assert target[A, "adriver"] is a
     assert target[AProtocol, "adriver"] is a
-    with pytest.raises(NoDriverFoundError):
+    with pytest.raises(NoDriverFoundError) as excinfo:
         target[A, "bdriver"]
-    with pytest.raises(NoDriverFoundError):
+    assert "have other names" in excinfo.value.msg
+    with pytest.raises(NoDriverFoundError) as excinfo:
         target[B, "adriver"]
+    assert "no active driver" in excinfo.value.msg
+
+    a2 = A(target, None)
+    target.activate(a2)
+    with pytest.raises(NoDriverFoundError) as excinfo:
+        target[A]
+    assert "multiple active drivers" in excinfo.value.msg
 
 
 def test_no_resource(target):

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -132,6 +132,53 @@ def test_suppliers_ab_missing(target):
     with pytest.raises(NoSupplierFoundError):
         d = DriverWithAB(target, "driver")
 
+
+class DriverWithNamedA(Driver):
+    bindings = {
+        "res": Driver.NamedBinding(ResourceA),
+    }
+
+
+def test_suppliers_named_a(target):
+    ra = ResourceA(target, "resource")
+    target.set_binding_map({"res": "resource"})
+    d = DriverWithNamedA(target, "driver")
+    assert d.res is ra
+
+
+class DriverWithMultiA(Driver):
+    bindings = {
+        "res1": ResourceA,
+        "res2": ResourceA,
+    }
+
+
+def test_suppliers_multi_a(target):
+    ra = ResourceA(target, "resource1")
+    d = DriverWithMultiA(target, "driver")
+    assert d.res1 is ra
+    assert d.res2 is ra
+
+
+class DriverWithNamedMultiA(Driver):
+    bindings = {
+        "res1": Driver.NamedBinding(ResourceA),
+        "res2": Driver.NamedBinding(ResourceA),
+    }
+
+
+def test_suppliers_multi_named_a(target):
+    ra1 = ResourceA(target, "resource1")
+    ra2 = ResourceA(target, "resource2")
+    target.set_binding_map({
+        "res1": "resource1",
+        "res2": "resource2",
+    })
+    d = DriverWithNamedMultiA(target, "driver")
+    assert d.res1 is ra1
+    assert d.res2 is ra2
+
+
 # test nested resource creation
 @attr.s(cmp=False)
 class DiscoveryResource(Resource):

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -18,7 +18,7 @@ def test_get_resource(target):
     class a(Resource):
         pass
 
-    a(target)
+    a(target, "aresource")
     assert isinstance(target.get_resource(a), a)
 
 
@@ -26,7 +26,7 @@ def test_get_driver(target):
     class a(Driver):
         pass
 
-    a(target)
+    a(target, "adriver")
     assert isinstance(target.get_driver(a), a)
 
 
@@ -62,48 +62,48 @@ class DriverWithAB(Driver):
 
 
 def test_suppliers_a(target):
-    ra = ResourceA(target)
-    d = DriverWithA(target)
+    ra = ResourceA(target, "resource")
+    d = DriverWithA(target, "resource")
     assert d.res is ra
 
 
 def test_suppliers_aset(target):
-    ra = ResourceA(target)
-    d = DriverWithASet(target)
+    ra = ResourceA(target, "resource")
+    d = DriverWithASet(target, "driver")
     assert d.res is ra
 
 
 def test_suppliers_ab_a(target):
-    ra = ResourceA(target)
-    d = DriverWithAB(target)
+    ra = ResourceA(target, "resource")
+    d = DriverWithAB(target, "driver")
     assert d.res is ra
 
 
 def test_suppliers_ab_b(target):
-    rb = ResourceB(target)
-    d = DriverWithAB(target)
+    rb = ResourceB(target, "resource")
+    d = DriverWithAB(target, "driver")
     assert d.res is rb
 
 
 def test_suppliers_ab_both(target):
-    ra = ResourceA(target)
-    rb = ResourceB(target)
+    ra = ResourceA(target, "resource_a")
+    rb = ResourceB(target, "resource_b")
     with pytest.raises(NoSupplierFoundError):
-        d = DriverWithAB(target)
+        d = DriverWithAB(target, "driver")
 
 
 def test_suppliers_ab_missing(target):
     with pytest.raises(NoSupplierFoundError):
-        d = DriverWithAB(target)
+        d = DriverWithAB(target, "driver")
 
 # test nested resource creation
 @attr.s(cmp=False)
 class DiscoveryResource(Resource):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        ResourceA(self.target)
+        ResourceA(self.target, "resource")
 
 def test_nested(target):
-    rd = DiscoveryResource(target)
-    d = DriverWithAB(target)
+    rd = DiscoveryResource(target, "discovery")
+    d = DriverWithAB(target, "driver")
     assert isinstance(d.res, ResourceA)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,6 +1,7 @@
-import pytest
+import abc
 
 import attr
+import pytest
 
 from labgrid import Target, target_factory
 from labgrid.resource import Resource
@@ -15,19 +16,46 @@ def test_instanziation():
 
 
 def test_get_resource(target):
-    class a(Resource):
+    class A(Resource):
         pass
 
-    a(target, "aresource")
-    assert isinstance(target.get_resource(a), a)
+    a = A(target, "aresource")
+    assert isinstance(target.get_resource(A), A)
+    assert target.get_resource(A) is a
+    assert target.get_resource(A, name="aresource") is a
 
 
 def test_get_driver(target):
-    class a(Driver):
+    class A(Driver):
         pass
 
-    a(target, "adriver")
-    assert isinstance(target.get_driver(a), a)
+    a = A(target, "adriver")
+    assert isinstance(target.get_driver(A), A)
+    assert target.get_driver(A) is a
+    assert target.get_driver(A, name="adriver") is a
+
+
+def test_getitem(target):
+    class AProtocol(abc.ABC):
+        pass
+
+    class A(Driver, AProtocol):
+        pass
+
+    class B(Driver):
+        pass
+
+    a = A(target, "adriver")
+    target.activate(a)
+    assert isinstance(target[A], A)
+    assert target[A] is a
+    assert target[AProtocol] is a
+    assert target[A, "adriver"] is a
+    assert target[AProtocol, "adriver"] is a
+    with pytest.raises(NoDriverFoundError):
+        target[A, "bdriver"]
+    with pytest.raises(NoDriverFoundError):
+        target[B, "adriver"]
 
 
 def test_no_resource(target):

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -4,6 +4,7 @@ import attr
 import pytest
 
 from labgrid import Target, target_factory
+from labgrid.binding import BindingError
 from labgrid.resource import Resource
 from labgrid.driver import Driver
 from labgrid.exceptions import NoSupplierFoundError, NoDriverFoundError, NoResourceFoundError
@@ -154,10 +155,22 @@ class DriverWithMultiA(Driver):
 
 
 def test_suppliers_multi_a(target):
-    ra = ResourceA(target, "resource1")
+    ra1 = ResourceA(target, "resource1")
+    with pytest.raises(BindingError) as excinfo:
+        DriverWithMultiA(target, "driver")
+    assert "duplicate bindings" in excinfo.value.msg
+
+
+def test_suppliers_multi_a_explict(target):
+    ra1 = ResourceA(target, "resource1")
+    ra2 = ResourceA(target, "resource2")
+    target.set_binding_map({
+        "res1": "resource1",
+        "res2": "resource2",
+    })
     d = DriverWithMultiA(target, "driver")
-    assert d.res1 is ra
-    assert d.res2 is ra
+    assert d.res1 is ra1
+    assert d.res2 is ra2
 
 
 class DriverWithNamedMultiA(Driver):

--- a/tests/test_usbemulator.py
+++ b/tests/test_usbemulator.py
@@ -6,8 +6,8 @@ from labgrid.external import USBStick
 
 class TestUSBStick:
     def test_create(self, target):
-        d = FakeCommandDriver(target)
-        f = FakeFileTransferDriver(target)
+        d = FakeCommandDriver(target, "command")
+        f = FakeFileTransferDriver(target, "filetransfer")
         target.activate(d)
         target.activate(f)
         u = USBStick(target, 'imagepath', 'imagename')


### PR DESCRIPTION
This adds names to Resources and Drivers, which allows us to have multiple instances of the same class in one Target.

PR #123 needs to be merged first.