### PR TITLE
implement autoinstaller tool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ New Features
   junit XML output.
 - The ``labgrid-client`` tool now understands a ``--state`` option to
   transition to the provided state using a :any:`Strategy`.
-  This requires an environemnt yaml file with a :any:`RemotePlace` `Resource` and
+  This requires an environment yaml file with a :any:`RemotePlace` `Resource` and
   matching `Drivers`.
 - Resource matches for places configured in the coordinator can now have a
   name, allowing multiple resources with the same class.
@@ -28,6 +28,7 @@ New Features
 - The `ShellDriver` now supports configuring the login prompt timeout.
 - The `SerialDriver` now supports using plain TCP instead of RFC 2217, which is
   needed from some console servers.
+- Experimental: The labgrid-autoinstall tool was added (see below).
 
 Incompatible Changes
 ~~~~~~~~~~~~~~~~~~~~
@@ -94,6 +95,24 @@ New (with real names):
   SerialPort(target=Target(name='MyTarget', env=None), name='MyPort', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
   >>> SerialDriver(t, "MyDriver")
   SerialDriver(target=Target(name='MyTarget', env=None), name='MyDriver', state=<BindingState.bound: 1>, txdelay=0.0)
+
+Auto-Installer Tool
+~~~~~~~~~~~~~~~~~~~
+
+To simplify using labgrid for provisioning several boards in parallel, the
+``labgrid-autoinstall`` tool was added.
+It reads a YAML file defining several targets and a Python script to be run for
+each board.
+Interally, it spawns a child process for each target, which waits until a matching
+resource becomes available and then executes the script.
+
+For example, this makes it simple to load a bootloader via the
+:any:`BootstrapProtocol`, use the :any:`AndroidFastbootDriver` to upload a
+kernel with initramfs and then write the target's eMMC over a USB Mass Storage
+gadget.
+
+.. note::
+  ``labgrid-autoinstall`` is still experimental and no documentation has been written.
 
 Release 0.1.0 (released May 11, 2017)
 -------------------------------------

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -363,20 +363,6 @@ Ideas
 
 .. please keep these sorted alphabetically
 
-Auto-Installer Tool
-~~~~~~~~~~~~~~~~~~~
-
-To simplify using labgrid for provisioning several boards in parallel, we should
-add a new tool which reads a YAML file defining several targets and a Python
-script to be run for each board.
-This tool would spawn a child process for each target, which waits until a matching
-resource becomes available and then executes the script.
-
-For example, it would make it simple to load a bootloader via the
-:any:`BootstrapProtocol`, use the :any:`AndroidFastbootDriver` to upload a
-kernel with initramfs and then write the target's eMMC over a USB Mass Storage
-gadget.
-
 Driver Priorities
 ~~~~~~~~~~~~~~~~~
 

--- a/labgrid/autoinstall/main.py
+++ b/labgrid/autoinstall/main.py
@@ -1,0 +1,221 @@
+"""The autoinstall.main module runs an installation script automatically on multiple targets."""
+import ast
+import argparse
+import logging
+import sys
+import multiprocessing
+import textwrap
+from time import sleep
+
+from .. import Environment, target_factory
+from ..stepreporter import StepReporter
+from ..exceptions import NoResourceFoundError
+
+
+class Handler(multiprocessing.Process):
+    def __init__(self, env, args, name):
+        super().__init__(name=name)
+        self.env = env
+        self.args = args
+        self.config = env.config
+        self.name = name
+
+        self.context = {
+            'name': self.name,
+            'env': self.env,
+            'config': self.config,
+        }
+        self.context.update(target_factory.resources)
+        self.context.update(target_factory.drivers)
+
+    def _get_function(self, name, context):
+        snippet = self.config.data['autoinstall'].get(name)
+        if not snippet:
+            return None
+
+        code = 'def {}():\n{}'.format(name, textwrap.indent(snippet, ' '))
+        tree = ast.parse(code, filename=self.env.config_file)
+        ast.increment_lineno(tree, snippet.start_mark.line)
+        co = compile(tree, filename=self.env.config_file, mode='exec')
+
+        stage = {}
+        exec(co, context, stage)
+        return stage[name]
+
+    def _get_setup_function(self):
+        context = self.context
+        context['log'] = self.log.getChild('setup')
+        setup = self._get_function('setup', self.context)
+        if setup is None:
+            def setup():
+                pass
+        return setup
+
+    def _get_handler_function(self):
+        context = self.context.copy()
+        context['log'] = self.log.getChild('handler')
+        handler = self._get_function('handler', context)
+        return handler
+
+    def _get_initial_resource(self):
+        cls = self.config.data['autoinstall'].get('initial-resource')
+        if not cls:
+            return None
+
+        return self.target.get_resource(self.context[cls], await=False)
+
+    def run(self):
+        self.log = logging.getLogger(self.name)
+        self.log.info("creating new handler (PID %s)", self.pid)
+
+        try:
+            self.target = self.env.get_target(self.name)
+            self.context['target'] = self.target
+        except:
+            self.log.exception("target creation failed")
+            return
+
+        self.setup = self._get_setup_function()
+        self.setup()
+
+        self.initial_resource = self._get_initial_resource()
+
+        self.handler = self._get_handler_function()
+        while self.run_once():
+            sleep(3)
+
+    def run_once(self):
+        try:
+            if self.initial_resource:
+                self.log.info("waiting until %s is available",
+                        self.initial_resource.display_name)
+                while True:
+                    self.target.update_resources()
+                    if self.initial_resource.avail:
+                        break
+                    sleep(0.25)
+
+            self.log.info("starting handler")
+            self.target.update_resources()
+            result = self.handler()
+            if result is not None:
+                self.log.warn("unexpected return value from handler: %s",
+                        repr(result))
+            self.log.info("completed handler")
+
+            if self.initial_resource:
+                self.log.info("waiting until %s is unavailable",
+                    self.initial_resource.display_name)
+                while True:
+                    self.target.update_resources()
+                    if not self.initial_resource.avail:
+                        break
+                    sleep(0.25)
+
+        except NoResourceFoundError as e:
+            if e.filter and len(e.filter) > 1:
+                self.log.warning("resources %s not found, restarting",
+                        e.filter)
+            elif e.filter:
+                self.log.warning("resource %s not found, restarting",
+                        next(iter(e.filter)))
+            else:
+                self.log.warning("resource not found, restarting")
+        except:
+            self.log.exception("handler failed")
+            return False
+
+        if self.args.once:
+            self.log.info("stopping handler (--once)")
+            return False
+
+        return True
+
+
+class Manager:
+    def __init__(self, env, args):
+        self.env = env
+        self.args = args
+        self.config = env.config
+        self.log = logging.getLogger("manager")
+
+    def configure(self):
+        if not 'autoinstall' in self.env.config.data:
+            self.log.error("no 'autoinstall' section found in '%s'",
+                    self.env.config_file)
+            return False
+
+        if not 'handler' in self.env.config.data['autoinstall']:
+            self.log.error("no 'handler' definition found in '%s'",
+                    self.env.config_file)
+            return False
+
+        self.handlers = {}
+        for target_name in self.config.data.get('targets', {}).keys():
+            self.handlers[target_name] = Handler(self.env, self.args,
+                    target_name)
+
+        if not self.handlers:
+            self.log.error("no targets found in '%s'",
+                    self.env.config_file)
+            return False
+
+        return True
+
+    def start(self):
+        for i, handler in enumerate(self.handlers.values()):
+            if i:
+                # give previous handler some time to start
+                sleep(3)
+            handler.daemon = True
+            handler.start()
+
+    def join(self):
+        for handler in self.handlers.values():
+            handler.join()
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)7s %(name)-20s %(message)s',
+        stream=sys.stderr,
+    )
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        default=False,
+        help="enable debug mode"
+    )
+    parser.add_argument(
+        '--once',
+        action='store_true',
+        default=False,
+        help="handle each target only once"
+    )
+    parser.add_argument(
+        'config',
+        type=str,
+        help="config file"
+    )
+
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    env = Environment(config_file=args.config)
+
+    StepReporter()
+
+    manager = Manager(env, args)
+    if not manager.configure():
+        exit(1)
+    manager.start()
+    manager.join()
+
+
+if __name__ == "__main__":
+    main()

--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -55,6 +55,17 @@ class BindingMixin:
             target.bind(self)
             assert self.target is not None
 
+    @property
+    def display_name(self):
+        if self.name:
+            return "{}(target={}, name={})".format(
+                self.__class__.__name__, self.target.name, self.name
+            )
+        else:
+            return "{}(target={})".format(
+                self.__class__.__name__, self.target.name
+            )
+
     def on_supplier_bound(self, supplier, name):
         """Called by the Target after a new supplier has been bound"""
         pass

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     ],
     packages=[
         'labgrid',
+        'labgrid.autoinstall',
         'labgrid.driver',
         'labgrid.driver.power',
         'labgrid.external',
@@ -53,6 +54,7 @@ setup(
         'console_scripts': [
             'labgrid-client = labgrid.remote.client:main',
             'labgrid-exporter = labgrid.remote.exporter:main',
+            'labgrid-autoinstall = labgrid.autoinstall.main:main',
         ]
     },
     # custom PyPI classifier for pytest plugins

--- a/tests/test_autoinstall.py
+++ b/tests/test_autoinstall.py
@@ -1,0 +1,64 @@
+import pytest
+import pexpect
+
+def test_autoinstall_help():
+    with pexpect.spawn('python -m labgrid.autoinstall.main --help') as spawn:
+        spawn.expect("usage")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+def test_autoinstall_error_missing_autoinstall(tmpdir):
+    c = tmpdir.join("config.yaml")
+    c.write("""
+    targets:
+        test: {}
+    """)
+    with pexpect.spawn('python -m labgrid.autoinstall.main {}'.format(c)) as spawn:
+        spawn.expect("no 'autoinstall' section found")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 1
+
+def test_autoinstall_error_missing_handler(tmpdir):
+    c = tmpdir.join("config.yaml")
+    c.write("""
+    autoinstall: |
+        print("foo")
+    """)
+    with pexpect.spawn('python -m labgrid.autoinstall.main {}'.format(c)) as spawn:
+        spawn.expect("no 'handler' definition found")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 1
+
+def test_autoinstall_no_targets(tmpdir):
+    c = tmpdir.join("config.yaml")
+    c.write("""
+    autoinstall:
+        handler: |
+            print("handler-test-output")
+    """)
+    with pexpect.spawn('python -m labgrid.autoinstall.main {}'.format(c)) as spawn:
+        spawn.expect("no targets found")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 1
+
+def test_autoinstall_simple(tmpdir):
+    c = tmpdir.join("config.yaml")
+    c.write("""
+    targets:
+        test1:
+            resources: {}
+            drivers: {}
+    autoinstall:
+        handler: |
+            print("handler-test-output")
+    """)
+    with pexpect.spawn('python -m labgrid.autoinstall.main --once {}'.format(c)) as spawn:
+        spawn.expect("handler-test-output")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+


### PR DESCRIPTION
This implements a new stand-alone tool for labgrind, which uses an environment config file with embedded python code to automatically install software to multiple targets.

PR #124 needs to be merge before this.