### PR TITLE
Automatic print command output to local stdout / stderr

### DIFF
--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -1,6 +1,7 @@
 # pylint: disable=no-member
 import logging
 import re
+import sys
 import shlex
 from time import sleep
 
@@ -57,7 +58,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run(self, cmd: str, *, step):
+    def run(self, cmd: str, *, step, print=False):
         """
         Runs the specified command on the shell and returns the output.
 
@@ -82,6 +83,8 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
             # Remove VT100 Codes and split by newline
             data = self.re_vt100.sub('', match.group(1).decode('utf-8')).split('\r\n')[1:-1]
             self.logger.debug("Received Data: %s", data)
+            if print:
+                sys.stdout.write("\n".join(data))
             # Get exit code
             exitcode = int(match.group(2))
             return (data, [], exitcode)
@@ -89,7 +92,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
             return None
 
     @Driver.check_active
-    def run_check(self, cmd: str):
+    def run_check(self, cmd: str, print=False):
         """
         Runs the specified command on the shell and returns the output if successful,
         raises ExecutionError otherwise.
@@ -100,7 +103,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         Returns:
             List[str]: stdout of the executed command
         """
-        res = self.run(cmd)
+        res = self.run(cmd,print=print)
         if res[2] != 0:
             raise ExecutionError(cmd)
         return res[0]

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -69,7 +69,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         self._status = 0
 
     @step(args=['cmd'], result=True)
-    def _run(self, cmd, *, step, timeout=30.0):
+    def _run(self, cmd, *, step, timeout=30.0,print=False):
         """
         Runs the specified cmd on the shell and returns the output.
 
@@ -92,17 +92,15 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         if data and not data[-1]:
             del data[-1]
         self.logger.debug("Received Data: %s", data)
+        if print:
+            sys.stdout.write("\n".join(data))
         # Get exit code
         exitcode = int(match.group(2))
         return (data, [], exitcode)
 
     @Driver.check_active
     def run(self, cmd, timeout=30.0, print=False):
-        data = self._run(cmd, timeout=timeout)
-        if print:
-            sys.stdout.write("\n".join(data[0]))
-            sys.stderr.write("\n".join(data[1]))
-        return data
+        return self._run(cmd, timeout=timeout, print=print)
 
     @step()
     def _await_login(self):
@@ -127,14 +125,14 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         self._check_prompt()
 
     @step(args=['cmd'], result=True)
-    def _run_check(self, cmd, timeout=30):
-        out, _, res = self._run(cmd, timeout=timeout)
+    def _run_check(self, cmd, timeout=30, print=False):
+        out, _, res = self._run(cmd, timeout=timeout,print=print)
         if res != 0:
             raise ExecutionError(cmd)
         return out
 
     @Driver.check_active
-    def run_check(self, cmd, timeout=30):
+    def run_check(self, cmd, timeout=30, print=False):
         """
         Runs the specified cmd on the shell and returns the output if successful,
         raises ExecutionError otherwise.
@@ -142,7 +140,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         Arguments:
         cmd - cmd to run on the shell
         """
-        return self._run_check(cmd, timeout=timeout)
+        return self._run_check(cmd, timeout=timeout, print=print)
 
     @step()
     def get_status(self):

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -4,6 +4,7 @@
 import io
 import logging
 import os
+import sys
 import re
 import shlex
 from time import sleep
@@ -96,8 +97,12 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return (data, [], exitcode)
 
     @Driver.check_active
-    def run(self, cmd, timeout=30.0):
-        return self._run(cmd, timeout=timeout)
+    def run(self, cmd, timeout=30.0, print=False):
+        data = self._run(cmd, timeout=timeout)
+        if print:
+            sys.stdout.write("\n".join(data[0]))
+            sys.stderr.write("\n".join(data[1]))
+        return data
 
     @step()
     def _await_login(self):

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -132,7 +132,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run_check(self, cmd):
+    def run_check(self, cmd, print=False):
         """
         Runs the specified cmd on the shell and returns the output if successful,
         raises ExecutionError otherwise.
@@ -140,7 +140,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         Arguments:
         cmd - cmd to run on the shell
         """
-        res = self.run(cmd)
+        res = self.run(cmd,print=print)
         if res[2] != 0:
             raise ExecutionError(cmd)
         return res[0]

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -2,6 +2,7 @@
 """The SSHDriver uses SSH as a transport to implement CommandProtocol and FileTransferProtocol"""
 import logging
 import os
+import sys
 import shutil
 import subprocess
 import tempfile
@@ -93,7 +94,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run(self, cmd):
+    def run(self, cmd, print=False):
         """Execute `cmd` on the target.
 
         This method runs the specified `cmd` as a command on its target.
@@ -124,6 +125,9 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         stderr = stderr.decode("utf-8").split('\n')
         stdout.pop()
         stderr.pop()
+        if print:
+            sys.stdout.write("\n".join(stdout))
+            sys.stderr.write("\n".join(stderr))
         return (stdout, stderr, sub.returncode)
 
     @Driver.check_active

--- a/labgrid/protocol/commandprotocol.py
+++ b/labgrid/protocol/commandprotocol.py
@@ -5,14 +5,14 @@ class CommandProtocol(abc.ABC):
     """Abstract class for the CommandProtocol"""
 
     @abc.abstractmethod
-    def run(self, command: str):
+    def run(self, command: str, print: bool=False):
         """
         Run a command
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def run_check(self, command: str):
+    def run_check(self, command: str, print: bool=False):
         """
         Run a command, return str if succesful, ExecutionError otherwise
         """


### PR DESCRIPTION
To gather information about a test-failure it is sometime necessary to print the output of a command executed at the target. To reduce boilerplate in the testcases i propose to add a option to the command protocol to automatically print the output to the stdout/stderr.