### PR TITLE
add ssh commandline to supress warning

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -32,6 +32,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def on_activate(self):
         self.ssh_prefix = "-i {}".format(os.path.abspath(self.keyfile)
                                          ) if self.keyfile else ""
+        self.ssh_prefix += " -o LogLevel=ERROR"
         self.control = self._check_master()
         self.ssh_prefix += " -F /dev/null"
         self.ssh_prefix += " -o ControlPath={}".format(


### PR DESCRIPTION
On every ssh-connection we get a "Warning: Permanently added '...' (RSA) to the list of known hosts."
This will add a option to the ssh client to suppress the output of warning messages.