### PR TITLE
ubootdriver: configurable interrupt and correct autoboot

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -512,6 +512,7 @@ Implements:
 Arguments:
   - prompt (regex): u-boot prompt to match
   - password (str): optional u-boot unlock password
+  - interrupt (str, default="\\n"): string to interrupt autoboot (use "\\x03" for CTRL-C)
   - init_commands (tuple): tuple of commands to execute after matching the
     prompt
 

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -29,6 +29,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     bindings = {"console": ConsoleProtocol, }
     prompt = attr.ib(default="", validator=attr.validators.instance_of(str))
     password = attr.ib(default="", validator=attr.validators.instance_of(str))
+    interrupt = attr.ib(default="\n", validator=attr.validators.instance_of(str))
     init_commands = attr.ib(default=attr.Factory(tuple), convert=tuple)
 
     def __attrs_post_init__(self):
@@ -169,6 +170,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
             else:
                 raise Exception("Password entry needed but no password set")
         else:
+            self.console.write(self.interrupt.encode('ASCII'))
             self._check_prompt()
         for command in self.init_commands:  #pylint: disable=not-an-iterable
             self._run_check(command)


### PR DESCRIPTION
The UBootDriver did not correctly interrupt the autoboot, resulting in it
swallowing one character for the next command. Interrupt the autoboot and while
at it also make it configurable like the BareboxDriver

Fixes #117

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>