### PR TITLE
setup: workaround for the coordinator extra install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
                                  'man/labgrid-device-config.1'])],
     extras_require={
         'onewire': ['onewire>=0.2'],
-        'coordinator': ['crossbar']
+        'coordinator': ['crossbar', 'idna==2.5']
     },
     setup_requires=['pytest-runner', 'setuptools_scm'],
     tests_require=['pytest-mock', ],


### PR DESCRIPTION
This is a workaround for Issue #141. We'll introduce a proper fix later on.

Fixes #141 

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>