### PR TITLE
added a simple power driver for YEPKIT YKUSH switchable USB hubs - th…

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -108,6 +108,26 @@ The example describes port 0 on the remote power switch
 Used by:
   - `NetworkPowerDriver`_
 
+YKUSHPowerPort
+~~~~~~~~~~~~~~~~
+A YKUSHPowerPort describes a YEPKIT YKUSH USB (HID) switchable USB hub.
+
+.. code-block:: yaml
+
+   YKUSHPowerPort:
+     serial: YK12345
+     index: 1
+
+The example describes port 1 on the YKUSH USB hub with the
+serial "YK12345".
+(use "pykush -l" to get your serial...)
+
+- serial (str): serial number of the YKUSH hub
+- index (int): number of the port to switch
+
+Used by:
+  - `YKUSHPowerDriver`_
+
 NetworkService
 ~~~~~~~~~~~~~~
 A NetworkService describes a remote SSH connection.
@@ -641,6 +661,25 @@ Implements:
 .. code-block:: yaml
 
    NetworkPowerDriver:
+     delay: 5.0
+
+Arguments:
+  - delay (float): optional delay in seconds between off and on
+
+YKUSHPowerDriver
+~~~~~~~~~~~~~~~~~~
+A YKUSHPowerDriver controls a `YKUSHPowerPort`, allowing control of the
+target power state without user interaction.
+
+Binds to:
+  - `YKUSHPowerPort`_
+
+Implements:
+  - :any:`PowerProtocol`
+
+.. code-block:: yaml
+
+   YKUSHPowerDriver:
      delay: 5.0
 
 Arguments:

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -8,7 +8,7 @@ from .exception import CleanUpError, ExecutionError
 from .fastbootdriver import AndroidFastbootDriver
 from .openocddriver import OpenOCDDriver
 from .onewiredriver import OneWirePIODriver
-from .powerdriver import ManualPowerDriver, ExternalPowerDriver, DigitalOutputPowerDriver
+from .powerdriver import ManualPowerDriver, ExternalPowerDriver, DigitalOutputPowerDriver, YKUSHPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver
 from .usbstorage import USBStorageDriver
 from .infodriver import InfoDriver

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -6,3 +6,4 @@ from .power import NetworkPowerPort
 from .remote import RemotePlace
 from .udev import USBSerialPort
 from .common import Resource, ResourceManager, ManagedResource
+from .ykushpowerport import YKUSHPowerPort

--- a/labgrid/resource/ykushpowerport.py
+++ b/labgrid/resource/ykushpowerport.py
@@ -1,0 +1,17 @@
+import attr
+
+from ..factory import target_factory
+from .common import Resource
+
+
+@target_factory.reg_resource
+@attr.s(cmp=False)
+class YKUSHPowerPort(Resource):
+    """This resource describes a YEPKIT YKUSH switchable USB hub.
+
+    Args:
+        serial (str): serial of the YKUSH device 
+        index (int): port index"""
+    serial = attr.ib(validator=attr.validators.instance_of(str))
+    index = attr.ib(validator=attr.validators.instance_of(int),
+                    convert=lambda x: int(x))


### PR DESCRIPTION
…is currently "highjacks" the NetworkPowerPort resource by using the host entry as serial for the USB hub. 
works for me as it is but i might be willing to tweak some stuff if you are interested in getting it into your repo ;-)

Signed-off-by: Tobi Gschwendtner <tg@bloks.de>