### PR TITLE
setup, requirements: avoid attrs 17.3.0

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 PyYAML
-attrs>=16.3.0
+attrs>=16.3.0,<17.3.0
 crossbar==17.8.1.post1
 pexpect
 pyserial>=3.3

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     setup_requires=['pytest-runner', 'setuptools_scm'],
     tests_require=['pytest-mock', ],
     install_requires=[
-        'attrs>=16.3.0',
+        'attrs>=16.3.0,<17.3.0',
         'jinja2',
         'pexpect',
         'pyserial>=3.3',


### PR DESCRIPTION
Attrs 17.3.0 changes the attribute order for classes using multiple
inheritance, causing problems with default/non-default attributes.