### PR TITLE
support for ssh password

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -160,9 +160,12 @@ A NetworkService describes a remote SSH connection.
 
 The example describes a remote SSH connection to the computer `example.computer`
 with the username `root`.
+Set the optional password password property to make SSH login with a password
+instead of the key file (needs sshpass to be installed)
 
 - address (str): hostname of the remote system
 - username (str): username used by SSH
+- password (str): password used by SSH
 
 Used by:
   - `SSHDriver`_
@@ -531,6 +534,7 @@ Implements:
 
 Arguments:
   - keyfile (str): filename of private key to login into the remote system
+    (only used if password is not set)
 
 InfoDriver
 ~~~~~~~~~~

--- a/labgrid/resource/networkservice.py
+++ b/labgrid/resource/networkservice.py
@@ -9,3 +9,4 @@ from .common import Resource
 class NetworkService(Resource):
     address = attr.ib(validator=attr.validators.instance_of(str))
     username = attr.ib(validator=attr.validators.instance_of(str))
+    password = attr.ib(default='', validator=attr.validators.instance_of(str))


### PR DESCRIPTION
* the networkservice resource has a new password property - if it is set
  the sshdriver will login with sshpass (needs to be installed) instead
  of the key file

Signed-off-by: Tobi Gschwendtner <tg@bloks.de>