### PR TITLE
add fastboot continue command

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -59,3 +59,8 @@ class AndroidFastbootDriver(Driver):
         filename = os.path.abspath(filename)
         check_file(filename, command_prefix=self.fastboot.command_prefix)
         self("flash", partition, filename)
+
+    @Driver.check_active
+    @step(title='continue')
+    def continue_boot(self):
+        self("continue")


### PR DESCRIPTION
added the "continue" command for fastboot.
This particulary useful to run a "special fastboot" uboot version
which always starts in fastboot mode, enableling flashing without
any external trigger. After exiting the fastboot mode with the
"continue" command uboot will continue to boot normally.

Signed-off-by: Tobi Gschwendtner <tg@bloks.de>