### PR TITLE
resource/udev: remove devices only on unbind

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -90,7 +90,7 @@ class USBResource(ManagedResource):
             self.device = device
         elif device.action in ['change', 'move']:
             self.device = device
-        else:
+        elif device.action in ['unbind', 'remove']:
             self.avail = False
             self.device = None
         self.update()


### PR DESCRIPTION
Before this change every action which is not in one of the previous cases would
remove the device and set availability to false. This includes the 'bind'
action. Remove the device only if the device unbinds.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>