### PR TITLE
changed "-f" option for SSH master to "-n"

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -52,7 +52,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         )
         # use sshpass if we have a password
         sshpass = "sshpass -e " if self.networkservice.password else ""
-        args = ("{}ssh -f {} -x -o ConnectTimeout=30 -o ControlPersist=300 "
+        args = ("{}ssh -n {} -x -o ConnectTimeout=30 -o ControlPersist=300 "
                 "-o UserKnownHostsFile=/dev/null "
                 "-o StrictHostKeyChecking=no -MN -S {} {}@{}").format(
                     sshpass, self.ssh_prefix, control,


### PR DESCRIPTION
Signed-off-by: Tobi Gschwendtner <tg@bloks.de>

this fixes some "strange" ssh behavior for me where the ssh master seems to got to background too early (im missing 2 debug messages in those cases) sometimes (about every 20 tries) on some machines and i then get connection refused errors when trying to connect via the control socket.