### PR TITLE
Fix documentation compilation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ New Features
 
 - The target now saves it's attached drivers, resources and protocols in a
   lookup table, avoiding the need of importing many Drivers and Protocols (see
-  :any:`Syntactic sugar for targets`)
+  `Syntactic sugar for Targets`_)
 - The new subcommand ``labgrid-client monitor`` shows resource or places
   changes as they happen, which is useful during development or debugging.
 - The new `QEMUDriver` runs a system image in QEmu and implements the
@@ -22,8 +22,8 @@ New Features
   junit XML output.
 - The ``labgrid-client`` tool now understands a ``--state`` option to
   transition to the provided state using a :any:`Strategy`.
-  This requires an environment yaml file with a :any:`RemotePlace` `Resource` and
-  matching `Drivers`.
+  This requires an environment yaml file with a :any:`RemotePlace` Resources and
+  matching Drivers.
 - Resource matches for places configured in the coordinator can now have a
   name, allowing multiple resources with the same class.
 - The new `Target.__getitem__` method makes writing using protocols less verbose.
@@ -38,7 +38,7 @@ Incompatible Changes
 
 - When using the coordinator, it must be upgrade together with the clients
   because of the newly introduce match names.
-- `Resources` and `Drivers` now need to be created with an explicit name
+- Resources and Drivers now need to be created with an explicit name
   parameter.
   It can be ``None`` to keep the old behaviour.
   See below for details.
@@ -84,7 +84,7 @@ ConsoleProtocol:
 PowerProtocol:
    In some cases, multiple power ports need to be controlled for one Target.
 
-To support these use cases, `Resources` and `Drivers` must be created with a
+To support these use cases, Resources and Drivers must be created with a
 name parameter.
 When updating your code to this version, you can either simply set the name to
 ``None`` to keep the previous behaviour.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -167,6 +167,7 @@ texinfo_documents = [
 # -- Options for autodoc --------------------------------------------------
 
 autodoc_member_order = 'bysource'
+autodoc_default_flags = ['special-members']
 autodoc_mock_imports = ['onewire',
                         'txaio',
                         'autobahn',
@@ -178,6 +179,10 @@ autodoc_mock_imports = ['onewire',
                         'autobahn.twisted.wamp',
                         'autobahn.wamp.exception',
                         'twisted.internet.defer']
+
+from unittest.mock import Mock
+for mod in autodoc_mock_imports:
+    sys.modules[mod] = Mock()
 
 def run_apidoc(app):
     from sphinx.apidoc import main

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -150,7 +150,7 @@ class Config:
         """Helper function that returns the list of all imports
 
         Returns:
-            list: List of files which should be imported
+            List: List of files which should be imported
         """
         imports = []
 

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -59,7 +59,7 @@ class Target:
         Poll the given resources and wait until they are (un-)available.
 
         Args:
-            resources (list): the resources to poll
+            resources (List): the resources to poll
             timeout (float): optional timeout
             avail (bool): optionally wait until the resources are unavailable with avail=False
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ addopts = -p no:labgrid
 [yapf]
 dedent_closing_brackets = true
 coalesce_brackets = true
+[build_sphinx]
+warning-is-error = 1


### PR DESCRIPTION
This PR fixes the errors during documentation compilation. The last commit is a very dirty hack, but works for now. I'll dig into apidoc some more if we want to drop that commit.