### PR TITLE
remote/client: Added missing speed configuration for microcom console

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -632,7 +632,7 @@ class ClientSession(ApplicationSession):
         assert resource.port is not None, "Port is not set"
 
         call = [
-            'microcom', '-t',
+            'microcom', '-s', str(resource.speed), '-t',
             "{}:{}".format(resource.host, resource.port)
         ]
         print("connecting to ", resource, "calling ", " ".join(call))


### PR DESCRIPTION
microcom console was missing capability to adjust speed even though
resource.speed exist.
