### PR TITLE
driver/smallubootdriver: add driver for small UBoots

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -618,6 +618,58 @@ Arguments:
     defaults to "U-Boot 20\d+"
   - bootstring (str): optional, regex to match on Linux Kernel boot
 
+SmallUBootDriver
+~~~~~~~~~~~~~~~~
+A SmallUBootDriver interfaces with stripped-down UBoot variants that are
+sometimes used in cheap consumer electronics.
+
+SmallUBootDriver is meant as a driver for UBoot with only little
+functionality compared to standard a standard UBoot.
+Especially is copes with the following limitations:
+
+- The UBoot does not have a real password-prompt but can be activated by
+  entering a "secret" after a message was displayed.
+- The command line is does not have a build-in echo command. Thus this
+  driver uses 'Unknown Command' messages as marker before and after the
+  output of a command.
+- Since there is no echo we can not return the exit code of the command.
+  Commands will always return 0 unless the command was not found.
+
+This driver needs the following features activated in UBoot to work:
+
+- The UBoot must not have real password prompt. Instead it must be
+  keyword activated.
+  For example it should be activated by a dialog like the following:
+
+  - UBoot: "Autobooting in 1s..."
+  - Labgrid: "secret"
+  - UBoot: <switching to console>
+
+- The UBoot must be able to parse multiple commands in a single
+  line separated by ";".
+- The UBoot must support the "bootm" command to boot from a
+  memory location.
+
+Binds to:
+  - :any:`ConsoleProtocol` (see `SerialDriver`_)
+
+Implements:
+  - :any:`CommandProtocol`
+
+.. code-block:: yaml
+
+   SmallUBootDriver:
+     prompt: 'ap143-2\.0> '
+     boot_expression: 'Autobooting in 1 seconds'
+     boot_secret: "tpl"
+
+Arguments:
+  - prompt (regex): u-boot prompt to match
+  - init_commands (tuple): tuple of commands to execute after matching the
+    prompt
+  - boot_expression (str): optional, regex to match the uboot start string
+    defaults to "U-Boot 20\d+"
+
 BareboxDriver
 ~~~~~~~~~~~~~
 

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -1,5 +1,6 @@
 from .bareboxdriver import BareboxDriver
 from .ubootdriver import UBootDriver
+from .smallubootdriver import SmallUBootDriver
 from .serialdriver import SerialDriver
 from .shelldriver import ShellDriver
 from .sshdriver import SSHDriver

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -1,0 +1,118 @@
+import logging
+import re
+
+import attr
+from pexpect import TIMEOUT
+
+from ..factory import target_factory
+from ..protocol import CommandProtocol, ConsoleProtocol, LinuxBootProtocol
+from ..util import gen_marker
+from ..step import step
+from .common import Driver
+from .commandmixin import CommandMixin
+from .exception import ExecutionError
+
+from .ubootdriver import UBootDriver
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class SmallUBootDriver(UBootDriver):
+    """
+    SmallUBootDriver is meant as a driver for UBoot with only little
+    functionality compared to standard a standard UBoot.
+    Especially is copes with the following limitations:
+
+    - The UBoot does not have a real password-prompt but can be activated by
+      entering a "secret" after a message was displayed.
+    - The command line is does not have a build-in echo command. Thus this
+      driver uses 'Unknown Command' messages as marker before and after the
+      output of a command.
+    - Since there is no echo we can not return the exit code of the command.
+      Commands will always return 0 unless the command was not found.
+
+    This driver needs the following features activated in UBoot to work:
+
+    - The UBoot must not have real password prompt. Instead it must be
+      keyword activated.
+      For example it should be activated by a dialog like the following:
+      UBoot: "Autobooting in 1s..."
+      Labgrid: "secret"
+      UBoot: <switching to console>
+    - The UBoot must be able to parse multiple commands in a single
+      line separated by ";".
+    - The UBoot must support the "bootm" command to boot from a
+      memory location.
+
+    This driver was created especially for the following devices:
+
+    - TP-Link WR841 v11
+    """
+
+    boot_secret = attr.ib(default="a", validator=attr.validators.instance_of(str))
+
+    @step()
+    def _await_prompt(self):
+        """
+        Await autoboot_expression. If this line was read enter the 'secret' (or a
+        single character) to interrupt normal boot.
+        """
+
+        # wait for boot expression. Afterwards enter secret
+        self.console.expect(self.boot_expression)
+        self.console.sendline(self.boot_secret)
+        self._status = 1
+
+        # wait until UBoot has reached it's prompt
+        self.console.expect(self.prompt)
+
+    @step(args=['cmd'], result=True)
+    def _run(self, cmd):
+        """
+        If Uboot is in Command-Line mode: Run command cmd and return it's
+        output.
+
+        Arguments:
+        cmd - Command to run
+        """
+
+        # Check if Uboot is in command line mode
+        if self._status != 1:
+            return None
+
+        marker = gen_marker()
+
+        # Create multi-part command like we would do for a normal uboot.
+        # but since this simple uboot does not have an echo-command we will
+        # handle it's error message as an echo-output.
+        # additionally we are not able to get the command's return code and
+        # will always return 0.
+        cmp_command = """echo{}; {}; echo{}""".format(
+            marker,
+            cmd,
+            marker
+        )
+
+        self.console.sendline(cmp_command)
+        _, before, _, _ = self.console.expect(self.prompt)
+
+        data = self.re_vt100.sub(
+            '', before.decode('utf-8'), count=1000000
+        ).replace("\r","").split("\n")
+        data = data[1:]
+        data = data[data.index("Unknown command 'echo{}' - try 'help'".format(marker)) +1 :]
+        data = data[:data.index("Unknown command 'echo{}' - try 'help'".format(marker))]
+        if len(data) >= 1:
+            if data[0].startswith("Unknown command '"):
+                return (data, [], 1)
+        return (data, [], 0)
+
+    @Driver.check_active
+    @step(args=['name'], result=True)
+    def boot(self, name):
+        """
+        Boot the device from the given memory location using 'bootm'.
+
+        Args:
+            name (str): address to boot
+        """
+        self.console.sendline("bootm {}".format(name))


### PR DESCRIPTION
This patch adds a driver for really small (and thus stripped down)
UBoot drivers.

This UBoots do not have:
* A real password prompt
* An echo command
* The possibility to print the return code of a command

This driver copes with these limitations.

Tested against the stock-uboot on a TP-Link WR841N v11.

Signed-off-by: Chris Fiege <chris@tinyhost.de>