### PR TITLE
 driver/powerdriver: Add SerialPortPowerdriver 

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -891,6 +891,30 @@ Arguments:
   - cmd_off (str): command to turn power to the board off
   - delay (float): configurable delay in seconds between off and on
 
+SerialPortDigitalOutputDriver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The SerialPortDigitalOutputDriver makes it possible to use a UART
+as a 1-Bit general-purpose digital output.
+
+This driver sits on top of a SerialDriver and uses the it's pyserial-
+port to control the flow control lines.
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   SerialPortDigitalOutputDriver:
+     signal: "DTR"
+     bindings: { serial : "nameOfSerial" }
+
+Arguments:
+  - signal (str): control signal to use: DTR or RTS
+  - bindings (dict): A named ressource of the type SerialDriver to
+    bind against. This is only needed if you have multiple
+    SerialDriver in your environment (what is likely to be the case
+    if you are using this driver).
+
 ModbusCoilDriver
 ~~~~~~~~~~~~~~~~
 A ModbusCoilDriver controls a `ModbusTCPCoil` resource.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -873,9 +873,11 @@ Arguments:
 
 DigitalOutputPowerDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~
-A DigitalOutputPowerDriver can be used to control a device with external
-commands and a digital output port. The digital output port is used to reset the
-device.
+A DigitalOutputPowerDriver can be used to control the power of a
+Device using a DigitalOutputDriver.
+
+Using this driver you probably want an external relay to switch the
+power of your DUT.
 
 Binds to:
   - :any:`DigitalOutputProtocol`
@@ -883,12 +885,9 @@ Binds to:
 .. code-block:: yaml
 
    DigitalOutputPowerDriver:
-     cmd_on: example_command on
-     cmd_off: example_command off
+     delay: Delay for a power cycle
 
 Arguments:
-  - cmd_on (str): command to turn power to the board on
-  - cmd_off (str): command to turn power to the board off
   - delay (float): configurable delay in seconds between off and on
 
 SerialPortDigitalOutputDriver

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -10,7 +10,8 @@ from .fastbootdriver import AndroidFastbootDriver
 from .openocddriver import OpenOCDDriver
 from .quartushpsdriver import QuartusHPSDriver
 from .onewiredriver import OneWirePIODriver
-from .powerdriver import ManualPowerDriver, ExternalPowerDriver, YKUSHPowerDriver
+from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
+                         DigitalOutputPowerDriver, YKUSHPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver
 from .usbstorage import USBStorageDriver
 from .usbsdmuxdriver import USBSDMuxDriver

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -21,3 +21,4 @@ from .modbusdriver import ModbusCoilDriver
 from .sigrokdriver import SigrokDriver
 from .networkusbstoragedriver import NetworkUSBStorageDriver
 from .resetdriver import DigitalOutputResetDriver
+from .serialdigitaloutput import SerialPortDigitalOutputDriver

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -131,6 +131,41 @@ class NetworkPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 
 @target_factory.reg_driver
 @attr.s(cmp=False)
+class DigitalOutputPowerDriver(Driver, PowerResetMixin, PowerProtocol):
+    """
+    DigitalOutputPowerDriver uses a DigitalOutput to control the power
+    of a DUT.
+    """
+    bindings = {"output": DigitalOutputProtocol, }
+    delay = attr.ib(default=1.0, validator=attr.validators.instance_of(float))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    @Driver.check_active
+    @step()
+    def on(self):
+        self.output.set(True)
+
+    @Driver.check_active
+    @step()
+    def off(self):
+        self.output.set(False)
+
+    @Driver.check_active
+    @step()
+    def cycle(self):
+        self.off()
+        time.sleep(self.delay)
+        self.on()
+
+    @Driver.check_active
+    @step()
+    def get(self):
+        return self.output.get()
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
 class YKUSHPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """YKUSHPowerDriver - Driver using a YEPKIT YKUSH switchable USB hub
         to control a target's power - https://www.yepkit.com/products/ykush"""
@@ -165,3 +200,4 @@ class YKUSHPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     @Driver.check_active
     def get(self):
         return self.pykush.get_port_state(self.port.index)
+

--- a/labgrid/driver/serialdigitaloutput.py
+++ b/labgrid/driver/serialdigitaloutput.py
@@ -1,0 +1,60 @@
+import shlex
+import subprocess
+import time
+from importlib import import_module
+import serial
+
+import attr
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol
+from ..step import step
+from ..resource import SerialPort
+from .common import Driver
+from . import SerialDriver
+from .onewiredriver import OneWirePIODriver
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class SerialPortDigitalOutputDriver(Driver, DigitalOutputProtocol):
+    """
+    Controls the state of a GPIO using the control lines of a serial port.
+
+    This driver uses the flow-control pins of a serial port (for example
+    an USB-UART-dongle) to control some external power switch. You may connect
+    some kind of relay board to the flow control pins.
+
+    The serial port should NOT be used for serial communication at the same
+    time. This will probably reset the flow-control signals.
+
+    Usable signals are DTR and RTS.
+    """
+
+    bindings = {'serial': SerialDriver}
+    signal= attr.ib(validator=attr.validators.instance_of(str))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        # basic input format checking
+        self.signal = self.signal.lower()
+        if self.signal not in  ["dtr", "rts"]:
+            raise Exception("Unknown index for serial-power-driver")
+
+        self._p = self.serial.serial
+
+    @Driver.check_active
+    @step()
+    def get(self):
+        if self.signal ==  "dtr":
+            return self._p.dtr
+        elif self.signal == "rts":
+            return self._p.rts
+
+    @Driver.check_active
+    @step()
+    def set(self, value):
+        if self.signal == "dtr":
+            self._p.dtr = value
+        elif self.signal == "rts":
+            self._p.rts = value


### PR DESCRIPTION
Adding a powerdriver that controls an external relais board connected to
the control signals of a USB-UART-dongle.

This is a poor-mans solution for a power switch that can be used for
desktops with only a single place.