### PR TITLE
 driver/shelldriver: Add 'enable console' feature

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -608,6 +608,10 @@ Arguments:
     `SSHDriver`_ usable
   - login_timeout (int): optional, timeout for login prompt detection in
     seconds (default 60)
+  - await_login_timeout (int): optional, time in seconds of silence that needs
+    to pass before sending a newline to device.
+  - console_ready (regex): optional, pattern used by the kernel to inform
+    the user that a console can be activated by pressing enter.
 
 .. _conf-sshdriver:
 


### PR DESCRIPTION
This feature can be used for embedded devices that do not - by default -
start a console on the serial terminal.  The 'console_ready'-regex is
used to identify when the kernel is ready to start a console. Afterwards
<enter> is send to the device. The shelldriver now waits for a prompt or login.

Tested with a 4.4-kernel on a LEDE-based device.

If 'console_ready' is not set _await_login() should behave like before.

Depends on #192.
