### PR TITLE
Remove leftover installation section from overview

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1,45 +1,6 @@
 Overview
 ========
 
-Installation
-------------
-
-The default installation is available via PyPI:
-
-.. code-block:: bash
-
-    $ pip install labgrid
-
-or by cloning the repository and installing manually:
-
-.. code-block:: bash
-
-    $ git clone https://github.com/labgrid-project/labgrid
-    $ cd labgrid && python3 setup.py install
-
-Extra Requirements
-~~~~~~~~~~~~~~~~~~
-Labgrid supports different extras:
-
-- onewire: install onewire support, requires ``onewire>=0.0.2`` from PyPI and
-  additionally ``libow-dev`` on Debian based distributions.
-- coordinator: installs required depencies to start a crossbar coordinator
-
-The extras can be selected by passing them after the package name in square
-brackets:
-
-.. code-block:: bash
-
-    $ pip install labgrid[onewire]
-
-or to enable both:
-
-.. code-block:: bash
-
-    $ pip install labgrid[onewire,coordinator]
-
-Depending on the used shell settings, the brackets may have to be escaped via ``\``.
-
 Architecture
 ------------
 


### PR DESCRIPTION
The overview section also has an Installation section. Remove it since it's outdated and the installation procedure fits into getting started better anyway.