### PR TITLE
map LG_* variables from OS environment into YAML config file 

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -15,6 +15,7 @@ class Config:
     filename = attr.ib(validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
+        # load and parse the yaml configuration file
         self.base = os.path.dirname(os.path.abspath(self.filename))
         try:
             with open(self.filename) as file:
@@ -26,6 +27,12 @@ class Config:
         substitutions = {
             'BASE': self.base,
         }
+        # map LG_* variables from OS environment into YAML config file using !template $LG_*
+        # Only map LG_*, to protect from weird things in environment
+        for x in os.environ.keys():
+            if x.startswith( "LG_" ):
+                substitutions[x] = os.environ[x]
+
         try:
             resolve_templates(self.data, substitutions)
         except KeyError as e:


### PR DESCRIPTION
Reads all shell environment variables named LG_* and adds these to the substitution list used by !template in the YAML config file.

Ex. a place can thus be specified via the environment
`export LG_PLACE=kjeldsboard
`
And in local.yaml write
```
targets:
  main:
    resources:
      RemotePlace:
        name: !template $LG_PLACE
```

In this way, the same config can be used on several targets without editing before running pytest.
