### PR TITLE
implement driver priorities and the ResetProtocol

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -370,25 +370,6 @@ Ideas
 
 .. please keep these sorted alphabetically
 
-Driver Priorities
-~~~~~~~~~~~~~~~~~
-
-In more complex use-cases, we often have multiple drivers implementing the same
-Protocols on the same :any:`Target`. For example:
-
-CommandProtocol (ShellDriver and SSHDriver):
-   The SSHDriver may not be active all the time, but should be preferred when it
-   is.
-
-ResetProtocol (DigitalOutputResetDriver and NetworkPowerPort via power cycling):
-   This will occour when we implement the `ResetProtocol`_ as below.
-   The real reset driver should be preferred in that case.
-
-To avoid a central precedence list (which would be problematic for third-party
-drivers), each driver should declare its precedence per protocol relative other
-drivers by referencing them by class name.
-This way, the Target can sort them at runtime.
-
 Driver Preemption
 ~~~~~~~~~~~~~~~~~
 
@@ -421,18 +402,6 @@ notifying the current user on each invocation of labgrid-client that another
 user is waiting.
 The reservation should expire after some time if it is not used to lock the
 target after it becomes available.
-
-ResetProtocol
-~~~~~~~~~~~~~
-
-Resetting a board is a distinct operation from cycling the power and is often
-triggered by pushing a button (automated via a relays or FET).
-If a real reset is unavailable, power cycling could be used to emulate the reset.
-Currently, the :any:`DigitalOutputPowerDriver` implements the
-:any:`PowerProtocol` instead, mixing the two aspects.
-
-To handle falling back to emulation via the PowerProtocol nicely, we would need
-to implement `Driver Priorities`_
 
 Step Tracing
 ~~~~~~~~~~~~

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -137,6 +137,35 @@ specific driver set a binding mapping before creating the driver:
   >>> sd.port
   SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
 
+Priorities
+~~~~~~~~~~
+Each driver supports a priorities class variable.
+This allows drivers which implement the same protocol to add a priority option
+to each of their protocols.
+This way a `NetworkPowerDriver` can implement the `ResetProtocol`, but if another
+`ResetProtocol` driver with a higher protocol is available, it will be selected
+instead.
+
+.. note::
+  Priority resolution only takes place if you have multiple drivers
+  which implement the same protocol and you are not fetching them by
+  name.
+
+The target resolves the driver priority via the Method Resolution Order (MRO)
+of the driver's base classes.
+If a base class has a `priorities` dictionary which contains the requested
+Protocol as a key, that priority is used.
+Otherwise, `0` is returned as the default priority.
+
+To set the priority of a protocol for a driver, add a class variable with the
+name `priorities`, e.g.
+
+.. code-block:: python
+
+   @attr.s
+   class NetworkPowerDriver(Driver, PowerProtocol, ResetProtocol):
+       priorities: {PowerProtocol: -10}
+
 Strategies
 ~~~~~~~~~~
 

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -10,7 +10,7 @@ from .fastbootdriver import AndroidFastbootDriver
 from .openocddriver import OpenOCDDriver
 from .quartushpsdriver import QuartusHPSDriver
 from .onewiredriver import OneWirePIODriver
-from .powerdriver import ManualPowerDriver, ExternalPowerDriver, DigitalOutputPowerDriver, YKUSHPowerDriver
+from .powerdriver import ManualPowerDriver, ExternalPowerDriver, YKUSHPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver
 from .usbstorage import USBStorageDriver
 from .usbsdmuxdriver import USBSDMuxDriver
@@ -20,3 +20,4 @@ from .qemudriver import QEMUDriver
 from .modbusdriver import ModbusCoilDriver
 from .sigrokdriver import SigrokDriver
 from .networkusbstoragedriver import NetworkUSBStorageDriver
+from .resetdriver import DigitalOutputResetDriver

--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -25,6 +25,24 @@ class Driver(BindingMixin):
         if self.target is None:
             raise BindingError("Drivers can only be created on a valid target")
 
+    def get_priority(self, protocol):
+        """Retrieve the priority for a given protocol
+
+        Arguments:
+        protocol - protocol to search for in the MRO
+
+        Returns:
+            Int: value of the priority if it is found, 0 otherwise.
+        """
+        for cls in self.__class__.__mro__:
+            prios = getattr(cls, 'priorities', {})
+            # we found a matching parent priorities attribute with the matching protocol
+            if prios and protocol in prios:
+                return prios.get(protocol)
+            # If we find the parent protocol, set the priority to 0
+            if cls.__name__ == protocol.__name__:
+                return 0
+
 
 def check_file(filename, *, command_prefix=[]):
     if subprocess.call(command_prefix + ['test', '-r', filename]) != 0:

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -116,44 +116,7 @@ class NetworkPowerDriver(Driver, PowerProtocol):
 
 @target_factory.reg_driver
 @attr.s(cmp=False)
-class DigitalOutputPowerDriver(Driver, PowerProtocol):
-    """DigitalOutputPowerDriver - Driver using a DigitalOutput to reset the target and
-    subprocesses to turn it on and off"""
-    bindings = {"output": DigitalOutputProtocol, }
-    cmd_on = attr.ib(validator=attr.validators.instance_of(str))
-    cmd_off = attr.ib(validator=attr.validators.instance_of(str))
-    delay = attr.ib(default=1.0, validator=attr.validators.instance_of(float))
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-
-    @Driver.check_active
-    @step()
-    def on(self):
-        cmd = shlex.split(self.cmd_on)
-        subprocess.check_call(cmd)
-
-    @Driver.check_active
-    @step()
-    def off(self):
-        cmd = shlex.split(self.cmd_off)
-        subprocess.check_call(cmd)
-
-    @Driver.check_active
-    @step()
-    def cycle(self):
-        self.output.set(True)
-        time.sleep(self.delay)
-        self.output.set(False)
-
-    @Driver.check_active
-    @step()
-    def get(self):
-        return True # FIXME
-
-@target_factory.reg_driver
-@attr.s(cmp=False)
-class YKUSHPowerDriver(Driver, PowerProtocol):
+class YKUSHPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """YKUSHPowerDriver - Driver using a YEPKIT YKUSH switchable USB hub
         to control a target's power - https://www.yepkit.com/products/ykush"""
     bindings = {"port": YKUSHPowerPort, }

--- a/labgrid/driver/resetdriver.py
+++ b/labgrid/driver/resetdriver.py
@@ -1,0 +1,26 @@
+import time
+
+import attr
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol, ResetProtocol
+from ..step import step
+from .common import Driver
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class DigitalOutputResetDriver(Driver, ResetProtocol):
+    """DigitalOutputResetDriver - Driver using a DigitalOutput to reset the
+    target"""
+    bindings = {"output": DigitalOutputProtocol, }
+    delay = attr.ib(default=1.0, validator=attr.validators.instance_of(float))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    @Driver.check_active
+    @step()
+    def reset(self):
+        self.output.set(True)
+        time.sleep(self.delay)
+        self.output.set(False)

--- a/labgrid/protocol/__init__.py
+++ b/labgrid/protocol/__init__.py
@@ -8,3 +8,4 @@ from .infoprotocol import InfoProtocol
 from .digitaloutputprotocol import DigitalOutputProtocol
 from .mmioprotocol import MMIOProtocol
 from .filesystemprotocol import FileSystemProtocol
+from .resetprotocol import ResetProtocol

--- a/labgrid/protocol/resetprotocol.py
+++ b/labgrid/protocol/resetprotocol.py
@@ -1,0 +1,6 @@
+import abc
+
+class ResetProtocol(abc.ABC):
+    @abc.abstractmethod
+    def reset(self):
+        raise NotImplementedError

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -170,9 +170,23 @@ class Target:
                     "no driver matching {} found in target {}".format(cls, self)
                 )
         elif len(found) > 1:
-            raise NoDriverFoundError(
-                "multiple drivers matching {} found in target {}".format(cls, self)
-            )
+            prio_last = -255
+            prio_found = []
+            for drv in found:
+                prio = drv.get_priority(cls)
+                if prio > prio_last:
+                    prio_found = []
+                    prio_found.append(drv)
+                    prio_last = prio
+                elif prio == prio_last:
+                    prio_found.append(drv)
+
+            if len(prio_found) == 1:
+                found = prio_found
+            else:
+                raise NoDriverFoundError(
+                    "multiple drivers matching {} found in target {} with the same priorities".format(cls, self)
+                   )
         if activate:
             self.activate(found[0])
         return found[0]


### PR DESCRIPTION
Initial starting point for the driver priorities. I wrote three tests and tweaked the `get_driver` function so far, so the tests pass. I have not looked a other parts of the chain yet.
TODO:
- [x] update docstrings for the DigitalOutputResetDriver