### PR TITLE
Add Support for the Pengutronix USB-SD-Mux Hardware

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -205,6 +205,18 @@ A USBMassStorage resource describes a USB memory stick or similar device.
 
 Used by:
   - `USBStorageDriver`_
+  - `NetworkUSBStorageDriver`_
+
+NetworkUSBMassStorage
+~~~~~~~~~~~~~~~~~~~~~
+A NetworkUSBMassStorage resource describes a USB memory stick or similar
+device available on a remote computer.
+
+Used by:
+  - `NetworkUSBStorageDriver`_
+
+The NetworkUSBMassStorage can be used in test cases by calling the
+`write_image()`, and `get_size()` functions.
 
 SigrokDevice
 ~~~~~~~~~~~~
@@ -930,6 +942,25 @@ Implements:
 
    USBStorageDriver: {}
 
+
+Arguments:
+  - None
+
+NetworkUSBStorageDriver
+~~~~~~~~~~~~~~~~~~~~~~~
+A NetworkUSBStorageDriver allows access to a USB stick or similar local or
+remote device.
+
+Binds to:
+  - `USBMassStorage`_
+  - `NetworkUSBMassStorage`_
+
+Implements:
+  - None (yet)
+
+.. code-block:: yaml
+
+   NetworkUSBStorageDriver: {}
 
 Arguments:
   - None

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -366,6 +366,12 @@ device.
 Used by:
   - `USBSDMUXDriver`_
 
+NetworkUSBSDMuxDevice
+~~~~~~~~~~~~~~~~~~~~~
+
+A :any:`NetworkUSBSDMuxDevice` resource descibes a `USBSDMuxDevice`_ available
+on a remote computer.
+
 RemotePlace
 ~~~~~~~~~~~
 A RemotePlace describes a set of resources attached to a labgrid remote place.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -349,6 +349,23 @@ A SigrokUSBDevice resource describes a sigrok USB device.
 Used by:
   - `SigrokDriver`_
 
+USBSDMuxDevice
+~~~~~~~~~~~~~~
+A :any:`USBSDMuxDevice` resource describes a Pengutronix
+`USB-SD-Mux <https://www.pengutronix.de/de/2017-10-23-usb-sd-mux-automated-sd-card-juggler.html>`_
+device.
+
+.. code-block:: yaml
+
+   USBSDMuxDevice:
+     match:
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
+
+- match (str): key and value for a udev match, see `udev Matching`_
+
+Used by:
+  - `USBSDMUXDriver`_
+
 RemotePlace
 ~~~~~~~~~~~
 A RemotePlace describes a set of resources attached to a labgrid remote place.
@@ -1052,6 +1069,18 @@ Implements:
 
 The driver can be used in test cases by calling the `capture`, `stop` and
 `analyze` functions.
+
+USBSDMuxDriver
+~~~~~~~~~~~~~~
+The :any:`USBSDMuxDriver` uses a USBSDMuxDevice resource to control a
+USB-SD-Mux device via `usbsdmux <https://github.com/pengutronix/usbsdmux>`_
+tool.
+
+Implements:
+  - None yet
+
+The driver can be used in test cases by calling the `set_mode()` function with
+argument being `dut`, `host`, `off`, or `client`.
 
 Strategies
 ----------

--- a/examples/usbsdmux/local.yaml
+++ b/examples/usbsdmux/local.yaml
@@ -1,0 +1,11 @@
+targets:
+  main:
+    resources:
+      USBSDMuxDevice:
+        match:
+          '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
+    drivers:
+      USBSDMuxDriver: {}
+
+tools:
+  usbsdmux: /home/enrico/Code/usbsdmux/env/bin/usbsdmux

--- a/examples/usbsdmux/test_sdmux.py
+++ b/examples/usbsdmux/test_sdmux.py
@@ -1,0 +1,4 @@
+def test_stick_plugin(target):
+    sdmux = target.get_driver('USBSDMuxDriver')
+    sdmux.set_mode('dut')
+    sdmux.set_mode('host')

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -18,3 +18,4 @@ from .common import Driver
 from .qemudriver import QEMUDriver
 from .modbusdriver import ModbusCoilDriver
 from .sigrokdriver import SigrokDriver
+from .networkusbstoragedriver import NetworkUSBStorageDriver

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -13,6 +13,7 @@ from .onewiredriver import OneWirePIODriver
 from .powerdriver import ManualPowerDriver, ExternalPowerDriver, DigitalOutputPowerDriver, YKUSHPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver
 from .usbstorage import USBStorageDriver
+from .usbsdmuxdriver import USBSDMuxDriver
 from .infodriver import InfoDriver
 from .common import Driver
 from .qemudriver import QEMUDriver

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -4,15 +4,15 @@ import subprocess
 import os
 
 from ..factory import target_factory
-from ..resource.udev import USBMassStorage
-from ..resource.remote import NetworkUSBMassStorage
+from ..resource.udev import USBMassStorage, USBSDMuxDevice
+from ..resource.remote import NetworkUSBMassStorage, NetworkUSBSDMuxDevice
 from ..step import step
 from .common import Driver, check_file
 
 @target_factory.reg_driver
 @attr.s(cmp=False)
 class NetworkUSBStorageDriver(Driver):
-    bindings = {"storage": {USBMassStorage, NetworkUSBMassStorage}, }
+    bindings = {"storage": {USBMassStorage, NetworkUSBMassStorage, USBSDMuxDevice, NetworkUSBSDMuxDevice}, }
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -1,0 +1,40 @@
+# pylint: disable=no-member
+import attr
+import subprocess
+import os
+
+from ..factory import target_factory
+from ..resource.udev import USBMassStorage
+from ..resource.remote import NetworkUSBMassStorage
+from ..step import step
+from .common import Driver, check_file
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class NetworkUSBStorageDriver(Driver):
+    bindings = {"storage": {USBMassStorage, NetworkUSBMassStorage}, }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    @step(args=['filename'])
+    def write_image(self, filename):
+        filename = os.path.abspath(filename)
+        check_file(filename, command_prefix=self.storage.command_prefix)
+        print("pwd: %s" % os.getcwd())
+        subprocess.check_call(
+          self.storage.command_prefix+["dd", "if=%s" % filename, "of=%s status=progress bs=4M conv=fdatasync" % self.storage.path]
+        )
+
+    @step(result=True)
+    def get_size(self):
+        size = subprocess.check_output(
+          self.storage.command_prefix+["cat", "/sys/class/block/%s/size" % self.storage.path[5:]]
+        )
+        return int(size)

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -1,0 +1,41 @@
+# pylint: disable=no-member
+import attr
+import subprocess
+
+from labgrid.factory import target_factory
+from labgrid.driver.common import Driver
+from ..resource.udev import USBSDMuxDevice
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class USBSDMuxDriver(Driver):
+    """The USBSDMuxDriver uses the usbsdmux tool
+    (https://github.com/pengutronix/usbsdmux) to control the USB-SD-Mux
+    hardware
+
+    Args:
+        bindings (dict): driver to use with usbsdmux
+    """
+    bindings = {
+        "mux": {USBSDMuxDevice},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('usbsdmux') or 'usbsdmux'
+        else:
+            self.tool = 'usbsdmux'
+
+    @Driver.check_active
+    def set_mode(self, mode):
+        ''
+        if not mode.lower() in ['dut', 'host', 'off', 'client']:
+            raise ExecutionError("Setting mode '%s' not supported by USBSDMuxDriver" % mode)
+        cmd = [
+                self.tool,
+                "-c",
+                self.mux.control_path,
+                mode.lower()
+        ]
+        subprocess.check_call(cmd)

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -5,6 +5,7 @@ import subprocess
 from labgrid.factory import target_factory
 from labgrid.driver.common import Driver
 from ..resource.udev import USBSDMuxDevice
+from ..resource.remote import NetworkUSBSDMuxDevice
 
 @target_factory.reg_driver
 @attr.s(cmp=False)
@@ -17,7 +18,7 @@ class USBSDMuxDriver(Driver):
         bindings (dict): driver to use with usbsdmux
     """
     bindings = {
-        "mux": {USBSDMuxDevice},
+        "mux": {USBSDMuxDevice, NetworkUSBSDMuxDevice},
     }
 
     def __attrs_post_init__(self):
@@ -32,7 +33,7 @@ class USBSDMuxDriver(Driver):
         ''
         if not mode.lower() in ['dut', 'host', 'off', 'client']:
             raise ExecutionError("Setting mode '%s' not supported by USBSDMuxDriver" % mode)
-        cmd = [
+        cmd = self.mux.command_prefix + [
                 self.tool,
                 "-c",
                 self.mux.control_path,

--- a/labgrid/driver/usbstorage.py
+++ b/labgrid/driver/usbstorage.py
@@ -4,7 +4,7 @@ import os
 
 from ..factory import target_factory
 from ..protocol import BootstrapProtocol
-from ..resource.udev import USBMassStorage
+from ..resource.udev import USBMassStorage, USBSDMuxDevice
 from ..step import step
 from .common import Driver
 from .exception import ExecutionError
@@ -13,7 +13,7 @@ from .exception import ExecutionError
 @target_factory.reg_driver
 @attr.s(cmp=False)
 class USBStorageDriver(Driver):
-    bindings = {"storage": USBMassStorage, }
+    bindings = {"storage": {USBMassStorage, USBSDMuxDevice}, }
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -202,12 +202,32 @@ class USBSigrokExport(USBGenericExport):
             'channels': self.local.channels
         }
 
+@attr.s(cmp=False)
+class USBSDMuxExport(USBGenericExport):
+    """ResourceExport for USB devices accessed directly from userspace"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': gethostname(),
+            'busnum': self.local.busnum,
+            'devnum': self.local.devnum,
+            'path': self.local.path,
+            'vendor_id': self.local.vendor_id,
+            'model_id': self.local.model_id,
+            'control_path': self.local.control_path,
+        }
+
 
 exports["AndroidFastboot"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
 exports["MXSUSBLoader"] = USBGenericExport
 exports["AlteraUSBBlaster"] = USBGenericExport
 exports["SigrokUSBDevice"] = USBSigrokExport
+exports["USBSDMuxDevice"] = USBSDMuxExport
 
 exports["USBMassStorage"] = USBGenericExport
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -209,6 +209,8 @@ exports["MXSUSBLoader"] = USBGenericExport
 exports["AlteraUSBBlaster"] = USBGenericExport
 exports["SigrokUSBDevice"] = USBSigrokExport
 
+exports["USBMassStorage"] = USBGenericExport
+
 
 @attr.s
 class EthernetPortExport(ResourceExport):

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -7,5 +7,6 @@ from .onewireport import OneWirePIO
 from .power import NetworkPowerPort
 from .remote import RemotePlace
 from .udev import USBSerialPort
+from .udev import USBSDMuxDevice
 from .common import Resource, ResourceManager, ManagedResource
 from .ykushpowerport import YKUSHPowerPort

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -159,3 +159,12 @@ class NetworkUSBMassStorage(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(cmp=False)
+class NetworkUSBSDMuxDevice(RemoteUSBResource):
+    """The NetworkUSBSDMuxDevice describes a remotely accessible USBSDMux device"""
+    control_path = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -151,3 +151,11 @@ class NetworkSigrokUSBDevice(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(cmp=False)
+class NetworkUSBMassStorage(RemoteUSBResource):
+    """The NetworkUSBMassStorage describes a remotely accessible USB storage device"""
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -171,7 +171,10 @@ class USBMassStorage(USBResource):
 
     @property
     def path(self):
-        return self.device.device_node
+        if self.device:
+            return self.device.device_node
+        else:
+            return None
 
 @target_factory.reg_resource
 @attr.s(cmp=False)


### PR DESCRIPTION
This adds support for the quite useful SD card juggler from Pengutronix (https://www.pengutronix.de/de/2017-10-23-usb-sd-mux-automated-sd-card-juggler.html) finally allowing to use it for automated testing with labgrid.

I also added a lg-command `sd-mux` to switch the USB-SD-Mux via `labgrid-client` but kept it out of this series because not being sure about how generic this is.

Despite the actual `/dev/sgX` device the Muxer uses is a `scsi_generic` one, I added the muxer as an USB device because it actually has a USB cable.

For now I realize this by matching the actual SCSI-Device and scanning if the parent matches the USB-SD-Mux USB vender and model ID's. To make this work with recent labgrid UBS resource implementation I had to adapt the DEVNUM and BUSNAME lookup a little.

Another approach that came to my mind was matching the actual USB device and then scanning its childs to find out the `/dev/sgX` device which I found to be more complex and not required as long as we do not intend to handle the SD-Cards block devices together with the sg device of the same Muxer to provide a more abstract 'switchable SD-Card'.


The series requires to set up the `usbsdmux ` tool as described here: https://github.com/pengutronix/usbsdmux