### PR TITLE
Make the ExecutionError readable for the run_check case

### DIFF
--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -90,24 +90,6 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
             return None
 
     @Driver.check_active
-    def run_check(self, cmd: str, timeout: int = 30):
-        """
-        Runs the specified command on the shell and returns the output if successful,
-        raises ExecutionError otherwise.
-
-        Args:
-            cmd (str): command to run on the shell
-            timeout (int): optional, timeout in seconds
-
-        Returns:
-            List[str]: stdout of the executed command
-        """
-        res = self.run(cmd, timeout=timeout)
-        if res[2] != 0:
-            raise ExecutionError(cmd)
-        return res[0]
-
-    @Driver.check_active
     @step()
     def reset(self):
         """Reset the board via a CPU reset

--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -22,3 +22,34 @@ class CommandMixin:
             sleep(sleepduration)
         if timeout.expired:
             raise ExecutionError("Wait timeout expired")
+
+    def _run_check(self, cmd: str, timeout=30):
+        """
+        Internal function which runs the specified command on the shell and
+        returns the output if successful, raises ExecutionError otherwise.
+
+        Args:
+            cmd (str): command to run on the shell
+
+        Returns:
+            List[str]: stdout of the executed command
+        """
+        stdout, stderr, exitcode = self.run(cmd, timeout=timeout)
+        if exitcode != 0:
+            raise ExecutionError(cmd, stdout, stderr)
+        return stdout
+
+    @Driver.check_active
+    def run_check(self, cmd: str, timeout=30):
+        """
+        External run_check function, only available if the driver is active.
+        Runs the supplied command and returns the stdout, raises an
+        ExecutionError otherwise.
+
+        Args:
+            cmd (str): command to run on the shell
+
+        Returns:
+            List[str]: stdout of the executed command
+        """
+        return self._run_check(cmd,timeout)

--- a/labgrid/driver/exception.py
+++ b/labgrid/driver/exception.py
@@ -4,6 +4,8 @@ import attr
 @attr.s(cmp=False)
 class ExecutionError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
+    stdout = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(list)))
+    stderr = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(list)))
 
 
 @attr.s(cmp=False)

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -169,24 +169,6 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             if time.time() > start + self.login_timeout:
                 raise TIMEOUT("Timeout of {} seconds exceeded during waiting for login".format(self.login_timeout))
 
-    @step(args=['cmd'], result=True)
-    def _run_check(self, cmd, timeout=30):
-        out, _, res = self._run(cmd, timeout=timeout)
-        if res != 0:
-            raise ExecutionError(cmd)
-        return out
-
-    @Driver.check_active
-    def run_check(self, cmd, timeout=30):
-        """
-        Runs the specified cmd on the shell and returns the output if successful,
-        raises ExecutionError otherwise.
-
-        Arguments:
-        cmd - cmd to run on the shell
-        """
-        return self._run_check(cmd, timeout=timeout)
-
     @step()
     def get_status(self):
         """Returns the status of the shell-driver.

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -137,21 +137,6 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         stderr.pop()
         return (stdout, stderr, sub.returncode)
 
-    @Driver.check_active
-    @step(args=['cmd'])
-    def run_check(self, cmd):
-        """
-        Runs the specified cmd on the shell and returns the output if successful,
-        raises ExecutionError otherwise.
-
-        Arguments:
-        cmd - cmd to run on the shell
-        """
-        res = self.run(cmd)
-        if res[2] != 0:
-            raise ExecutionError(cmd)
-        return res[0]
-
     def get_status(self):
         """The SSHDriver is always connected, return 1"""
         return 1

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -105,27 +105,6 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """
         return self._run(cmd)
 
-    @step(args=['cmd'], result=True)
-    def _run_check(self, cmd):
-        res = self._run(cmd)
-        if res[2] != 0:
-            raise ExecutionError(cmd)
-        return res[0]
-
-    @Driver.check_active
-    def run_check(self, cmd):
-        """
-        Runs the specified command on the shell and returns the output if successful,
-        raises ExecutionError otherwise.
-
-        Args:
-            cmd (str): command to run on the shell
-
-        Returns:
-            List[str]: stdout of the executed command
-        """
-        return self._run_check
-
     def get_status(self):
         """Retrieve status of the UBootDriver.
         0 means inactive, 1 means active.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,12 +9,18 @@ from labgrid import Target, target_factory
 from labgrid.driver import SerialDriver
 from labgrid.protocol import CommandProtocol, ConsoleProtocol
 from labgrid.resource import RawSerialPort, NetworkSerialPort
+from labgrid.driver.fake import FakeConsoleDriver
 
 
 @pytest.fixture(scope='function')
 def target():
     return Target('Test')
 
+@pytest.fixture(scope='function')
+def target_with_fakeconsole():
+    t = Target('dummy')
+    cp = FakeConsoleDriver(t, "console")
+    return t
 
 @pytest.fixture(scope='function')
 def serial_port(target):

--- a/tests/test_bareboxdriver.py
+++ b/tests/test_bareboxdriver.py
@@ -6,6 +6,7 @@ from labgrid.driver import BareboxDriver
 from labgrid.driver.fake import FakeConsoleDriver
 from labgrid.protocol import (CommandProtocol, ConsoleProtocol,
                               LinuxBootProtocol)
+from labgrid.driver import ExecutionError
 
 
 class TestBareboxDriver:
@@ -16,3 +17,19 @@ class TestBareboxDriver:
         assert (isinstance(d, BareboxDriver))
         assert (isinstance(d, CommandProtocol))
         assert (isinstance(d, LinuxBootProtocol))
+
+    def test_barebox_run(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = BareboxDriver(t, "barebox")
+        d = t.get_driver(BareboxDriver)
+        d.run = mocker.MagicMock(return_value=[['success'],[],0])
+        res = d.run_check("test")
+        assert res == ['success']
+
+    def test_barebox_run_error(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = BareboxDriver(t, "barebox")
+        d = t.get_driver(BareboxDriver)
+        d.run = mocker.MagicMock(return_value=[['error'],[],1])
+        with pytest.raises(ExecutionError):
+            res = d.run_check("test")

--- a/tests/test_shelldriver.py
+++ b/tests/test_shelldriver.py
@@ -1,6 +1,6 @@
 import pytest
 
-from labgrid.driver import ShellDriver
+from labgrid.driver import ShellDriver, ExecutionError
 from labgrid.exceptions import NoDriverFoundError
 
 
@@ -12,3 +12,30 @@ class TestShellDriver:
     def test_no_driver(self, target):
         with pytest.raises(NoDriverFoundError):
             ShellDriver(target, "shell", "", "", "")
+
+    def test_run(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
+        d.on_activate = mocker.MagicMock()
+        d = t.get_driver('ShellDriver')
+        d.run = mocker.MagicMock(return_value=[['success'],[],0])
+        res = d.run_check("test")
+        assert res == ['success']
+
+    def test_run_error(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
+        d.on_activate = mocker.MagicMock()
+        d = t.get_driver('ShellDriver')
+        d.run = mocker.MagicMock(return_value=[['error'],[],1])
+        with pytest.raises(ExecutionError):
+            res = d.run_check("test")
+
+    def test_run_with_timeout(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
+        d.on_activate = mocker.MagicMock()
+        d = t.get_driver('ShellDriver')
+        d.run = mocker.MagicMock(return_value=[['success'],[],0])
+        res = d.run_check("test", timeout=30.0)
+        assert res == ['success']

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -1,9 +1,23 @@
 import pytest
 
-from labgrid.driver import SSHDriver
+from labgrid.driver import SSHDriver, ExecutionError
 from labgrid.exceptions import NoResourceFoundError
 from labgrid.resource import NetworkService
 
+@pytest.fixture(scope='function')
+def ssh_driver_mocked_and_activated(target, mocker):
+        NetworkService(target, "service", "1.2.3.4", "root")
+        call = mocker.patch('subprocess.call')
+        call.return_value = 0
+        popen = mocker.patch('subprocess.Popen', autospec=True)
+        path = mocker.patch('os.path.exists')
+        path.return_value = True
+        instance_mock = mocker.MagicMock()
+        popen.return_value = instance_mock
+        instance_mock.wait = mocker.MagicMock(return_value=0)
+        SSHDriver(target, "ssh")
+        s = target.get_driver("SSHDriver")
+        return s
 
 class TestSSHDriver:
     def test_create_fail_missing_resource(self, target):
@@ -22,3 +36,15 @@ class TestSSHDriver:
         instance_mock.wait = mocker.MagicMock(return_value=0)
         s = SSHDriver(target, "ssh")
         assert (isinstance(s, SSHDriver))
+
+    def test_run_check(self, ssh_driver_mocked_and_activated, mocker):
+        s = ssh_driver_mocked_and_activated
+        s.run = mocker.MagicMock(return_value=[['success'],[],0])
+        res = s.run_check("test")
+        assert res == ['success']
+
+    def test_run_check_raise(self, ssh_driver_mocked_and_activated, mocker):
+        s = ssh_driver_mocked_and_activated
+        s.run = mocker.MagicMock(return_value=[['error'],[],1])
+        with pytest.raises(ExecutionError):
+            res = s.run_check("test")


### PR DESCRIPTION
If you use the run_check function and get an ExecutionError, it will only contain the command that was run, but not the stdout or stderr. Add those and refactor run_check into the mixin.