### PR TITLE
Add codec and decodeerrors parameters to .run methods on SSHDriver and ShellDriver

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -68,7 +68,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         self._status = 0
 
     @step(args=['cmd'], result=True)
-    def _run(self, cmd, *, step, timeout=30.0):
+    def _run(self, cmd, *, step, timeout=30.0, codec="utf-8", decodeerrors="strict"):
         """
         Runs the specified cmd on the shell and returns the output.
 
@@ -87,7 +87,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             marker, marker, self.prompt
         ), timeout=timeout)
         # Remove VT100 Codes, split by newline and remove surrounding newline
-        data = self.re_vt100.sub('', match.group(1).decode('utf-8')).split('\r\n')
+        data = self.re_vt100.sub('', match.group(1).decode(codec, decodeerrors)).split('\r\n')
         if data and not data[-1]:
             del data[-1]
         self.logger.debug("Received Data: %s", data)
@@ -96,8 +96,8 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return (data, [], exitcode)
 
     @Driver.check_active
-    def run(self, cmd, timeout=30.0):
-        return self._run(cmd, timeout=timeout)
+    def run(self, cmd, timeout=30.0, codec="utf-8", decodeerrors="strict"):
+        return self._run(cmd, timeout=timeout, codec=codec, decodeerrors=decodeerrors)
 
     @step()
     def _await_login(self):

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -104,7 +104,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run(self, cmd):
+    def run(self, cmd, codec="utf-8", decodeerrors="strict"):
         """Execute `cmd` on the target.
 
         This method runs the specified `cmd` as a command on its target.
@@ -131,8 +131,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             )
 
         stdout, stderr = sub.communicate()
-        stdout = stdout.decode("utf-8").split('\n')
-        stderr = stderr.decode("utf-8").split('\n')
+        stdout = stdout.decode(codec, decodeerrors).split('\n')
+        stderr = stderr.decode(codec, decodeerrors).split('\n')
         stdout.pop()
         stderr.pop()
         return (stdout, stderr, sub.returncode)


### PR DESCRIPTION
Problem is described in this issue https://github.com/labgrid-project/labgrid/issues/203 

This PR solves this by allowing the .run method for the SSHDriver and the ShellDriver to take extra arguments. All tests that have conflicting characters must be rewritten.

```
stdout, stderr, returncode = command.run("/tmp/pcm52test/test-registration", codec = "iso-8859-1" )
stdout, stderr, returncode = command.run("/tmp/pcm52test/test-registration", codecerrors = "ignore" )
stdout, stderr, returncode = command.run("/tmp/pcm52test/test-registration", codec = "iso-8859-1", codecerrors = "ignore" )
```

The parameters are passed to str.decode(), for more information on possible parameters see https://docs.python.org/3/howto/unicode.html

The defaults is "utf-8" and strict, which is also the defaults for str.decode(), and thus no existing tests will be affected by this PR. 