### PR TITLE
Use --hostname to override export host name

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -390,8 +390,8 @@ def main():
         '--name',
         dest='name',
         type=str,
-        default=gethostname(),
-        help='public name of this exporter'
+        default=None,
+        help='public name of this exporter (defaults to the system hostname)'
     )
     parser.add_argument(
         '-d',
@@ -412,13 +412,21 @@ def main():
     level='debug' if args.debug else 'info'
 
     extra = {
-        'name': args.name,
+        'name': args.name or gethostname(),
         'resources': args.resources,
     }
 
+    crossbar_url = args.crossbar
+    crossbar_realm = os.environ.get("LG_CROSSBAR_REALM", "realm1")
+
+    print("crossbar URL: {}".format(crossbar_url))
+    print("crossbar realm: {}".format(crossbar_realm))
+    print("exporter name: {}".format(extra['name']))
+    print("resource config file: {}".format(extra['resources']))
+
     extra['loop'] = loop = asyncio.get_event_loop()
     #loop.set_debug(True)
-    runner = ApplicationRunner(url=args.crossbar, realm=os.environ.get("LG_CROSSBAR_REALM", "realm1"), extra=extra)
+    runner = ApplicationRunner(url=crossbar_url, realm=crossbar_realm, extra=extra)
     runner.run(ExporterSession, log_level=level)
     if reexec:
         exit(100)

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -52,7 +52,23 @@ the crossbar url of the coordinator
 .TP
 .B \-n\fP,\fB  \-\-name
 the public name of the exporter
+.TP
+.B \-\-hostname
+hostname (or IP) published for accessing resources
 .UNINDENT
+.SS \-n / \-\-name
+.sp
+This option is used to configure the exporter name under which resources are
+registered with the coordinator, which is useful when running multiple
+exporters on the same host.
+It defaults to the system hostname.
+.SS \-\-hostname
+.sp
+For resources like USBSerialPort, USBGenericExport or USBSigrokExport, the
+exporter needs to provide a host name to set the exported value of the "host"
+key.
+If the system hostname is not resolvable via DNS, this option can be used to
+override this default with another name (or an IP address).
 .SH CONFIGURATION
 .sp
 The exporter uses a YAML configuration file which defines groups of releated

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -42,6 +42,23 @@ OPTIONS
     the crossbar url of the coordinator
 -n, --name
     the public name of the exporter
+--hostname
+    hostname (or IP) published for accessing resources
+
+-n / --name
+~~~~~~~~~~~
+This option is used to configure the exporter name under which resources are
+registered with the coordinator, which is useful when running multiple
+exporters on the same host.
+It defaults to the system hostname.
+
+--hostname
+~~~~~~~~~~
+For resources like USBSerialPort, USBGenericExport or USBSigrokExport, the
+exporter needs to provide a host name to set the exported value of the "host"
+key.
+If the system hostname is not resolvable via DNS, this option can be used to
+override this default with another name (or an IP address).
 
 CONFIGURATION
 -------------


### PR DESCRIPTION
When exporting USBSerialPort the exporter exports the host as the hostname. This may however not always resolve. 

setting LG_HOSTNAME to ex an IP address will override gethostname() in the exporter
This variable can be used with ex. USBSerialPort, USBGenericExport, USBSigrokExport
Tested with USBSerialPort only.
