### PR TITLE
Driver: Add SysfsDigitalOutput

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1071,6 +1071,34 @@ Arguments:
     SerialDriver in your environment (what is likely to be the case
     if you are using this driver).
 
+
+SysfsDigitalOutputDriver
+------------------------
+The SysfsDigitalOutputDriver makes it possible to use a GPIO that is available
+in the Linux-Sysfs.
+
+The driver takes care of the exporting the pin and setting its direction to
+output. Besides this the user running labgrid on the machine needs the
+correct access-rights to */sys/class/gpio/*.
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   SysfsDigitalOutputDriver:
+     signal: "17"
+     initial_state: False
+     inverted: False
+
+Arguments:
+  - signal (str): Number of the GPIO that should be used.
+  - initial_state (bool): The state in which the GPIO should be initiated after
+    being exported.
+  - inverted (bool): Inverts the values written to this GPIO. Use with caution.
+    Setting this to True can and will confuse you or your colleagues at one
+    point in time.
+
 ModbusCoilDriver
 ~~~~~~~~~~~~~~~~
 A ModbusCoilDriver controls a `ModbusTCPCoil` resource.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1081,6 +1081,10 @@ The driver takes care of the exporting the pin and setting its direction to
 output. Besides this the user running labgrid on the machine needs the
 correct access-rights to */sys/class/gpio/*.
 
+.. note::
+  This driver is mainly useful for local testing, as it doesn't support remote
+  access via the network or binds to a corresponding resource.
+
 Implements:
   - :any:`DigitalOutputProtocol`
 

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -25,3 +25,4 @@ from .networkusbstoragedriver import NetworkUSBStorageDriver
 from .resetdriver import DigitalOutputResetDriver
 from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver
+from .sysfsdigitaloutput import SysfsDigitalOutputDriver

--- a/labgrid/driver/sysfsdigitaloutput.py
+++ b/labgrid/driver/sysfsdigitaloutput.py
@@ -1,0 +1,69 @@
+import attr
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol
+from ..step import step
+from .common import Driver
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class SysfsDigitalOutputDriver(Driver, DigitalOutputProtocol):
+    """
+    Controls a GPIO using the Linux /sys/class/gpio - interface.
+
+    Outputs are identified using their ID.
+
+    A given pin will be exported as GPIO and set as output during setup.
+
+    The used part of the sysfs needs to be writeable by the user running labgrid.
+    """
+
+    signal = attr.ib(validator=attr.validators.instance_of(str))
+    initial_state = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    inverted = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+
+    @staticmethod
+    def _sysfs_write(endpoint, value):
+        with open("/sys/class/gpio/" + endpoint, "w") as fh:
+            fh.write(value)
+
+    @staticmethod
+    def _sysfs_read(endpoint):
+        with open("/sys/class/gpio/" + endpoint, "r") as fh:
+            return fh.read()
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        # export pin
+        try:
+            SysfsDigitalOutputDriver._sysfs_write("export", self.signal)
+        except OSError as e:
+            if e.errno == 16:
+                # pin was already exported. We can ignore this.
+                pass
+            else:
+                raise e
+
+        # set to output
+        if self.inverted:
+            local_initial_state = not self.initial_state
+        else:
+            local_initial_state = self._initial_state
+        local_initial_state = "high" if local_initial_state else "low"
+        SysfsDigitalOutputDriver._sysfs_write("gpio{}/direction".format(self.signal), local_initial_state)
+
+    @Driver.check_active
+    @step()
+    def get(self):
+        state = SysfsDigitalOutputDriver._sysfs_read("gpio{}/value".format(self.signal)).strip()
+        return True if state == "1" else False
+
+    @Driver.check_active
+    @step()
+    def set(self, value):
+        if self.inverted:
+            value = not value
+        self._state = value
+        out = "1" if value else "0"
+        SysfsDigitalOutputDriver._sysfs_write("gpio{}/value".format(self.signal), out)


### PR DESCRIPTION
Controls a GPIO using the Linux /sys/class/gpio - interface.
Outputs are identified using their ID.
A given pin will be exported as GPIO and set es output on setupOutputs .
A given pin will be exported as GPIO and set es output during setup.

Signed-off-by: Chris Fiege <chris@tinyhost.de>