### PR TITLE
remote: exporter: The 'changed' variable is not set when exception oc…

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -376,6 +376,7 @@ class ExporterSession(ApplicationSession):
                 except:
                     print("Exception while polling {}".format(resource), file=sys.stderr)
                     traceback.print_exc()
+                    continue
                 if changed:
                     # resource has changed
                     data = resource.asdict()


### PR DESCRIPTION
I started my exporter on a machine that doesn't have ser2net installed an was prompted with two exceptions. One for the missing ser2net and another one because 'changed' was not assigned.

UnboundLocalError: local variable 'changed' referenced before assignment

I figured we can either continue to the next iteration upon exception, or enclose the 'if changed' conditional into an else clause.. Since we don't do anything but checking for changes, I chose to add a 'continue'.

Signed-off-by: Robin van der Gracht <robin@protonic.nl>