### PR TITLE
multiple: add _run function, use _run in _run_check for the mixin

### DIFF
--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -62,6 +62,9 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     @Driver.check_active
     @step(args=['cmd'])
     def run(self, cmd: str, *, step, timeout: int = 30):  # pylint: disable=unused-argument
+        return self._run(cmd, step=step, timeout=timeout)
+
+    def _run(self, cmd: str, *, step, timeout: int = 30):  # pylint: disable=unused-argument
         """
         Runs the specified command on the shell and returns the output.
 

--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -34,7 +34,7 @@ class CommandMixin:
         Returns:
             List[str]: stdout of the executed command
         """
-        stdout, stderr, exitcode = self.run(cmd, timeout=timeout)
+        stdout, stderr, exitcode = self._run(cmd, timeout=timeout)
         if exitcode != 0:
             raise ExecutionError(cmd, stdout, stderr)
         return stdout

--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -40,6 +40,7 @@ class CommandMixin:
         return stdout
 
     @Driver.check_active
+    @step(args=['cmd'], result=True)
     def run_check(self, cmd: str, timeout=30):
         """
         External run_check function, only available if the driver is active.

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -67,7 +67,6 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def on_deactivate(self):
         self._status = 0
 
-    @step(args=['cmd'], result=True)
     def _run(self, cmd, *, step, timeout=30.0, codec="utf-8", decodeerrors="strict"):
         """
         Runs the specified cmd on the shell and returns the output.
@@ -96,6 +95,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return (data, [], exitcode)
 
     @Driver.check_active
+    @step(args=['cmd'], result=True)
     def run(self, cmd, timeout=30.0, codec="utf-8", decodeerrors="strict"):
         return self._run(cmd, timeout=timeout, codec=codec, decodeerrors=decodeerrors)
 

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -58,7 +58,6 @@ class SmallUBootDriver(UBootDriver):
         # wait until UBoot has reached it's prompt
         self.console.expect(self.prompt)
 
-    @step(args=['cmd'], result=True)
     def _run(self, cmd):
         """
         If Uboot is in Command-Line mode: Run command cmd and return it's

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -99,11 +99,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return self._start_own_master()
 
     @Driver.check_active
-    @step(args=['cmd'])
+    @step(args=['cmd'], result=True)
     def run(self, cmd, codec="utf-8", decodeerrors="strict", timeout=None): # pylint: disable=unused-argument
         return self._run(cmd, codec=codec, decodererrors=decodeerrors)
 
-    @step(args=['cmd'])
     def _run(self, cmd, codec, decodeerrors): # pylint: disable=unused-argument
         """Execute `cmd` on the target.
 

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -101,6 +101,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     @Driver.check_active
     @step(args=['cmd'])
     def run(self, cmd, codec="utf-8", decodeerrors="strict", timeout=None): # pylint: disable=unused-argument
+        return self._run(cmd, codec=codec, decodererrors=decodeerrors)
+
+    @step(args=['cmd'])
+    def _run(self, cmd, codec, decodeerrors): # pylint: disable=unused-argument
         """Execute `cmd` on the target.
 
         This method runs the specified `cmd` as a command on its target.

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -64,7 +64,6 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """
         self._status = 0
 
-    @step(args=['cmd'], result=True)
     def _run(self, cmd):
         # FIXME: Handle pexpect Timeout
         # TODO: Shell Escaping for the U-Boot Shell
@@ -94,6 +93,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         return None
 
     @Driver.check_active
+    @step(args=['cmd'], result=True)
     def run(self, cmd, timeout=None): # pylint: disable=unused-argument
         """
         Runs the specified command on the shell and returns the output.

--- a/tests/test_bareboxdriver.py
+++ b/tests/test_bareboxdriver.py
@@ -20,7 +20,7 @@ class TestBareboxDriver:
         t = target_with_fakeconsole
         d = BareboxDriver(t, "barebox")
         d = t.get_driver(BareboxDriver)
-        d.run = mocker.MagicMock(return_value=[['success'],[],0])
+        d._run = mocker.MagicMock(return_value=[['success'],[],0])
         res = d.run_check("test")
         assert res == ['success']
 
@@ -28,6 +28,6 @@ class TestBareboxDriver:
         t = target_with_fakeconsole
         d = BareboxDriver(t, "barebox")
         d = t.get_driver(BareboxDriver)
-        d.run = mocker.MagicMock(return_value=[['error'],[],1])
+        d._run = mocker.MagicMock(return_value=[['error'],[],1])
         with pytest.raises(ExecutionError):
             res = d.run_check("test")

--- a/tests/test_bareboxdriver.py
+++ b/tests/test_bareboxdriver.py
@@ -20,14 +20,18 @@ class TestBareboxDriver:
         t = target_with_fakeconsole
         d = BareboxDriver(t, "barebox")
         d = t.get_driver(BareboxDriver)
-        d._run = mocker.MagicMock(return_value=[['success'],[],0])
+        d._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = d.run_check("test")
         assert res == ['success']
+        res = d.run("test")
+        assert res == (['success'], [], 0)
 
     def test_barebox_run_error(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
         d = BareboxDriver(t, "barebox")
         d = t.get_driver(BareboxDriver)
-        d._run = mocker.MagicMock(return_value=[['error'],[],1])
+        d._run = mocker.MagicMock(return_value=(['error'], [], 1))
         with pytest.raises(ExecutionError):
             res = d.run_check("test")
+        res = d.run("test")
+        assert res == (['error'], [], 1)

--- a/tests/test_shelldriver.py
+++ b/tests/test_shelldriver.py
@@ -18,7 +18,7 @@ class TestShellDriver:
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
         d.on_activate = mocker.MagicMock()
         d = t.get_driver('ShellDriver')
-        d.run = mocker.MagicMock(return_value=[['success'],[],0])
+        d._run = mocker.MagicMock(return_value=[['success'],[],0])
         res = d.run_check("test")
         assert res == ['success']
 
@@ -27,7 +27,7 @@ class TestShellDriver:
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
         d.on_activate = mocker.MagicMock()
         d = t.get_driver('ShellDriver')
-        d.run = mocker.MagicMock(return_value=[['error'],[],1])
+        d._run = mocker.MagicMock(return_value=[['error'],[],1])
         with pytest.raises(ExecutionError):
             res = d.run_check("test")
 
@@ -36,6 +36,6 @@ class TestShellDriver:
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
         d.on_activate = mocker.MagicMock()
         d = t.get_driver('ShellDriver')
-        d.run = mocker.MagicMock(return_value=[['success'],[],0])
+        d._run = mocker.MagicMock(return_value=[['success'],[],0])
         res = d.run_check("test", timeout=30.0)
         assert res == ['success']

--- a/tests/test_shelldriver.py
+++ b/tests/test_shelldriver.py
@@ -18,24 +18,30 @@ class TestShellDriver:
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
         d.on_activate = mocker.MagicMock()
         d = t.get_driver('ShellDriver')
-        d._run = mocker.MagicMock(return_value=[['success'],[],0])
+        d._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = d.run_check("test")
         assert res == ['success']
+        res = d.run("test")
+        assert res == (['success'], [], 0)
 
     def test_run_error(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
         d.on_activate = mocker.MagicMock()
         d = t.get_driver('ShellDriver')
-        d._run = mocker.MagicMock(return_value=[['error'],[],1])
+        d._run = mocker.MagicMock(return_value=(['error'], [], 1))
         with pytest.raises(ExecutionError):
             res = d.run_check("test")
+        res = d.run("test")
+        assert res == (['error'], [], 1)
 
     def test_run_with_timeout(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')
         d.on_activate = mocker.MagicMock()
         d = t.get_driver('ShellDriver')
-        d._run = mocker.MagicMock(return_value=[['success'],[],0])
+        d._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = d.run_check("test", timeout=30.0)
         assert res == ['success']
+        res = d.run("test")
+        assert res == (['success'], [], 0)

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -39,12 +39,16 @@ class TestSSHDriver:
 
     def test_run_check(self, ssh_driver_mocked_and_activated, mocker):
         s = ssh_driver_mocked_and_activated
-        s._run = mocker.MagicMock(return_value=[['success'],[],0])
+        s._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = s.run_check("test")
         assert res == ['success']
+        res = s.run("test")
+        assert res == (['success'], [], 0)
 
     def test_run_check_raise(self, ssh_driver_mocked_and_activated, mocker):
         s = ssh_driver_mocked_and_activated
-        s._run = mocker.MagicMock(return_value=[['error'],[],1])
+        s._run = mocker.MagicMock(return_value=(['error'], [], 1))
         with pytest.raises(ExecutionError):
             res = s.run_check("test")
+        res = s.run("test")
+        assert res == (['error'], [], 1)

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -39,12 +39,12 @@ class TestSSHDriver:
 
     def test_run_check(self, ssh_driver_mocked_and_activated, mocker):
         s = ssh_driver_mocked_and_activated
-        s.run = mocker.MagicMock(return_value=[['success'],[],0])
+        s._run = mocker.MagicMock(return_value=[['success'],[],0])
         res = s.run_check("test")
         assert res == ['success']
 
     def test_run_check_raise(self, ssh_driver_mocked_and_activated, mocker):
         s = ssh_driver_mocked_and_activated
-        s.run = mocker.MagicMock(return_value=[['error'],[],1])
+        s._run = mocker.MagicMock(return_value=[['error'],[],1])
         with pytest.raises(ExecutionError):
             res = s.run_check("test")


### PR DESCRIPTION
Commit 1deea1c71728f50644ffd7b7e709577f43e1d4c2 introduced a bug where the
internal _run_check function used the run function guarded by a check_active
decorator. Use _run for the run_check function, refactor _run functions for
drivers who did not have it and adjust the tests to mock the correct funtion.

Fixes #230

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>