### PR TITLE
resource: IMXUSBLoader: add i.MX25 product ID

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -184,7 +184,7 @@ class IMXUSBLoader(USBResource):
     def filter_match(self, device):
         if device.get('ID_VENDOR_ID') != "15a2":
             return False
-        if device.get('ID_MODEL_ID') not in ["0054", "0061", "007d"]:
+        if device.get('ID_MODEL_ID') not in ["0054", "0061", "007d", "003a"]:
             return False
         return super().filter_match(device)
 


### PR DESCRIPTION
The board shows up in imx-usb-loader as "i.MX25", and in lsusb as "Freescale Semiconductor, Inc. SE Blank SENNA".

cc @olerem