### PR TITLE
ser2net fix

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -376,6 +376,7 @@ class ExporterSession(ApplicationSession):
                 except:
                     print("Exception while polling {}".format(resource), file=sys.stderr)
                     traceback.print_exc()
+                    continue
                 if changed:
                     # resource has changed
                     data = resource.asdict()


### PR DESCRIPTION
When many udev events happen very quickly (such as when a whole USB bus is reconnected), the intermediate disconnected state may be missed. This patch makes sure to restart ser2net when needed by comparing the current parameters to the ones used to start running ser2net process.