### PR TITLE
RemoteTmpdir, create and interface a remote temporary directory

### DIFF
--- a/examples/remote_tmpdir/hello.sh
+++ b/examples/remote_tmpdir/hello.sh
@@ -1,0 +1,2 @@
+echo hello
+

--- a/examples/remote_tmpdir/hello.sh
+++ b/examples/remote_tmpdir/hello.sh
@@ -1,2 +1,2 @@
+#!/bin/sh
 echo hello
-

--- a/examples/remote_tmpdir/test_remote_tmpdir.py
+++ b/examples/remote_tmpdir/test_remote_tmpdir.py
@@ -1,0 +1,30 @@
+"""
+    RemoteTmpdir is a class that maintains a temporary directory on a
+    remote linux system.
+    Ex. when copying a test script or binary to DUT, RemoteTmpdir assists
+    to prevent pollution of the target.
+
+    RemoteTmpdir is to be created in a fixture, which can take care of a
+    testmodule in a subdirectory. Recommended scope is function, to avoid
+    polution between tests
+"""
+import pytest
+from labgrid.external import RemoteTmpdir
+
+
+# scope may also be module or session
+@pytest.fixture(scope='function')
+def remote_tmpdir(target, request):
+    # RemoteTmpdir needs to have a Driver which offers put and run
+    shell = target.get_active_driver("CommandProtocol")
+    # find the relative root of the files to put
+    tmpdir = RemoteTmpdir(shell, request.fspath.dirname)
+    yield tmpdir
+    # Remove the tmpdir again
+    tmpdir.cleanup()
+
+
+def test_hello(remote_tmpdir):
+    shell = target.get_active_driver("CommandProtocol")
+    remote_tmpdir.put('hello.sh')
+    shell.run_check(remote_tmpdir.path + 'hello.sh')

--- a/examples/remote_tmpdir/test_remote_tmpdir.py
+++ b/examples/remote_tmpdir/test_remote_tmpdir.py
@@ -1,30 +1,31 @@
-"""
-    RemoteTmpdir is a class that maintains a temporary directory on a
-    remote linux system.
-    Ex. when copying a test script or binary to DUT, RemoteTmpdir assists
-    to prevent pollution of the target.
-
-    RemoteTmpdir is to be created in a fixture, which can take care of a
-    testmodule in a subdirectory. Recommended scope is function, to avoid
-    polution between tests
-"""
 import pytest
 from labgrid.external import RemoteTmpdir
 
 
+"""
+RemoteTmpdir is a class that maintains a temporary directory on a
+remote linux system.
+Ex. when copying a test script or binary to DUT, RemoteTmpdir assists
+to prevent pollution of the target.
+
+RemoteTmpdir is to be created in a fixture, which can take care of a
+testmodule in a subdirectory. Recommended scope is function, to avoid
+polution between tests
+"""
 # scope may also be module or session
 @pytest.fixture(scope='function')
 def remote_tmpdir(target, request):
     # RemoteTmpdir needs to have a Driver which offers put and run
-    shell = target.get_active_driver("CommandProtocol")
+    shell = target.get_active_driver('CommandProtocol')
     # find the relative root of the files to put
     tmpdir = RemoteTmpdir(shell, request.fspath.dirname)
     yield tmpdir
-    # Remove the tmpdir again
+    # remove the tmpdir again
     tmpdir.cleanup()
 
 
 def test_hello(remote_tmpdir):
-    shell = target.get_active_driver("CommandProtocol")
+    shell = target.get_active_driver('CommandProtocol')
     remote_tmpdir.put('hello.sh')
-    shell.run_check(remote_tmpdir.path + 'hello.sh')
+    shell.run_check('chmod +x {}hello.sh'.format(remote_tmpdir.path))
+    shell.run_check('{}hello.sh'.format(remote_tmpdir.path))

--- a/labgrid/external/__init__.py
+++ b/labgrid/external/__init__.py
@@ -1,2 +1,4 @@
 from .hawkbit import HawkbitTestClient
 from .usbstick import USBStick
+from .remote_tmpdir import RemoteTmpdir
+

--- a/labgrid/external/__init__.py
+++ b/labgrid/external/__init__.py
@@ -1,4 +1,3 @@
 from .hawkbit import HawkbitTestClient
 from .usbstick import USBStick
 from .remote_tmpdir import RemoteTmpdir
-

--- a/labgrid/external/remote_tmpdir.py
+++ b/labgrid/external/remote_tmpdir.py
@@ -1,0 +1,70 @@
+"""
+    RemoteTmpdir is a class that maintains a temporary directory on a
+    remote linux system.
+    Ex. when copying a test script or binary to DUT, RemoteTmpdir assists
+    to prevent pollution of the target.
+
+    RemoteTmpdir is to be created in a fixture, which can take care of a
+    testmodule in a subdirectory. Recommended scope is function, to avoid
+    polution between tests.
+
+    See examples/remote_tmpdir
+"""
+
+import os
+
+
+class RemoteTmpdir:
+
+    # shell   A driver able to do run on target.
+    # basedir A directory relative to pytest root
+    # filetransfer Defaults to shell, but only needs to be able to do filetransfer
+    #              Used if a more efficient filetransfer is used
+    def __init__(self, shell, basedir=None, filetransfer=None):
+        stdout = shell.run_check("mktemp -d")
+        assert len(stdout) == 1
+        self.path = stdout[0] + '/'
+        if filetransfer is None:
+            filetransfer = shell
+        self.filetransfer = filetransfer
+        self.shell = shell
+        self.basedir = basedir
+
+        if self.basedir is not None and os.path.isfile(self.basedir):
+            raise Exception("RemoteTmpdir: {} is not a directory".format(
+                            self.basedir))
+
+    ## Copy a file or contents of directory the created tmdir
+    # path   file or directory to copy
+    #        does not create sub directories, but copies all files
+    def put(self, *items):
+        for path in items:
+            # resolve relative paths
+            if not os.path.isabs(path) and self.basedir is not None:
+                path = os.path.join(self.basedir, path)
+
+            if os.path.isfile(path):
+                remotepath = self.path + os.path.basename(path)
+                self.filetransfer.put(path, remotepath)
+            else:
+                # then it is a whole directory to copy
+                for filename in os.listdir(path):
+                    localpath = os.path.join(path, filename)
+                    remotepath = self.path + filename
+                    if os.path.isfile(localpath):
+                        self.filetransfer.put(localpath, remotepath)
+
+    def get(self, *files, localdir=None):
+        for path in files:
+            remotepath = self.path + str(path)
+            assert localdir or self.basedir, "RemoteTmpdir does not have basedir set, use localdir= in get"
+            self.filetransfer.get(remotepath, localdir or self.basedir)
+
+    # Remove the directory again on target.
+    def cleanup(self):
+        # Usually teardown code, thus failure ignored but returned
+        try:
+            self.shell.run_check("rm -r {}".format(self.path))
+            return True
+        except:
+            return False

--- a/tests/test_remote_tmpdir.py
+++ b/tests/test_remote_tmpdir.py
@@ -23,7 +23,7 @@ def ssh_driver_mocked_and_activated(target, mocker):
                         return b'', b''
             return xx
         return Popen
-    NetworkService(target, "service", "1.2.3.4", "root")
+    NetworkService(target, 'service', '1.2.3.4', 'root')
     call = mocker.patch('subprocess.call')
     call.return_value = 0
     popen = mocker.patch('subprocess.Popen', new_callable=dummy)
@@ -32,13 +32,12 @@ def ssh_driver_mocked_and_activated(target, mocker):
     instance_mock = mocker.MagicMock()
     popen.return_value = instance_mock
     instance_mock.wait = mocker.MagicMock(return_value=0)
-    SSHDriver(target, "ssh")
-    s = target.get_driver("SSHDriver")
+    SSHDriver(target, 'ssh')
+    s = target.get_driver('SSHDriver')
     return s
 
 
 class TestTmpdir:
-
     def test_create(self, ssh_driver_mocked_and_activated, mocker):
         s = ssh_driver_mocked_and_activated
         s.run = mocker.MagicMock(return_value=[['/tmp/mock.dir'], [], 0])
@@ -61,5 +60,5 @@ class TestTmpdir:
         remote.put(__file__)
         remote.put(os.path.basename(__file__))
         remote.put(__file__,__file__)
-        remote.get("remotefile", "localfile")
-        remote.get("remotefile")
+        remote.get('remotefile', 'localfile')
+        remote.get('remotefile')

--- a/tests/test_remote_tmpdir.py
+++ b/tests/test_remote_tmpdir.py
@@ -1,0 +1,65 @@
+import pytest
+from py.path import local
+import tempfile
+import os
+
+from labgrid.external import RemoteTmpdir
+
+from labgrid.driver import SSHDriver, ExecutionError
+from labgrid.exceptions import NoResourceFoundError
+from labgrid.resource import NetworkService
+
+
+@pytest.fixture(scope='function')
+def ssh_driver_mocked_and_activated(target, mocker):
+    def dummy():
+        def Popen(cmd, stdout=None, stderr=None):
+            class xx:
+                returncode = 0
+                def communicate(*x):
+                    if "mktemp" in cmd:
+                        return b'/tmp/tmp.aaaa\n', b''
+                    else:
+                        return b'', b''
+            return xx
+        return Popen
+    NetworkService(target, "service", "1.2.3.4", "root")
+    call = mocker.patch('subprocess.call')
+    call.return_value = 0
+    popen = mocker.patch('subprocess.Popen', new_callable=dummy)
+    path = mocker.patch('os.path.exists')
+    path.return_value = True
+    instance_mock = mocker.MagicMock()
+    popen.return_value = instance_mock
+    instance_mock.wait = mocker.MagicMock(return_value=0)
+    SSHDriver(target, "ssh")
+    s = target.get_driver("SSHDriver")
+    return s
+
+
+class TestTmpdir:
+
+    def test_create(self, ssh_driver_mocked_and_activated, mocker):
+        s = ssh_driver_mocked_and_activated
+        s.run = mocker.MagicMock(return_value=[['/tmp/mock.dir'], [], 0])
+        remote = RemoteTmpdir(s)
+        assert remote.path.startswith('/tmp')
+
+    def xtest_create_filetransfer(self, ssh_driver_mocked_and_activated, mocker):
+        s = ssh_driver_mocked_and_activated
+        s.run = mocker.MagicMock(return_value=[['/tmp/mock.dir'], [], 0])
+        remote = RemoteTmpdir(s, filetransfer=s)
+        assert remote.path.startswith('/tmp')
+
+    def xtest_put(self, ssh_driver_mocked_and_activated, mocker):
+        s = ssh_driver_mocked_and_activated
+        s.run = mocker.MagicMock(return_value=[['/tmp/mock.dir'], [], 0])
+        remote = RemoteTmpdir(s,os.path.dirname(__file__))
+
+        s.run = mocker.MagicMock(return_value=[['success'], [], 0])
+
+        remote.put(__file__)
+        remote.put(os.path.basename(__file__))
+        remote.put(__file__,__file__)
+        remote.get("remotefile", "localfile")
+        remote.get("remotefile")


### PR DESCRIPTION
RemoteTmpdir is a class that maintains a temporary directory on a
remote linux system.
Ex. when copying a test script or binary to DUT, RemoteTmpdir assists
to prevent pollution of the target.

RemoteTmpdir is to be created in a fixture, which can take care of a testmodule 
in a subdirectory. Recommended scope is function, to avoid pollution between tests.

Signed-off-by: Kjeld Flarup <kfa@deif.com>