### PR TITLE
pylintrc: adjust configuration to labgrid needs

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -65,7 +65,7 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=next-method-called,import-star-module-level,dict-view-method,basestring-builtin,unpacking-in-except,map-builtin-not-iterating,input-builtin,coerce-builtin,xrange-builtin,backtick,indexing-exception,unichr-builtin,suppressed-message,parameter-unpacking,execfile-builtin,standarderror-builtin,filter-builtin-not-iterating,reload-builtin,attribute-defined-outside-init,raising-string,print-statement,hex-method,useless-suppression,long-suffix,reduce-builtin,cmp-builtin,intern-builtin,delslice-method,coerce-method,raw_input-builtin,oct-method,setslice-method,buffer-builtin,range-builtin-not-iterating,cmp-method,dict-iter-method,no-absolute-import,old-octal-literal,apply-builtin,file-builtin,zip-builtin-not-iterating,getslice-method,long-builtin,unicode-builtin,round-builtin,nonzero-method,metaclass-assignment,old-division,old-ne-operator,old-raise-syntax,using-cmp-argument
+disable=next-method-called,import-star-module-level,dict-view-method,basestring-builtin,unpacking-in-except,map-builtin-not-iterating,input-builtin,coerce-builtin,xrange-builtin,backtick,indexing-exception,unichr-builtin,suppressed-message,parameter-unpacking,execfile-builtin,standarderror-builtin,filter-builtin-not-iterating,reload-builtin,attribute-defined-outside-init,raising-string,print-statement,hex-method,useless-suppression,long-suffix,reduce-builtin,cmp-builtin,intern-builtin,delslice-method,coerce-method,raw_input-builtin,oct-method,setslice-method,buffer-builtin,range-builtin-not-iterating,cmp-method,dict-iter-method,no-absolute-import,old-octal-literal,apply-builtin,file-builtin,zip-builtin-not-iterating,getslice-method,long-builtin,unicode-builtin,round-builtin,nonzero-method,metaclass-assignment,old-division,old-ne-operator,old-raise-syntax,using-cmp-argument,useless-super-delegation,duplicate-code,no-member
 
 
 [REPORTS]
@@ -369,13 +369,13 @@ max-branches=12
 max-statements=50
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=10
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=10
 
 # Minimum number of public methods for a class (see R0903).
-min-public-methods=2
+min-public-methods=0
 
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20


### PR DESCRIPTION
> no-member

Pretty useless, because attr is used pretty much everywhere and pylint does not recognize it. Ignore this.

> arguments-differ

Not sure if we should check this, e.g. almost every driver implements a run method with different arguments.

> useless-super-delegation

The [docs](https://labgrid.readthedocs.io/en/latest/development.html#writing-a-driver) state that this is needed:
"The minimum requirement is a call to `super().__attrs_post_init__()`." Why do we override it to call the method on super?

> no-self-use

I think wrapping functionality in methods that could be functions is still a good thing for the sake of logic. Ignore this.

> protected-access

Not sure if we should check this, there are quite some occurrences across labgrid. Maybe this is by design or we need to define exceptions in file headers for this.

> duplicate-code

Detects only by-design boilerplate code, ignore it.

> max-attributes=10

Increase this, 10 should be okay too.

> min-public-methods=0

Decrease this to fit labgrid's inheritance model.

> max-parents=10

Increase this, having a lot of parents is needed by design.