### PR TITLE
Using imx-usb-loader for MXS devices

### DIFF
--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -50,7 +50,7 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
 @attr.s(cmp=False)
 class IMXUSBDriver(Driver, BootstrapProtocol):
     bindings = {
-        "loader": {IMXUSBLoader, NetworkIMXUSBLoader},
+        "loader": {IMXUSBLoader, NetworkIMXUSBLoader, MXSUSBLoader, NetworkMXSUSBLoader},
     }
 
     image = attr.ib(default=None)


### PR DESCRIPTION
Since [recently](https://git.pengutronix.de/cgit/barebox/commit/?id=ca929ac265), imx-usb-loader can also load code into i.MX23/28 (MXS) devices.

Make it possible to override the use of mxs-usb-loader when bootstrapping a device by instantiating a IMXUSBDriver in a YAML file, like this:

``` yaml
targets:
  main:
    resources:
      RemotePlace:
        name: my-remote-place
    drivers:
      IMXUSBDriver: {}
```