### PR TITLE
linting: declare methods without self-use static and annotate legitimate methods

### DIFF
--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -82,7 +82,8 @@ class TargetFactory:
             assert 'cls' in item
         return result
 
-    def normalize_config(self, config):
+    @staticmethod
+    def normalize_config(config):
         resources = {}
         drivers = {}
         for item in TargetFactory._convert_to_named_list(config.get('resources', {})):

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -20,7 +20,8 @@ class TargetFactory:
         self.drivers[cls.__name__] = cls
         return cls
 
-    def _convert_to_named_list(self, data):
+    @staticmethod
+    def _convert_to_named_list(data):
         """Convert a tree of resources or drivers to a named list.
 
         When using named resources or drivers, the config file uses a list of
@@ -84,12 +85,12 @@ class TargetFactory:
     def normalize_config(self, config):
         resources = {}
         drivers = {}
-        for item in self._convert_to_named_list(config.get('resources', {})):
+        for item in TargetFactory._convert_to_named_list(config.get('resources', {})):
             resource = item.pop('cls')
             name = item.pop('name', None)
             args = item # remaining args
             resources.setdefault(resource, {})[name] = (args, )
-        for item in self._convert_to_named_list(config.get('drivers', {})):
+        for item in TargetFactory._convert_to_named_list(config.get('drivers', {})):
             driver = item.pop('cls')
             name = item.pop('name', None)
             bindings = item.pop('bindings', {})
@@ -129,12 +130,12 @@ class TargetFactory:
         from .target import Target
 
         target = Target(name, env=env)
-        for item in self._convert_to_named_list(config.get('resources', {})):
+        for item in TargetFactory._convert_to_named_list(config.get('resources', {})):
             resource = item.pop('cls')
             name = item.pop('name', None)
             args = item # remaining args
             self.make_resource(target, resource, name, args)
-        for item in self._convert_to_named_list(config.get('drivers', {})):
+        for item in TargetFactory._convert_to_named_list(config.get('drivers', {})):
             driver = item.pop('cls')
             name = item.pop('name', None)
             bindings = item.pop('bindings', {})

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -52,10 +52,10 @@ class ResourceExport(ResourceEntry):
             del self.params[key]
         self.start_params = None
 
-    def _get_start_params(self):
+    def _get_start_params(self):  # pylint: disable=no-self-use
         return {}
 
-    def _get_params(self):
+    def _get_params(self):  # pylint: disable=no-self-use
         return {}
 
     def _start(self, start_params):

--- a/labgrid/resource/ethernetport.py
+++ b/labgrid/resource/ethernetport.py
@@ -219,7 +219,7 @@ class EthernetPortManager(ResourceManager):
 
         async def poll_neighbour(self):
             self.logger.debug("polling neighbor table")
-            self.neighbors = self._get_neigh()
+            self.neighbors = EthernetPortManager._get_neigh()
 
             await asyncio.sleep(1.0)
 
@@ -252,7 +252,8 @@ class EthernetPortManager(ResourceManager):
         self.poll_tasks.append(self.loop.create_task(poll(self, poll_neighbour)))
         self.poll_tasks.append(self.loop.create_task(poll(self, poll_switches)))
 
-    def _get_neigh(self):
+    @staticmethod
+    def _get_neigh():
         """Internal function to retrieve the neighbors on the test machine
 
         Returns:

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -49,7 +49,7 @@ class USBResource(ManagedResource):
         self.match.setdefault('SUBSYSTEM', 'usb')
         super().__attrs_post_init__()
 
-    def filter_match(self, device):  # pylint: disable=unused-argument
+    def filter_match(self, device):  # pylint: disable=unused-argument,no-self-use
         return True
 
     def try_match(self, device):

--- a/labgrid/stepreporter.py
+++ b/labgrid/stepreporter.py
@@ -14,13 +14,14 @@ class StepReporter:
     def stop(cls):
         """stops the StepReporter"""
         assert cls.instance is not None
-        steps.unsubscribe(cls.instance.notify)
+        steps.unsubscribe(cls.notify)
         cls.instance = None
 
     def __init__(self):
-        steps.subscribe(self.notify)
+        steps.subscribe(StepReporter.notify)
 
-    def notify(self, event):
+    @staticmethod
+    def notify(event):
         # ignore tagged events
         if event.step.tag:
             return

--- a/labgrid/util/agent.py
+++ b/labgrid/util/agent.py
@@ -15,7 +15,8 @@ class Agent:
     def __init__(self):
         self.methods = {}
 
-    def _send(self, data):
+    @staticmethod
+    def _send(data):
         sys.stdout.write(json.dumps(data)+'\n')
         sys.stdout.flush()
 
@@ -31,7 +32,7 @@ class Agent:
             try:
                 request = json.loads(line)
             except json.JSONDecodeError:
-                self._send({'error': 'request parsing failed'})
+                Agent._send({'error': 'request parsing failed'})
                 break
 
             if request.get('close', False):
@@ -42,9 +43,9 @@ class Agent:
             kwargs = request['kwargs']
             try:
                 response = self.methods[name](*args, **kwargs)
-                self._send({'result': response})
+                Agent._send({'result': response})
             except Exception as e:  # pylint: disable=broad-except
-                self._send({'exception': repr(e)})
+                Agent._send({'exception': repr(e)})
                 break
 
 def handle_test(*args, **kwargs):  # pylint: disable=unused-argument


### PR DESCRIPTION
Fixes this linting warning:

> no-self-use (R0201):
> Method could be a function. Used when a method doesn’t use its bound instance, and so could be written as a function.