### PR TITLE
resource: IMXUSBLoader: add i.MX6SoloX product ID

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -197,7 +197,7 @@ class IMXUSBLoader(USBResource):
     def filter_match(self, device):
         if device.get('ID_VENDOR_ID') != "15a2":
             return False
-        if device.get('ID_MODEL_ID') not in ["0054", "0061", "007d", "003a"]:
+        if device.get('ID_MODEL_ID') not in ["0054", "0061", "0071", "007d", "003a"]:
             return False
         return super().filter_match(device)
 


### PR DESCRIPTION
The board reported by imx-usb-loader as "i.MX6 SoloX".

Signed-off-by: Oleksij Rempel <o.rempel@pengutronix.de>