### PR TITLE
resource/udev: add warning if port attribute is set on USBSerialPort

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -166,6 +166,11 @@ class USBResource(ManagedResource):
 class USBSerialPort(USBResource, SerialPort):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'tty'
+        if self.port:
+            warnings.warn(
+                "USBSerialPort: The port attribute will be overwritten by udev.\n"
+                "Please use udev matching as described in http://labgrid.readthedocs.io/en/latest/getting_started.html#udev-matching"
+            )
         super().__attrs_post_init__()
 
     def update(self):

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,4 +1,5 @@
 import pytest
+import warnings
 
 from labgrid import Environment
 from labgrid.exceptions import NoConfigFoundError, InvalidConfigError
@@ -163,3 +164,38 @@ imports:
 
         assert d_a.port is r_a
         assert d_b.port is r_b
+
+    def test_usbserialport_warning(self, tmpdir):
+        p = tmpdir.join("config.yaml")
+        p.write(
+            """
+        targets:
+          test1:
+            resources:
+            - USBSerialPort:
+                port: /dev/ttyS0
+            drivers:
+            - SerialDriver: {}
+        """
+        )
+        e = Environment(str(p))
+        with pytest.warns(UserWarning):
+            t = e.get_target("test1")
+
+    def test_usbserialport_no_warning(self, tmpdir):
+        p = tmpdir.join("config.yaml")
+        p.write(
+            """
+        targets:
+          test1:
+            resources:
+            - USBSerialPort: {}
+            drivers:
+            - SerialDriver: {}
+        """
+        )
+        e = Environment(str(p))
+        with pytest.warns(None) as record:
+            t = e.get_target("test1")
+        for i in record.list:
+            assert i.category != 'UserWarning'


### PR DESCRIPTION
The USBSerialPort overwrites its own port attribute via udev. Emit a warning and
redirect the user to the udev matching documentation if the port attribute is
set by the user. Also add a test for the warning.

Fixes #268

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>