### PR TITLE
driver/networkusbstoragedriver: fix concatinating tuple to list

### DIFF
--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -37,12 +37,12 @@ class NetworkUSBStorageDriver(Driver):
         filename = os.path.abspath(filename)
         check_file(filename, command_prefix=self.storage.command_prefix)
         self.logger.info("pwd: %s", os.getcwd())
-        args = (
+        args = [
             "dd",
             "if={}".format(filename),
             "of={} status=progress bs=4M conv=fdatasync"
             .format(self.storage.path)
-        )
+        ]
         subprocess.check_call(
             self.storage.command_prefix + args
         )


### PR DESCRIPTION
The dd command was moved to its own variable during linting, but
accidentally to a tuple and not a list. This leads to an error while
concatinating with self.storage.command_prefix:

  TypeError: can only concatenate list (not "tuple") to list

Fix that.

Fixes: 533cec4c ("linting: do miscellaneous linting")
Signed-off-by: Bastian Stender <bst@pengutronix.de>