### PR TITLE
Allow use of $LG_ENV environment variable instead of --lg-env arg

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -107,9 +107,9 @@ pytest Plugin
 -------------
 Labgrid includes a `pytest <http://pytest.org>`_ plugin to simplify writing tests which
 involve embedded boards.
-The plugin is configured by providing an environment config file (via the
---lg-env pytest option) and automatically creates the targets described in
-the environment.
+The plugin is configured by providing an environment config file
+(via the --lg-env pytest option, or the LG_ENV environment variable)
+and automatically creates the targets described in the environment.
 
 Two `pytest fixtures <http://docs.pytest.org/en/latest/fixture.html>`_ are provided:
 

--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -55,6 +55,8 @@ def env(request):
             lg_env = env_config
 
     if lg_env is None:
+        lg_env = os.environ.get('LG_ENV')
+    if lg_env is None:
         pytest.skip("missing environment config (use --lg-env)")
     env = Environment(config_file=lg_env)
     if lg_coordinator is not None:

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,3 +1,4 @@
+import os
 import pexpect
 import pytest
 
@@ -37,6 +38,14 @@ def test_env_fixture(short_env, short_test):
 def test_env_old_fixture(short_env, short_test):
     with pexpect.spawn('pytest --env-config {} {}'.format(short_env,short_test)) as spawn:
         spawn.expect("deprecated option")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+def test_env_env_fixture(short_env, short_test):
+    env=os.environ.copy()
+    env['LG_ENV'] = short_env
+    with pexpect.spawn('pytest {}'.format(short_test)) as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0


### PR DESCRIPTION
Depending on the exact workflow, it can be convenient to be able to set
an environment variabel once, and just run pytest without '--lg-env'
argument while testing.

Both --lg-env and --env-config overrules $LG_ENV, making this change
backwards compatible.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>