### PR TITLE
driver/networkusbstoragedriver: fix concatinating tuple to list in get_size()

### DIFF
--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -49,6 +49,6 @@ class NetworkUSBStorageDriver(Driver):
 
     @step(result=True)
     def get_size(self):
-        args = ("cat", "/sys/class/block/{}/size" % self.storage.path[5:])
+        args = ["cat", "/sys/class/block/{}/size" % self.storage.path[5:]]
         size = subprocess.check_output(self.storage.command_prefix + args)
         return int(size)


### PR DESCRIPTION
The cat command was moved to its own variable during linting, but
accidentally to a tuple and not a list. This leads to an error while
concatinating with self.storage.command_prefix:

  TypeError: can only concatenate list (not "tuple") to list

Fix that.

Another occurrence of the same error was fixed by 2544d1d1
("driver/networkusbstoragedriver: fix concatinating tuple to list")

Fixes: 533cec4 ("linting: do miscellaneous linting")
Signed-off-by: Bastian Stender <bst@pengutronix.de>