### PR TITLE
strategy/graphstrategy: pytest.exit() on strategy errors

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -1,6 +1,8 @@
 from tempfile import TemporaryDirectory
 import os
+import traceback
 
+import pytest
 from .common import Strategy, StrategyError
 from ..step import step
 
@@ -132,10 +134,9 @@ class GraphStrategy(Strategy):
                 try:
                     self.states[state_name]['method']()
 
-                except Exception:
-                    self.invalidate()
-
-                    raise
+                except Exception as e:
+                    traceback.print_exc()
+                    pytest.exit(e)
 
             self.path = abs_path
 


### PR DESCRIPTION
In case the strategy fails to reach the designated state for a test it
does not make sense to continue.

Signed-off-by: Bastian Stender <bst@pengutronix.de>