### PR TITLE
strategy/graphstrategy: add force kwarg to transition()

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -99,7 +99,7 @@ class GraphStrategy(Strategy):
         self.path = []
 
     @step(args=['state'])
-    def transition(self, state, via=None):
+    def transition(self, state, via=None, force=False):
         via = via or []
         try:
             # check if another transition is running
@@ -121,11 +121,10 @@ class GraphStrategy(Strategy):
 
             # find path
             abs_path = self.find_abs_path(state, via=via)
+            path = abs_path if force else self.find_rel_path(abs_path)
 
             if abs_path == self.path:
                 return []
-
-            path = self.find_rel_path(abs_path)
 
             # run state methods
             for state_name in path:


### PR DESCRIPTION
Calling `transition(.., force=True)` forces the Graph Strategy to
execute all states on the path from root node to the designated state.

Signed-off-by: Bastian Stender <bst@pengutronix.de>