### PR TITLE
driver/fastbootdriver: add run argument

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -60,6 +60,11 @@ class AndroidFastbootDriver(Driver):
         self("flash", partition, filename)
 
     @Driver.check_active
+    @step(args=['cmd'])
+    def run(self, cmd):
+        self("oem", "exec", "--", cmd)
+
+    @Driver.check_active
     @step(title='continue')
     def continue_boot(self):
         self("continue")


### PR DESCRIPTION
The fastboot protocol defines a "oem" command, that allows vendor specific
subcommands. barebox supports "exec", which executes arbitrary shell commands.

Add support for this to the fastbootdriver.

Signed-off-by: Steffen Trumtrar <s.trumtrar@pengutronix.de>