### PR TITLE
strategy/graphstrategy: deactivate drivers on invalidate()

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -98,6 +98,10 @@ class GraphStrategy(Strategy):
     def invalidate(self):
         self.path = []
 
+        # deactivate all drivers to restore initial state
+        for driver in self.target.drivers:
+            self.target.deactivate(driver)
+
     @step(args=['state'])
     def transition(self, state, via=None):
         via = via or []


### PR DESCRIPTION
invalidate() exists to reset the Graph Strategy. Make sure all drivers
are deactivated so they can be activated when starting over.

Signed-off-by: Bastian Stender <bst@pengutronix.de>