### PR TITLE
multiple: remove step kwarg from _run()/run()

### DIFF
--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -61,10 +61,10 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run(self, cmd: str, *, step, timeout: int = 30):  # pylint: disable=unused-argument
-        return self._run(cmd, step=step, timeout=timeout)
+    def run(self, cmd: str, *, timeout: int = 30):  # pylint: disable=unused-argument
+        return self._run(cmd, timeout=timeout)
 
-    def _run(self, cmd: str, *, step, timeout: int = 30):  # pylint: disable=unused-argument
+    def _run(self, cmd: str, *, timeout: int = 30):  # pylint: disable=unused-argument
         """
         Runs the specified command on the shell and returns the output.
 

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -67,7 +67,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def on_deactivate(self):
         self._status = 0
 
-    def _run(self, cmd, *, step, timeout=30.0, codec="utf-8", decodeerrors="strict"):
+    def _run(self, cmd, *, timeout=30.0, codec="utf-8", decodeerrors="strict"):
         """
         Runs the specified cmd on the shell and returns the output.
 


### PR DESCRIPTION
_run() methods are not called with step and step is not used anyway, so
remove it.

This fixes errors like:

  TypeError: _run() missing 1 required keyword-only argument: 'step'

Issue introduced by PR #237.

Signed-off-by: Bastian Stender <bst@pengutronix.de>