### PR TITLE
docker: Fixes #260. Integrate separate docker repo into labgrid repo

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.6
+MAINTAINER krev@triax.com
+
+# Tools
+RUN apt-get update && \
+    apt-get install -y ser2net && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/labgrid
+
+# Ensure that labgrid is build from current dir
+COPY ./ ./
+RUN pip install crossbar
+RUN pip install -e /opt/labgrid
+RUN git clone https://github.com/vishnubob/wait-for-it.git /opt/wait-for-it

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -1,0 +1,66 @@
+Labgrid Docker files
+====================
+
+Purpose
+-------
+This folder docker files to build one shared Docker image for the following Labgrid instances/containers.
+In staging the a docker-compose file describe how to use the image to start up the following instances:
+
+- **labgrid coordinator** (Crossbar) This instance simply configures a Labgrid coordinator instance.
+- **labgrid client** This instance contains the Labgrid client tools.
+- **labgrid exporter** This instance contains the Labgrid exporter tools.
+
+
+Desired architecture
+--------------------
+The docker image in this repository is thought to be used in a distributed setting, where a coordinator, client and exporter are utilized, as described in the `docs <https://labgrid.readthedocs.io/en/latest/getting_started.html#setting-up-the-distributed-infrastructure>`_
+
+Build
+-----
+The docker image must be build from the repository root as it copy in the labgrid code, hence in order to buiĺd from "./labgrid/":
+
+  .. code-block:: bash
+
+     $ docker build -f docker/Dockerfile .
+
+Staging - Test environment
+--------------------------
+In *staging* a docker compose based staging environment resides. The staging environment contains a coordinator, an exporter and a client instance. Moreover a simple example configuration is provided to expose the USB serial on the Host. **Note** It is assumed that /dev/ttyUSB0 is available on the host to run the staging. It is also assumed that the serial is connected to the DUT.
+
+Each container can be started individually with the appropriate debug TTY attached:
+
+Coordinator
+...........
+
+  .. code-block:: bash
+
+     $ docker-compose up coordinator
+
+Exporter
+........
+
+  .. code-block:: bash
+
+     $ docker-compose up exporter
+
+Client
+......
+
+  .. code-block:: bash
+
+     $ docker-compose up -d client
+
+As the client require an interactive shell, this can be achieved as described below, where an interactive shell is opened and the client is used to list the resources seen be the coordinator:
+
+  .. code-block:: bash
+
+     $ docker-compose exec client /bin/bash
+     $ labgrid-client -x ws://coordinator:20408/ws resources
+
+If debug TTY's are not needed the staging environment is simply started by:
+
+  .. code-block:: bash
+
+     $ docker-compose up -d
+
+The client can still be accessed by exec as described above.

--- a/docker/staging/docker-compose.yml
+++ b/docker/staging/docker-compose.yml
@@ -1,0 +1,43 @@
+version: '3.3'
+services:
+  coordinator:
+    build:
+      context: "../../"
+      dockerfile: "docker/Dockerfile"
+    networks:
+      - labgrid_net
+    tty: true
+    command: "crossbar start"
+  client:
+    build:
+      context: "../../"
+      dockerfile: "docker/Dockerfile"
+    networks:
+      - labgrid_net
+    tty: true
+    stdin_open: true
+    command: "/bin/bash"
+  exporter:
+    build:
+      context: "../../"
+      dockerfile: "docker/Dockerfile"
+    volumes:
+      - "./exporter-conf:/opt/exporter-conf"
+    devices:
+      - "/dev/ttyUSB0:/dev/ttyUSB0"
+    networks:
+      - labgrid_net
+    command: /opt/exporter-conf/entrypoint.sh
+    depends_on:
+      - coordinator
+    tty: true
+    stdin_open: true
+    privileged: true
+
+networks:
+  labgrid_net:
+    driver: bridge
+    driver_opts:
+      com.docker.network.bridge.name: labgrid_bridge
+    ipam:
+      driver: default

--- a/docker/staging/exporter-conf/config.yaml
+++ b/docker/staging/exporter-conf/config.yaml
@@ -1,0 +1,6 @@
+default-group:
+  location: default
+  NetworkSerialPort:
+    host: exporter
+    port: 3001
+    speed: 115200

--- a/docker/staging/exporter-conf/entrypoint.sh
+++ b/docker/staging/exporter-conf/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+SCRIPTPATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ser2net -c ${SCRIPTPATH}/ser2net.conf
+# wait-for-it is a simple script that waits until the coordinator service is up before starting the exporter
+/opt/wait-for-it/wait-for-it.sh coordinator:20408 -- labgrid-exporter -n default -x ws://coordinator:20408/ws ${SCRIPTPATH}/config.yaml

--- a/docker/staging/exporter-conf/ser2net.conf
+++ b/docker/staging/exporter-conf/ser2net.conf
@@ -1,0 +1,1 @@
+3001:telnet:0:/dev/ttyUSB0:115200


### PR DESCRIPTION
As proposed in issue #260 integrate the docker images into the project.
This enable regression testing of the python setup files as docker hub can
be configured to automatically build upon commit in the Labgrid repo.

Signed-off-by: Kasper Revsbech <krev@triax.com>