### PR TITLE
remote/exporter: set LOCAL option for ser2net exported serial ports

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -149,7 +149,7 @@ class USBSerialPortExport(ResourceExport):
             '-d',
             '-n',
             '-C',
-            '{}:telnet:0:{}:115200 8DATABITS NONE 1STOPBIT'.format(
+            '{}:telnet:0:{}:115200 8DATABITS NONE 1STOPBIT LOCAL'.format(
                 self.port, start_params['path']
             ),
         ])


### PR DESCRIPTION
Identify ports which are exported over ser2net as local ports, ignoring the
modem control lines.

We had a device which uses a full rs232 connection instead of the usual serial
to ttl usb converter. Somewhere in the boot process the device side closed the
port and signaled this via the modem control lines, reulting in an EOF in
ser2net.
Configure the ser2net subprocesses to assume that all serial ports are local
ports, telling the kernel to ignore the control lines.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>