### PR TITLE
factory: recognize invalid config yaml item in _convert_to_named_list()

### DIFF
--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -69,6 +69,8 @@ class TargetFactory:
                         item = item.copy()
                     else:
                         item = {'cls':  key}
+                        if value is None:
+                            raise InvalidConfigError("invalid list item, add empty dict for no arguments")
                         item.update(value)
                 result.append(item)
         elif isinstance(data, dict):

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -125,6 +125,14 @@ class TestTargetFactory:
             target_factory._convert_to_named_list(data)
         assert "missing 'cls' key in OrderedDict(" in excinfo.value.msg
 
+        with pytest.raises(InvalidConfigError) as excinfo:
+            data = load("""
+            - one:
+            - two: {}
+            """)
+            target_factory._convert_to_named_list(data)
+        assert "invalid list item, add empty dict for no arguments" in excinfo.value.msg
+
     def test_resource_param_error(self):
         with pytest.raises(InvalidConfigError) as excinfo:
             target_factory.make_resource(


### PR DESCRIPTION
Caused by copying/pasting the config yaml contains this:

```
  targets:
    main:
      drivers:
        - SerialDriver:
	- ShellDriver: {}
        ..
```

This leads to:

`TypeError: 'NoneType' object is not iterable`

To help debugging the config error from above now ends with:

`labgrid.exceptions.InvalidConfigError: invalid list item, add empty dict for no arguments`

Signed-off-by: Bastian Stender <bst@pengutronix.de>