### PR TITLE
remote: fix usb power hub detection on some devices

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -336,10 +336,16 @@ class USBPowerPort(USBResource):
         index (int): index of the downstream port on the USB hub
     """
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
-    def __attrs_post_init__(self):
-        self.match['DEVTYPE'] = 'usb_interface'
-        self.match['DRIVER'] = 'hub'
-        super().__attrs_post_init__()
+    def filter_match(self, device):
+        try:
+            devclass = device.attributes.asstring('bDeviceClass')
+            if devclass != '09':
+                return False
+        except UnicodeDecodeError:
+            pass
+        except KeyError:
+            pass
+        return super().filter_match(device)
 
 @target_factory.reg_resource
 @attr.s(cmp=False)

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -338,13 +338,15 @@ class USBPowerPort(USBResource):
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
     def filter_match(self, device):
         try:
-            devclass = device.attributes.asstring('bDeviceClass')
-            if devclass != '09':
+            devclass = device.attributes.asint('bDeviceClass')
+            if devclass != 9:
                 return False
         except UnicodeDecodeError:
-            pass
+            return False
         except KeyError:
-            pass
+            return False
+        except ValueError:
+            return False
         return super().filter_match(device)
 
 @target_factory.reg_resource


### PR DESCRIPTION
Not all usb hubs can be identified via DEVTYPE and DRIVER. For example
Raspberry 2 has DEVTYPE=usb_device and DRIVER=usb. Use the bDeviceClass
attribute to detect usb hubs for sure.