### PR TITLE
debian: fixed dependencies for stretch

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: labgrid
 Section: python
 Priority: extra
 Maintainer: Jan Lübbe <jlu@pengutronix.de>
-Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.8), libow-dev
+Build-Depends: debhelper (>= 9), python, dh-virtualenv (>= 0.8), libow-dev,
+ libpython3-dev, python3-venv, python3-setuptools, git
 Standards-Version: 3.9.5
 
 Package: labgrid


### PR DESCRIPTION
Building on stretch (minimal container - using dck-buildpackage) threw out lots of strange errors,
Problems were:

* python3-venv was missing 
* some deps need to C-compile, therefore python headers are needed
* python-setuptools need to be installed, otherwise some commands fail w/o any easily visible explaination (can we increase the debug level / verbosity here ?)
* some of the automatically pulled python modules lack (autogenerated) metadata, so git is needed to create them