### PR TITLE
doc: IMXUSBDriver/MXSUSBDriver expects images key instead of image path

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1083,11 +1083,17 @@ Implements:
 
 .. code-block:: yaml
 
-   MXSUSBDriver:
-     image: mybootloader.img
+   targets:
+     main:
+       drivers:
+         MXSUSBDriver:
+           image: mybootloaderkey
+
+   images:
+     mybootloaderkey: path/to/mybootloader.img
 
 Arguments:
-  - image (str): The image to bootstrap onto the target
+  - image (str): The key in :ref:`images <labgrid-device-config-images>` containing the path of an image to bootstrap onto the target
 
 IMXUSBDriver
 ~~~~~~~~~~~~
@@ -1104,12 +1110,17 @@ Implements:
 
 .. code-block:: yaml
 
-   IMXUSBDriver:
-     image: mybootloader.img
+   targets:
+     main:
+       drivers:
+         IMXUSBDriver:
+           image: mybootloaderkey
 
+   images:
+     mybootloaderkey: path/to/mybootloader.img
 
 Arguments:
-  - image (str): The image to bootstrap onto the target
+  - image (str): The key in :ref:`images <labgrid-device-config-images>` containing the path of an image to bootstrap onto the target
 
 USBStorageDriver
 ~~~~~~~~~~~~~~~~

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -60,6 +60,8 @@ OPTIONS KEYS
   takes as parameter the realm of the crossbar (coordinator) to connect to.
   Defaults to 'realm1'.
 
+.. _labgrid-device-config-images:
+
 IMAGES
 ------
 The ``images:`` top key provides paths to access preconfigured images to flash


### PR DESCRIPTION
Specifying an image path directly leads to:

  KeyError: "no path configured for image '/path/to/bootloader.img'"

Clarify that in the documentation.

Signed-off-by: Bastian Stender <bst@pengutronix.de>