### PR TITLE
pytest/fixtures: change --lg-log default to const

### DIFF
--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -34,7 +34,7 @@ def pytest_addoption(parser):
         dest='lg_log',
         metavar='path to logfiles',
         nargs='?',
-        default=".",
+        const=".",
         help='path to store logfiles')
 
 


### PR DESCRIPTION
Before the change, labgrid would always create console logfiles. Change the
option so that logfiles are only produced if --lg-log ist set.