### PR TITLE
SSHDriver: Properly handle SSH timeouts

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Release 0.2.0 (unreleased)
 New Features
 ~~~~~~~~~~~~
 
+- `SSHDriver` and `NetworkService` timeout is now configurable.
+- `NetworkService` now accepts extra SSH-specific options through
+  the ``NetworkService.options`` attribute.
 - The target now saves it's attached drivers, resources and protocols in a
   lookup table, avoiding the need of importing many Drivers and Protocols (see
   `Syntactic sugar for Targets`_)

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -191,6 +191,11 @@ instead of the key file (needs sshpass to be installed)
 - username (str): username used by SSH
 - password (str): password used by SSH
 - port (int): optional, port used by SSH (default 22)
+- options (str): optional, :manpage:`ssh(1)` options to pass through to SSH
+- timeout (int): optional, equivalent to
+                 `options: -o ConnectionTimeout=<timeout>` (default 30)
+- shared (str): optional, specifies whether SSH multiplexing (`ControlMaster` in
+                :manpage:`ssh_config(5)`) is used (default `true`)
 
 Used by:
   - `SSHDriver`_

--- a/labgrid/resource/networkservice.py
+++ b/labgrid/resource/networkservice.py
@@ -11,3 +11,6 @@ class NetworkService(Resource):
     username = attr.ib(validator=attr.validators.instance_of(str))
     password = attr.ib(default='', validator=attr.validators.instance_of(str))
     port = attr.ib(default=22, validator=attr.validators.instance_of(int))
+    options = attr.ib(default='', validator=attr.validators.instance_of(str))
+    timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
+    shared = attr.ib(default=True, validator=attr.validators.instance_of(bool))


### PR DESCRIPTION
This introduces three new parameters to `NetworkService`:

- `options` (str): optional, ssh(1) options to pass through to SSH
- `timeout` (int): optional, equivalent to options: `-o ConnectionTimeout=<timeout>`
                 (default `30`)
- `shared` (str): optional, specifies whether SSH multiplexing (`ControlMaster` in
                ssh_config(5)) is used (default `True`)

When `shared: false`, the run method's timeout parameter may be used as
well to specify a timeout, in which case it overrides the
`NetworkService`'s.