### PR TITLE
strategy: add off state to BareboxStrategy and UBootStrategy

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1319,9 +1319,10 @@ Such a state could be the boot loader or a booted Linux kernel with shell.
 
 BareboxStrategy
 ~~~~~~~~~~~~~~~
-A BareboxStrategy has three states:
+A BareboxStrategy has four states:
 
 - unknown
+- off
 - barebox
 - shell
 
@@ -1361,9 +1362,10 @@ activate the shelldriver.
 
 UBootStrategy
 ~~~~~~~~~~~~~
-A UBootStrategy has three states:
+A UBootStrategy has four states:
 
 - unknown
+- off
 - uboot
 - shell
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -256,17 +256,23 @@ Lets take a look at the builtin `BareboxStrategy`. The Status enum for Barebox:
 
    class Status(enum.Enum):
        unknown = 0
-       barebox = 1
-       shell = 2
+       off = 1
+       barebox = 2
+       shell = 3
 
-defines 2 custom states and the `unknown` state as the start point.
-These two states are handled in the transition function:
+defines 3 custom states and the `unknown` state as the start point.
+These three states are handled in the transition function:
 
 ::
 
-    elif status == Status.barebox:
-        # cycle power
+    elif status == Status.off:
+        self.target.deactivate(self.barebox)
+        self.target.deactivate(self.shell)
         self.target.activate(self.power)
+        self.power.off()
+    elif status == Status.barebox:
+        self.transition(Status.off)
+        # cycle power
         self.power.cycle()
         # interrupt barebox
         self.target.activate(self.barebox)
@@ -279,7 +285,7 @@ These two states are handled in the transition function:
 
 Here the `barebox` state simply cycles the board and activates the driver, while
 the `shell` state uses the barebox state to cycle the board and than boot the
-linux kernel.
+linux kernel. The `off` states switch the power off.
 
 Graph Strategies
 ----------------

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -214,6 +214,11 @@ useful to define a function scope fixture per state in ``conftest.py``::
           pytest.skip("strategy not found")
 
   @pytest.fixture(scope='function')
+  def switch_off(target, strategy, capsys):
+      with capsys.disabled():
+          strategy.transition('off')
+
+  @pytest.fixture(scope='function')
   def bootloader_command(target, strategy, capsys):
       with capsys.disabled():
           strategy.transition('barebox')

--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -11,8 +11,9 @@ from .common import Strategy, StrategyError
 
 class Status(enum.Enum):
     unknown = 0
-    barebox = 1
-    shell = 2
+    off = 1
+    barebox = 2
+    shell = 3
 
 
 @target_factory.reg_driver
@@ -39,9 +40,14 @@ class BareboxStrategy(Strategy):
         elif status == self.status:
             step.skip("nothing to do")
             return  # nothing to do
-        elif status == Status.barebox:
-            # cycle power
+        elif status == Status.off:
+            self.target.deactivate(self.barebox)
+            self.target.deactivate(self.shell)
             self.target.activate(self.power)
+            self.power.off()
+        elif status == Status.barebox:
+            self.transition(Status.off)  # pylint: disable=missing-kwoa
+            # cycle power
             self.power.cycle()
             # interrupt barebox
             self.target.activate(self.barebox)


### PR DESCRIPTION
This adds the off state which allows to switch the DUT off.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>