### PR TITLE
Add Labgrid-project pyserial fork

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -44,6 +44,22 @@ requirements from the `requirements.txt` file:
    Thus when installing directly from pip you have to test compatibility
    yourself.
 
+.. note::
+   If you are installing via pip and intend to use Serial over IP (RFC2217),
+   it is highly recommended to uninstall pyserial after installation and replace
+   it with the pyserial version from the labgrid project:
+
+      .. code-block:: bash
+
+          $ pip uninstall pyserial
+          $ pip install https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial
+
+   This pyserial version has two fixes for an Issue we found with Serial over IP
+   multiplexers. Additionally it reduces the Serial over IP traffic considerably
+   since the port is not reconfigured when labgrid changes the timeout (which is
+   done inside the library a lot).
+
+
 Test your installation by running:
 
 .. code-block:: bash

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 import attr
 import serial
@@ -24,6 +25,12 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         bindings = {"port": SerialPort, }
     else:
         bindings = {"port": {SerialPort, NetworkSerialPort}, }
+    if tuple(int(x) for x in serial.__version__.split('.')) <= (3, 4, 0, 1):
+        message = ("The installed python version does not contain important RFC2217 fixes.\n"
+            "You can install the labgrid fork via:\n"
+            "pip uninstall pyserial\n"
+            "pip install https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial\n")
+        warnings.warn(message)
 
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 attrs==17.4.0
 jinja2==2.10
 pexpect==4.3.1
-pyserial==3.4
+https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial
 pytest==3.4.0
 pyudev==0.21.0
 requests==2.18.4


### PR DESCRIPTION
Add our local pyserial fork in requirements and mention the fork in the installation chapter.