### PR TITLE
serialdriver: fix version detection for RFC2217

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -25,7 +25,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         bindings = {"port": SerialPort, }
     else:
         bindings = {"port": {SerialPort, NetworkSerialPort}, }
-    if tuple(int(x) for x in serial.__version__.split('.')) <= (3, 4, 0, 1):
+    if tuple(int(x) for x in serial.__version__.split('.')) < (3, 4, 0, 1):
         message = ("The installed python version does not contain important RFC2217 fixes.\n"
             "You can install the labgrid fork via:\n"
             "pip uninstall pyserial\n"


### PR DESCRIPTION
Our versioned release is 3.4.0.1, so we should only warn if the pyserial version
is lower than this , not equal and lower.

Fixes: 9d26bb2d86 ("serialdriver: add a warning about the RFC2217 fixes")
Reported-by: Jonathan Götzinger <J.Goetzinger@eckelmann.de>
Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>