### PR TITLE
sshdriver: use -f if ssh is used with password

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -53,7 +53,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         )
         # use sshpass if we have a password
         sshpass = "sshpass -e " if self.networkservice.password else ""
-        args = ("{}ssh -n {} -x -o ConnectTimeout=30 -o ControlPersist=300 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -MN -S {} -p {} {}@{}").format( # pylint: disable=line-too-long
+        args = ("{}ssh -f {} -x -o ConnectTimeout=30 -o ControlPersist=300 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -MN -S {} -p {} {}@{}").format( # pylint: disable=line-too-long
             sshpass, self.ssh_prefix, control, self.networkservice.port,
             self.networkservice.username, self.networkservice.address).split(" ")
 


### PR DESCRIPTION
-n to put the ssh program to background doesn't work with password.
Use -f instead.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>