### PR TITLE
driver/sshdriver: configure ServerAliveInterval to detect failed connections

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -706,6 +706,12 @@ SSHDriver
 ~~~~~~~~~
 A SSHDriver requires a `NetworkService` resource and allows the execution of
 commands and file upload via network.
+It uses SSH's ServerAliveInterval option to detect failed connections.
+
+If a shared SSH connection to the target is already open, it will reuse it when
+running commands.
+In that case, ServerAliveInterval should be set outside of labgrid, as it
+cannot be enabled for an existing connection.
 
 Binds to:
   networkservice:

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -51,7 +51,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         )
         # use sshpass if we have a password
         sshpass = "sshpass -e " if self.networkservice.password else ""
-        args = ("{}ssh -n {} -x -o ConnectTimeout=30 -o ControlPersist=300 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -MN -S {} -p {} {}@{}").format( # pylint: disable=line-too-long
+        args = ("{}ssh -n {} -x -o ConnectTimeout=30 -o ControlPersist=300 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -MN -S {} -p {} {}@{}").format( # pylint: disable=line-too-long
                     sshpass, self.ssh_prefix, control, self.networkservice.port,
                     self.networkservice.username, self.networkservice.address).split(" ")
 


### PR DESCRIPTION
TCP timeouts can take a long time to detect a failed connection, so we
enable keep-alives at the SSH level. With the default value of
ServerAliveCountMax of 3, this will detect a failed connection after
about 45 seconds.