### PR TITLE
graphstrategy: support a compatibility format for transitions with via

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -104,6 +104,11 @@ class GraphStrategy(Strategy):
 
     @step(args=['state'])
     def transition(self, state, via=None):
+        # for use with labgrid-client -s, if only state is set, try to extract
+        # the via states
+        if ':' in state and via is None:
+            state, via = state.split(':')
+            via = via.split(',')
         via = via or []
         try:
             # check if another transition is running

--- a/tests/test_graphstrategy.py
+++ b/tests/test_graphstrategy.py
@@ -210,6 +210,13 @@ def test_transition_via(graph_strategy):
     assert graph_strategy.transition('D', via=['A2']) == ['Root', 'A2', 'B', 'C1', 'D']
     assert graph_strategy.path == ['Root', 'A2', 'B', 'C1', 'D']
 
+    graph_strategy.invalidate()
+
+    assert graph_strategy.transition('D:A2') == ['Root', 'A2', 'B', 'C1', 'D']
+    assert graph_strategy.path == ['Root', 'A2', 'B', 'C1', 'D']
+
+    assert graph_strategy.transition('D:C2,A2') == ['Root', 'A2', 'B', 'C2', 'D']
+    assert graph_strategy.path == ['Root', 'A2', 'B', 'C2', 'D']
 
 @pytest.mark.dependency(depends=['api-works',
                                  'test_transition',


### PR DESCRIPTION
GraphStrategies have an additional 'via' keyword argument for
transitions. This change allows specifying this by using `labgrid-client
-s shell:off,barebox` which translates to `transition('shell',
via=['off', 'barebox'])`.