### PR TITLE
strategy/init: Also import StrategyError from common

### DIFF
--- a/labgrid/strategy/__init__.py
+++ b/labgrid/strategy/__init__.py
@@ -1,4 +1,4 @@
-from .common import Strategy
+from .common import Strategy, StrategyError
 from .bareboxstrategy import BareboxStrategy
 from .shellstrategy import ShellStrategy
 from .ubootstrategy import UBootStrategy


### PR DESCRIPTION
This will allow to use StrategyError by just importing Strategy
as done in examples/usbpower/examplestrategy which is currently
failing on raise StrategyError

Signed-off-by: Kasper Revsbech <krev@triax.com>