### PR TITLE
driver/sshdriver: Add option to merge stderr with stdout

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -729,6 +729,8 @@ Implements:
 Arguments:
   - keyfile (str): filename of private key to login into the remote system
     (only used if password is not set)
+  - stderr_merge (bool): set to True to make `run()` return stderr merged with
+      stdout, and an empty list as second element.
 
 InfoDriver
 ~~~~~~~~~~


### PR DESCRIPTION
This adds a stderr_merge flag to SSHDriver, which when se makes SSHDriver
instances return values from run() compatible with what is returned by
ShellDriver, ie. with stdout and stderr merged together in first value,
and [] in second.

With this, it is much easier to write test cases that can be used with
both SSHDriver and ShellDriver.

Example fixture for use:

    @pytest.fixture(scope='function')
    def shell(target):
        ssh = target.get_driver('SSHDriver')
        if ssh:
            target.activate(ssh)
            stderr_merge = ssh.stderr_merge
            ssh.stderr_merge = True
            yield ssh
            ssh.stderr_merge = stderr_merge
        else:
            return target.get_active_driver('CommandProtocol')

Signed-off-by: Esben Haabendal <esben@haabendal.dk>