### PR TITLE
driver/shelldriver: Fix initial login prompt timeout

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -114,7 +114,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         # the before property. So we store the last before value we've seen.
         # Because pexpect keeps any read data in it's buffer when a timeout
         # occours, we can't lose any data this way.
-        last_before = None
+        last_before = b''
 
         while True:
             index, before, _, _ = self.console.expect(


### PR DESCRIPTION
When waiting for the initial login prompt, the `before` value is `b''`
on timeout, so with `last_before = None` the timeout had to fire two times
before the `self.console.sendline("")` was executed.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>