### PR TITLE
Fix use of deprecated attrs convert() method

### DIFF
--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -98,12 +98,12 @@ class ResourceMatch:
 @attr.s(cmp=False)
 class Place:
     name = attr.ib()
-    aliases = attr.ib(default=attr.Factory(set), convert=set)
+    aliases = attr.ib(default=attr.Factory(set), converter=set)
     comment = attr.ib(default="")
     matches = attr.ib(default=attr.Factory(list))
     acquired = attr.ib(default=None)
     acquired_resources = attr.ib(default=attr.Factory(list))
-    allowed = attr.ib(default=attr.Factory(set), convert=set)
+    allowed = attr.ib(default=attr.Factory(set), converter=set)
     created = attr.ib(default=attr.Factory(time.time))
     changed = attr.ib(default=attr.Factory(time.time))
 

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -17,4 +17,4 @@ class NetworkPowerPort(Resource):
     model = attr.ib(validator=attr.validators.instance_of(str))
     host = attr.ib(validator=attr.validators.instance_of(str))
     index = attr.ib(validator=attr.validators.instance_of(str),
-                    convert=lambda x: str(int(x)))
+                    converter=lambda x: str(int(x)))

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -78,8 +78,8 @@ class RemotePlaceManager(ResourceManager):
             for k, v_new in attrs.items():
                 # check for attr converters
                 attrib = getattr(fields, k)
-                if attrib.convert:
-                    v_new = attrib.convert(v_new)
+                if attrib.converter:
+                    v_new = attrib.converter(v_new)
                 v_old = getattr(resource, k)
                 setattr(resource, k, v_new)
                 if v_old != v_new:

--- a/labgrid/resource/ykushpowerport.py
+++ b/labgrid/resource/ykushpowerport.py
@@ -14,4 +14,4 @@ class YKUSHPowerPort(Resource):
         index (int): port index"""
     serial = attr.ib(validator=attr.validators.instance_of(str))
     index = attr.ib(validator=attr.validators.instance_of(int),
-                    convert=lambda x: int(x))
+                    converter=lambda x: int(x))


### PR DESCRIPTION
The `convert()` method was deprecated with attrs 17.4.0.
See http://www.attrs.org/en/stable/changelog.html#id44

Signed-off-by: Esben Haabendal <esben@haabendal.dk>