### PR TITLE
remote/client: Allow use of $LG_ENV to specify config file

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -963,6 +963,7 @@ def main():
         '-c',
         '--config',
         type=str,
+        default=os.environ.get("LG_ENV"),
         help="config file"
     )
     parser.add_argument(

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -78,6 +78,10 @@ This variable can be used to specify a place without using the \fB\-p\fP option,
 This variable can be used to specify a state which the device transitions into
 before executing a command. Requires a configuration file and a Strategy
 specified for the device.
+.SS LG_ENV
+.sp
+This variable can be used to specify the configuration file to use without
+using the \fB\-\-config\fP option, the \fB\-\-config\fP option overrides it.
 .SS LG_CROSSBAR
 .sp
 This variable can be used to set the default crossbar URL (instead of using the

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -66,6 +66,12 @@ This variable can be used to specify a state which the device transitions into
 before executing a command. Requires a configuration file and a Strategy
 specified for the device.
 
+LG_ENV
+~~~~~~
+
+This variable can be used to specify the configuration file to use without
+using the ``--config`` option, the ``--config`` option overrides it.
+
 LG_CROSSBAR
 ~~~~~~~~~~~
 This variable can be used to set the default crossbar URL (instead of using the


### PR DESCRIPTION
When using the pytestplugin, $LG_ENV can be used for specifying the
configuration file.  Adding support for same behavior when using
labgrid-client allows setting up $LG_ENV and then using simple CLI commands
without having to bother with --lg-env and --config options.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>