### PR TITLE
driver/sshdriver: Make SSHDriver a preferred CommandProtocol

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -22,6 +22,7 @@ from .exception import ExecutionError
 class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     """SSHDriver - Driver to execute commands via SSH"""
     bindings = {"networkservice": NetworkService, }
+    priorities = {CommandProtocol: 10, FileTransferProtocol: 10}
     keyfile = attr.ib(default="", validator=attr.validators.instance_of(str))
     stderr_merge = attr.ib(default=False, validator=attr.validators.instance_of(bool))
 


### PR DESCRIPTION
For tests where both ShellDriver and SSHDriver are activated, the SSHDriver
should be preferred, as it much faster.  Without this, calling
`target.get_driver('CommandProtocol')` with both drivers active will fail.

For other use cases (ie. where only one CommandProtocol driver is active at a
time), things will work as before.

Signed-off-by: Esben Haabendal <esben@haabendal.dk>