### PR TITLE
Build Docker images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,21 @@ before_install:
   - sudo apt-get install -y libow-dev
 install:
   - pip install -r travis-requirements.txt
-  - pip install -e .
 script:
+  - pip install -e .
   - pytest --cov-config .coveragerc --cov=labgrid
   - python setup.py build_sphinx
   - make -C man all
   - git --no-pager diff --exit-code
 after_success:
   - codecov
+
+matrix:
+  include:
+    - stage: docker
+      python: "3.6"
+      services:
+        - docker
+      script: ./docker/build.sh
+  allow_failures:
+    - stage: docker

--- a/docker/README.rst
+++ b/docker/README.rst
@@ -1,0 +1,103 @@
+Labgrid Docker images
+=====================
+
+This folder contains Dockerfile's for building Docker images
+for the 3 different components of a Labgrid distributed infrastructure.
+
+- **labgrid-coordinator**
+  An image for with crossbar which can be used to run
+  a Labgrid coordinator instance.
+- **labgrid-client**
+  An image with the Labgrid client tools and pytest integration.
+- **labgrid-exporter**
+  An image with the Labgrid exporter tools.
+
+
+Build
+-----
+
+To build one of the above images,
+you need to run the `docker build` command in the root of this repository.
+Example showing how to build labgrid-client image:
+
+  .. code-block:: bash
+
+     $ docker build -t labgrid-client -f docker/client/Dockerfile .
+
+You can also choose to build all 3 images,
+with the included script
+(which also must be run from the root of this repository):
+
+  .. code-block:: bash
+
+     $ ./docker/build.sh
+
+
+Usage
+-----
+
+All 3 images are to be considered base images
+with the required software installed.
+No policy or configuration is done.
+
+
+labgrid-coordinator usage
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The labgrid-coordinator comes with a preconfigured Crossbar.io server.
+
+It listens to port 20408,
+so you probably want to publish that so you can talk to the coordinator.
+
+State is written to `/opt/crossbar`.
+You might want to bind a volume to that
+so you can restart the service without loosing state.
+
+  .. code-block:: bash
+
+     $ docker run -t -p 20408:20408 -v $HOME/crossbar:/opt/crossbar
+	 labgrid-coordinator
+
+
+labgrid-client usage
+~~~~~~~~~~~~~~~~~~~~
+
+The labgrid-client image can be used to
+run `labgrid-client` and `pytest` commands.
+For example listing available places registered at coordinator at
+ws://192.168.1.42:20408/ws
+
+  .. code-block:: bash
+
+     $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws labgrid-client \
+	 labgrid-client places
+
+Or running all pytest/labgrid tests at current directory:
+
+  .. code-block:: bash
+
+     $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws labgrid-client \
+	 pytest
+
+
+labgrid-exporter usage
+~~~~~~~~~~~~~~~~~~~~~~
+
+The labgrid-exporter image runs a labgrid-exporter
+and optionally an ser2net service.
+
+Configuration is not included,
+but needs to be bind mounted to
+/opt/conf/exporter.yaml and /opt/conf/ser2net.conf (optional).
+
+Start it with something like:
+
+  .. code-block:: bash
+
+     $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws \
+         -v $HOME/exporter-conf:/opt/conf \
+	 labgrid-coordinator
+
+If using ser2net,
+the devices needed must be added to Docker container
+(`docker run --device` option).

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ex
+docker build -t labgrid-client -f docker/client/Dockerfile .
+docker build -t labgrid-exporter -f docker/exporter/Dockerfile .
+docker build -t labgrid-coordinator -f docker/coordinator/Dockerfile .

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.6
+MAINTAINER eha@deif.com
+
+RUN mkdir -p /opt/labgrid
+COPY ./ /opt/labgrid/
+RUN cd /opt/labgrid \
+ && pip install -r requirements.txt \
+ && python setup.py install
+
+RUN apt-get update -q \
+ && apt-get install -q -y microcom \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+CMD ["/bin/bash"]

--- a/docker/coordinator/Dockerfile
+++ b/docker/coordinator/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.6
+MAINTAINER eha@deif.com
+
+RUN mkdir -p /opt/labgrid
+COPY ./ /opt/labgrid/
+RUN cd /opt/labgrid \
+ && pip install -r crossbar-requirements.txt \
+ && python setup.py install
+
+VOLUME /opt/crossbar
+EXPOSE 40208
+
+ENV CROSSBAR_DIR=/opt/crossbar
+CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]

--- a/docker/exporter/Dockerfile
+++ b/docker/exporter/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.6
+MAINTAINER eha@deif.com
+
+RUN mkdir -p /opt/labgrid
+COPY ./ /opt/labgrid/
+RUN cd /opt/labgrid \
+ && pip install -r requirements.txt \
+ && python setup.py install
+
+RUN apt-get update -q \
+ && apt-get install -q -y ser2net \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+VOLUME /opt/conf
+
+COPY docker/exporter/entrypoint.sh /entrypoint.sh
+CMD ["/entrypoint.sh"]

--- a/docker/exporter/entrypoint.sh
+++ b/docker/exporter/entrypoint.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+if [ -f /opt/conf/ser2net.conf ] ; then
+    ser2net -c /opt/conf/ser2net.conf
+fi
+labgrid-exporter "$@" /opt/conf/exporter.yaml


### PR DESCRIPTION
This add Dockerfile for building Docker images including the Labgrid distributed infrastructure components, and integrates build testing of them in Travis CI.

Replaces #284
Closes #260