### PR TITLE
requirements: update PyYAML to support python-3.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ pyudev==0.21.0
 requests==2.18.4
 xmodem==0.4.5
 autobahn==17.10.1
-PyYAML==3.12
+PyYAML==3.13


### PR DESCRIPTION
Building PyYAML with pip and python-3.7 fails with a number of errors
like this:

  ext/_yaml.c:24217:13: error: ‘PyThreadState’ {aka ‘struct _ts’} has no
  member named ‘exc_traceback’; did you mean ‘curexc_traceback’?

Upstream PyYAML has releases version 3.13 to address this, so update
requirements to install that version.

Signed-off-by: Martin Hundebøll <martin@geanix.com>