### PR TITLE
serialdriver: fix warning string

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -26,7 +26,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     else:
         bindings = {"port": {SerialPort, NetworkSerialPort}, }
     if tuple(int(x) for x in serial.__version__.split('.')) < (3, 4, 0, 1):
-        message = ("The installed python version does not contain important RFC2217 fixes.\n"
+        message = ("The installed pyserial version does not contain important RFC2217 fixes.\n"
             "You can install the labgrid fork via:\n"
             "pip uninstall pyserial\n"
             "pip install https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial\n")


### PR DESCRIPTION
<!--
Provide a general overview for the PR
I.e. Bug Fix, Add feature, amend documentation
--->
# General

Fix a bug in the serialdriver. It says python instead of pyserial.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
## Description
Fix for a copy-and-paste error I did with the pyserial version warning. 

<!---
This task list roughly outlines the steps for new features, remove and add tasks as needed:
--->
## Task List
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
