### PR TITLE
Allow import of python modules using imports: in config.yaml

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1502,6 +1502,7 @@ The skeleton for an environment consists of:
      <more tools>
    imports:
      - <import.py>
+     - <python module>
 
 If you have a single target in your environment, name it "main", as the
 ``get_target`` function defaults to "main".

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -167,7 +167,13 @@ class Config:
         if isinstance(self.data.get('imports', []), str):
             raise KeyError("imports needs to be list not string")
         for user_import in self.data.get('imports', []):
-            imports.append(self.resolve_path(user_import))
+            # Try to resolve the import to a .py file
+            import_path = self.resolve_path(user_import)
+            if import_path.endswith('.py'):
+                imports.append(import_path)
+            else:
+                # Fallback to importing module if not a .py file path
+                imports.append(user_import)
 
         return imports
 

--- a/labgrid/environment.py
+++ b/labgrid/environment.py
@@ -19,12 +19,16 @@ class Environment:
         self.config = Config(self.config_file)
 
         for user_import in self.config.get_imports():
+            import importlib
             from importlib.machinery import SourceFileLoader
             import sys
 
-            module_name = os.path.basename(user_import)[:-3]
-
-            module = SourceFileLoader(module_name, user_import).load_module()
+            if user_import.endswith('.py'):
+                module_name = os.path.basename(user_import)[:-3]
+                module = SourceFileLoader(module_name, user_import).load_module()
+            else:
+                module_name = user_import
+                module = importlib.import_module(user_import)
             sys.modules[module_name] = module
 
     def get_target(self, role: str = 'main') -> Target:


### PR DESCRIPTION
This extends the imports: mechanism in the config.yaml file with support for using Python
modules without having to care about their filesystem paths.

Say you have installed a Python module which includes a labgrid strategy driver as my.labgrid.strategy module, you can add

```yaml
imports:
  - my.labgrid.strategy
```

to your config.yaml.

This makes it easier to manage drivers when managed as an infrastructure part, and not directly in the test repositories.