### PR TITLE
driver/sshdriver: Extend StrictHostKeyChecking=no to scp

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -30,6 +30,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def on_activate(self):
         self.ssh_prefix = "-o LogLevel=ERROR"
+        self.ssh_prefix += " -o StrictHostKeyChecking=no"
         self.ssh_prefix += " -i {}".format(os.path.abspath(self.keyfile)
                                           ) if self.keyfile else ""
         self.ssh_prefix += " -o PasswordAuthentication=no" if (
@@ -51,7 +52,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         )
         # use sshpass if we have a password
         sshpass = "sshpass -e " if self.networkservice.password else ""
-        args = ("{}ssh -n {} -x -o ConnectTimeout=30 -o ControlPersist=300 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ServerAliveInterval=15 -MN -S {} -p {} {}@{}").format( # pylint: disable=line-too-long
+        args = ("{}ssh -n {} -x -o ConnectTimeout=30 -o ControlPersist=300 -o UserKnownHostsFile=/dev/null -o ServerAliveInterval=15 -MN -S {} -p {} {}@{}").format( # pylint: disable=line-too-long
                     sshpass, self.ssh_prefix, control, self.networkservice.port,
                     self.networkservice.username, self.networkservice.address).split(" ")
 


### PR DESCRIPTION
Apply the StrictHostKeyChecking for scp (put() and get()) instead of only
for ssh commands (run()).

Signed-off-by: Esben Haabendal <esben@haabendal.dk>