### PR TITLE
driver/serialdriver: remove wrong keyword argument

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -54,7 +54,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
             self.serial.port = self.port.port
             self.serial.baudrate = self.port.speed
         else:
-            host, port = proxymanager.get_host_and_port(self.port, proxy=True)
+            host, port = proxymanager.get_host_and_port(self.port)
             if self.port.protocol == "rfc2217":
                 self.serial.port = "rfc2217://{}:{}/".format(host, port)
             elif self.port.protocol == "raw":


### PR DESCRIPTION
This got refactored and is also not necessary here, since we rely on the proxy
setting of the exporter.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>