### PR TITLE
exporter: fix proxy arguments for non Exported classes

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -445,7 +445,7 @@ class ExporterSession(ApplicationSession):
         if issubclass(export_cls, ResourceExport):
             group[resource_name] = export_cls(config, host=self.hostname, proxy=getfqdn(), proxy_required=proxy_req)
         else:
-            group[resource_name] = export_cls(config, proxy=getfqdn(), proxy_required=proxy_req)
+            group[resource_name] = export_cls(config)
         await self.update_resource(group_name, resource_name)
 
     async def update_resource(self, group_name, resource_name):


### PR DESCRIPTION
Classes which are not a subclass of the ResourceExport don't have these keyword
arguments, remove them.

This causes an error for newly restarted exporters.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>