### PR TITLE
resource/udev: properties is not a method in filter_match()

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -261,9 +261,9 @@ class USBEthernetInterface(USBResource, EthernetInterface):
 @attr.s(cmp=False)
 class AlteraUSBBlaster(USBResource):
     def filter_match(self, device):
-        if device.properties().get('ID_VENDOR_ID') != "09fb":
+        if device.properties.get('ID_VENDOR_ID') != "09fb":
             return False
-        if device.properties().get('ID_MODEL_ID') not in ["6010", "6810"]:
+        if device.properties.get('ID_MODEL_ID') not in ["6010", "6810"]:
             return False
         return super().filter_match(device)
 


### PR DESCRIPTION
Signed-off-by: Bastian Stender <bst@pengutronix.de>
Fixes: 88ab4edb ("resource/udev: fix DeprecationWarnings")