### PR TITLE
util/proxy: fix docstring for proxy kwarg

### DIFF
--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -14,7 +14,7 @@ class ProxyManager:
 
         Args:
             res (Resource): The resource to retrieve the proxy for
-            proxy (:obj:`bool`, optional): whether to always proxy the
+            force_proxy (:obj:`bool`, optional): whether to always proxy the
                 connection, defaults to False
 
         Returns:


### PR DESCRIPTION
The keyword argument is actually called "force_proxy", not "proxy".

Signed-off-by: Bastian Stender <bst@pengutronix.de>