### PR TITLE
util/ssh: improve/correct error messages

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -291,14 +291,14 @@ class SSHConnection:
         try:
             if self.process.wait(timeout=30) is not 0:
                 raise ExecutionError(
-                    "failed to connect to {} with {} and {} [{}],[{}] ".format(
+                    "failed to connect to {} with args {}, returncode={} [{}],[{}] ".format(
                         self.host, args, self.process.wait(), self.process.stdout.readlines(), self.process.stderr.readlines()
                     )
                 )
         except subprocess.TimeoutExpired:
             raise ExecutionError(
-                "failed to connect to {} with {} and {} [{}],[{}]".format(
-                    self.host, args, self.process.readlines(), self.process.readlines()
+                "failed to connect (timeout) to {} with args {} [{}],[{}]".format(
+                    self.host, args, self.process.stdout.readlines(), self.process.stderr.readlines()
                 )
             )
 


### PR DESCRIPTION
The number of arguments in case of timeout was wrong. Correct this.
Improve error messages.

Signed-off-by: Bastian Stender <bst@pengutronix.de>