### PR TITLE
util/ssh: do not use foreign ControlMaster, leave ControlMaster open indefinitely, small fixes

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -210,7 +210,8 @@ class SSHConnection:
         """Put a file onto the remote host"""
         subprocess.check_call([
             "rsync", "-e", "ssh -o ControlPath={}".format(self._socket),
-            "{}".format(local_file), "{}:{}".format(self.host, remote_path)
+            "--copy-links", "{}".format(local_file),
+            "{}:{}".format(self.host, remote_path)
         ])
 
     @_check_connected


### PR DESCRIPTION
This is a collection of util/ssh fixes I came up with while using current labgrid master:
- util/ssh: remove unnecessary empty lines
- util/ssh: use self._socket consistently, remove return
- util/ssh: do not use foreign ControlMaster
- util/ssh: master connection must remain open indefinitely
- util/ssh: copy also symlink referents to remote