### PR TITLE
strategy/ubootstrategy: fix OFF transition

### DIFF
--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -38,7 +38,7 @@ class UBootStrategy(Strategy):
         elif status == self.status:
             return # nothing to do
         elif status == Status.off:
-            self.target.deactivate(self.barebox)
+            self.target.deactivate(self.uboot)
             self.target.deactivate(self.shell)
             self.target.activate(self.power)
             self.power.off()


### PR DESCRIPTION
Barebox does not exist in ubootstrategy.

Signed-off-by: Laurentiu Palcu <laurentiu.palcu@nxp.com>