### PR TITLE
remote/exporter: fix _stop() call in USBSerialPortExport

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -121,7 +121,7 @@ class USBSerialPortExport(ResourceExport):
 
     def __del__(self):
         if self.child is not None:
-            self._stop()
+            self.stop()
 
     def _get_start_params(self):
         return {


### PR DESCRIPTION
This works the same way as ResourceExport.stop() does.

It fixes:
`TypeError: _stop() missing 1 required positional argument: 'start_params'`

Signed-off-by: Bastian Krause <bst@pengutronix.de>