### PR TITLE
util/ssh: copy also symlink referents to remote

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -224,7 +224,8 @@ class SSHConnection:
     @_check_connected
     def put_file(self, local_file, remote_path):
         """Put a file onto the remote host"""
-        complete_cmd = ["rsync", "-e", " ".join(['ssh'] + self._get_ssh_args())]
+        complete_cmd = ["rsync", "--copy-links", "-e",
+                        " ".join(['ssh'] + self._get_ssh_args())]
         complete_cmd += [
                 "{}".format(local_file),
                 "{}:{}".format(self.host, remote_path)


### PR DESCRIPTION
In case an image file is given as a symlink pointing to the actual image
the rsync command skips the file:

  skipping non-regular file "myimage.img"

Fix this by actually copying the symlink referent to the remote.

This is important for Yocto builds. The resulting images contain a
timestamp in the file name. For each image a symlink with a predictable
name is created. So using this symlink is the easiest way of
referencing a Yocto image in an automated build and test chain.

See: https://www.yoctoproject.org/docs/1.8/ref-manual/ref-manual.html#images-dev-environment

Signed-off-by: Bastian Krause <bst@pengutronix.de>

Note: this was originally part of #336.