### PR TITLE
resource/udev: access USBSDMuxDevice's disk_path directly

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -300,7 +300,7 @@ class USBSDMuxDevice(USBResource):
         super().update()
         if not self.device:
             self.control_path = None
-            self.path = None
+            self.disk_path = None
         for child in self.device.children:
             if child.subsystem == 'block':
                 self.disk_path = child.device_node


### PR DESCRIPTION
USBSDMuxDevice's path property has no setter method. So use disk_path
directly on update().

Fixes: 9ef77464 ("resource/udev: use update function for USBSDMuxDevice")
Signed-off-by: Bastian Krause <bst@pengutronix.de>