### PR TITLE
resource/udev: fix missing else in USBSDMuxDevice update function

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -301,6 +301,7 @@ class USBSDMuxDevice(USBResource):
         if not self.device:
             self.control_path = None
             self.disk_path = None
+            return
         for child in self.device.children:
             if child.subsystem == 'block':
                 self.disk_path = child.device_node


### PR DESCRIPTION
The function would try to iterate on the NoneType object of no device was
available. Add the else path to only iterate on the device children if the
device is available

Fixes: 9ef7746 ("resource/udev: use update function for USBSDMuxDevice")
Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>