### PR TITLE
target: strategy/graphstrategy: simplify driver deactivation, deactivate before root state

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -137,6 +137,10 @@ class GraphStrategy(Strategy):
 
             # run state methods
             for state_name in path:
+                if state_name == self.root_state:
+                    # deactivate drivers before root state method is called
+                    self.target.deactivate_all_drivers()
+
                 try:
                     self.states[state_name]['method']()
 

--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -99,8 +99,7 @@ class GraphStrategy(Strategy):
         self.path = []
 
         # deactivate all drivers to restore initial state
-        for driver in self.target.drivers:
-            self.target.deactivate(driver)
+        self.target.deactivate_all_drivers()
 
     @step(args=['state'])
     def transition(self, state, via=None):

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -441,10 +441,14 @@ class Target:
         client.on_deactivate()
         client.state = BindingState.bound
 
-    def cleanup(self):
-        """Clean up conntected drivers and resources in reversed order"""
+    def deactivate_all_drivers(self):
+        """Deactivates all drivers in reversed order they were activated"""
         for drv in reversed(self.drivers):
             self.deactivate(drv)
+
+    def cleanup(self):
+        """Clean up conntected drivers and resources in reversed order"""
+        self.deactivate_all_drivers()
         for res in reversed(self.resources):
             self.deactivate(res)
 


### PR DESCRIPTION
Let the graph strategy deactivate all drivers before root state. This leads to more consistent driver handling in strategies. Simplify driver deactivation while at it.