### PR TITLE
Add write-image subcommand to the client, fix udev detection and check device path

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,11 @@
+Release 0.3.0 (unreleased)
+--------------------------
+
+New Features in 0.3.0
+~~~~~~~~~~~~~~~~~~~~~
+- labgrid-client ``write-image`` subcommand: labgrid client now has a
+  ``write-image`` command to write images onto block devices.
+
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------
 

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -10,6 +10,8 @@ from ..resource.remote import NetworkUSBMassStorage, NetworkUSBSDMuxDevice
 from ..step import step
 from ..util.managedfile import ManagedFile
 from .common import Driver
+from ..driver.exception import ExecutionError
+
 
 @target_factory.reg_driver
 @attr.s(cmp=False)
@@ -35,6 +37,10 @@ class NetworkUSBStorageDriver(Driver):
 
     @step(args=['filename'])
     def write_image(self, filename):
+        if not self.storage.path:
+            raise ExecutionError(
+                "{} is not available".format(self.storage_path)
+            )
         mf = ManagedFile(filename, self.storage)
         mf.sync_to_resource()
         self.logger.info("pwd: %s", os.getcwd())
@@ -50,6 +56,10 @@ class NetworkUSBStorageDriver(Driver):
 
     @step(result=True)
     def get_size(self):
+        if not self.storage.path:
+            raise ExecutionError(
+                "{} is not available".format(self.storage_path)
+            )
         args = ["cat", "/sys/class/block/{}/size" % self.storage.path[5:]]
         size = subprocess.check_output(self.storage.command_prefix + args)
         return int(size)

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -158,6 +158,8 @@ matches anything.
 \fBvideo\fP                       Start a video stream
 .sp
 \fBtmc\fP command                 Control a USB TMC device
+.sp
+\fBwrite\-image\fP         Write images onto block devices (USBSDMux, USB Sticks, …)
 .SH EXAMPLES
 .sp
 To retrieve a list of places run:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -150,6 +150,8 @@ LABGRID-CLIENT COMMANDS
 
 ``tmc`` command                 Control a USB TMC device
 
+``write-image``         Write images onto block devices (USBSDMux, USB Sticks, …)
+
 EXAMPLES
 --------
 


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
## Description
Add the write-image command to the client. This allows the writing of images to USB mass storage devices.
Also fix the disk_path property of the usbsdmux.
The `NetworkUSBStorageDriver` has been enhanced with a check for the `path` property of the resource, since the USBSDMux can be available, but in `DUT` mode does not expose a usb storage device.

<!---
This task list roughly outlines the steps for new features, remove and add tasks as needed:
--->
## Task List
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated