### PR TITLE
serialdriver: ignore SET_CONTROL answers when using rfc2217

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -56,7 +56,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         else:
             host, port = proxymanager.get_host_and_port(self.port)
             if self.port.protocol == "rfc2217":
-                self.serial.port = "rfc2217://{}:{}/".format(host, port)
+                self.serial.port = "rfc2217://{}:{}?ign_set_control".format(host, port)
             elif self.port.protocol == "raw":
                 self.serial.port = "socket://{}:{}/".format(host, port)
             else:


### PR DESCRIPTION
When using non compliant servers we may get a "ValueError: remote
rejected value for option 'control'" exception.

However, since Labgrid is not using HW flow control at all, we can
safely ignore the SET_CONTROL responses.

According to pyserial documentation, this can be achieved by adding the
'ign_set_control' option in the rfc2217 URL.

Signed-off-by: Laurentiu Palcu <laurentiu.palcu@nxp.com>