### PR TITLE
driver/serialdriver: empty read result can mean connection closed by …

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -78,7 +78,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         self.serial.timeout = timeout
         res = self.serial.read(reading)
         if not res:
-            raise TIMEOUT("Timeout of %.2f seconds exceeded" % timeout)
+            raise TIMEOUT("Timeout of %.2f seconds exceeded or connection closed by peer" % timeout)
         return res
 
     def _write(self, data: bytes):


### PR DESCRIPTION
…peer

There is no straightforward way to determine if the timeout is exceeded
or the peer closed the connection (e.g. ser2net died). So adjust the
error message.

Signed-off-by: Bastian Krause <bst@pengutronix.de>