### PR TITLE
Raise minimum pytest version to 3.6 (which introduced get_closest_marker)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
         'jinja2',
         'pexpect',
         'pyserial>=3.3',
-        'pytest',
+        'pytest>=3.6',
         'pyyaml',
         'pyudev',
         'requests',


### PR DESCRIPTION
Raise the minimal pytest version to 3.6.0 which introduced get_closest_marker.

**Checklist**
- [ ] PR has been tested