### PR TITLE
remote/client: use port from NetworkService for ssh call

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,14 +3,17 @@ Release 0.3.0 (unreleased)
 
 New Features in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~
+
 - labgrid-client ``write-image`` subcommand: labgrid client now has a
   ``write-image`` command to write images onto block devices.
+- ``labgrid-client ssh`` now also uses port from NetworkService resource if
+  available
 
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------
 
-New Features
-~~~~~~~~~~~~
+New Features in 0.2.0
+~~~~~~~~~~~~~~~~~~~~~
 
 - A colored StepReporter was added and can be used with ``pytest
   --lg-colored-steps``.

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -841,6 +841,7 @@ class ClientSession(ApplicationSession):
         try:
             resource = target.get_resource(NetworkService)
             username = resource.username
+            port = resource.port or 22
             # use sshpass if we have a password
             if resource.password:
                 env['SSHPASS'] = resource.password
@@ -849,10 +850,12 @@ class ClientSession(ApplicationSession):
         except NoResourceFoundError:
             username = 'root'
             sshpass = []
+            port = 22
 
         args = sshpass + [
             'ssh',
             '-l', username,
+            '-p', str(port),
             '-o', 'StrictHostKeyChecking no',
             '-o', 'UserKnownHostsFile /dev/null',
             str(ip),


### PR DESCRIPTION
**Description**

Since PR #342 NetworkService's IP/username/password are considered for
'labgrid-client ssh'. This also adds the SSH port.

Thanks to @maximilianriemensberger for [pointing this out](https://github.com/labgrid-project/labgrid/pull/342#pullrequestreview-191191011).

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated