### PR TITLE
pytestplugin/hooks: only set coordinator if env exists

### DIFF
--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -40,8 +40,8 @@ def pytest_configure(config):
         lg_env = os.environ.get('LG_ENV')
     if lg_env is not None:
         env = Environment(config_file=lg_env)
-    if lg_coordinator is not None:
-        env.config.set_option('crossbar_url', lg_coordinator)
+        if lg_coordinator is not None:
+            env.config.set_option('crossbar_url', lg_coordinator)
     config._labgrid_env = env
 
 @pytest.hookimpl()


### PR DESCRIPTION
**Description**
This fixes

  AttributeError: 'NoneType' object has no attribute 'config'

in case --lg-coordinator is given but --lg-env (or LG_ENV) is missing.

Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [x] PR has been tested
