### PR TITLE
LED testing via sysfs

### DIFF
--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -25,3 +25,4 @@ from .networkusbstoragedriver import NetworkUSBStorageDriver
 from .resetdriver import DigitalOutputResetDriver
 from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver
+from .leddriver import LedDriver

--- a/labgrid/driver/leddriver.py
+++ b/labgrid/driver/leddriver.py
@@ -1,0 +1,36 @@
+import attr
+
+from ..factory import target_factory
+from ..protocol import LedProtocol, CommandProtocol
+from .common import Driver
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class LedDriver(Driver, LedProtocol):
+    bindings = { "command": CommandProtocol }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def led_fn(self, name):
+        return "/sys/class/leds/"+name+"/brightness"
+
+    @Driver.check_active
+    def write_brightness(self, name, val):
+        stdout, stderr, returncode = self.command.run('echo '+str(int(val))+' > "'+self.led_fn(name)+'"')
+        assert returncode == 0
+        assert not stdout
+        assert not stderr
+
+    @Driver.check_active
+    def get_brightness(self, name):
+        stdout, stderr, returncode = self.command.run('cat "'+self.led_fn(name)+'"')
+        assert returncode == 0
+        assert stdout
+        assert not stderr
+        return int(stdout[0])
+
+    @Driver.check_active
+    def set_brightness(self, name, val):
+        self.write_brightness(name, val)
+        assert int(val) == int(self.get_brightness(name))

--- a/labgrid/protocol/__init__.py
+++ b/labgrid/protocol/__init__.py
@@ -9,3 +9,4 @@ from .digitaloutputprotocol import DigitalOutputProtocol
 from .mmioprotocol import MMIOProtocol
 from .filesystemprotocol import FileSystemProtocol
 from .resetprotocol import ResetProtocol
+from .ledprotocol import LedProtocol

--- a/labgrid/protocol/ledprotocol.py
+++ b/labgrid/protocol/ledprotocol.py
@@ -1,0 +1,18 @@
+import abc
+
+class LedProtocol(abc.ABC):
+
+    """just write the brightness and check for errors"""
+    @abc.abstractmethod
+    def write_brightness(self, name, val):
+        raise NotImplementedError
+
+    """retrieve the current brightness """
+    @abc.abstractmethod
+    def get_brightness(self, name):
+        raise NotImplementedError
+
+    """set the brightness, read back and compare"""
+    @abc.abstractmethod
+    def set_brightness(self, name, val):
+        raise NotImplementedError


### PR DESCRIPTION
The driver uses CommandProtocol to run shell commands and checks the results.

* get_brightness(name, val):

    read back the current brightness of given LED

* set_brightness(name, val):

    set the brightness of a specific LED, read back and compare

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
