### PR TITLE
remote/client: let fastboot use driver functions

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -740,6 +740,12 @@ class ClientSession(ApplicationSession):
             drv = AndroidFastbootDriver(target, name=None)
         drv.fastboot.timeout = self.args.wait
         target.activate(drv)
+        if args[0] == 'flash':
+            drv.flash(args[1], args[2])
+            return
+        if args[0] == 'boot':
+            drv.boot(args[1])
+            return
         drv(*args)
 
     def bootstrap(self):


### PR DESCRIPTION
**Description**
Fix the fastboot client command to use the driver functions which use the ManagedFile.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
