### PR TITLE
Conserve bandwidth when using ManagedFile

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -405,6 +405,16 @@ To use it in conjunction with a `Resource` and a file:
    mf.sync_to_resource()
    path = mf.get_remote_path()
 
+Unless constructed with `ManagedFile(..., detect_nfs=False)`, ManagedFile
+employs the following heuristic to check if a file is on NFS and if so, foregoes
+the transfer and `get_remote_path()` just returns the local path (which is
+identical to the remote path in this case):
+
+  - check if GNU coreutils stat(1) with option --format exists on local and
+    remote system
+  - check if inode number, total size and birth/modification timestamps match
+    on local and remote system
+
 ProxyManager
 ------------
 The proxymanager is used to open connections across proxies via an attribute in

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -53,7 +53,7 @@ class ManagedFile:
         if isinstance(self.resource, NetworkResource):
             host = self.resource.host
             conn = sshmanager.open(host)
-            conn.run_command("mkdir -p {}".format(self.rpath))
+            conn.run_check("mkdir -p {}".format(self.rpath))
             conn.put_file(
                 self.local_path,
                 "{}{}".format(self.rpath, os.path.basename(self.local_path))

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -1,5 +1,7 @@
 import hashlib
+import logging
 import os
+import subprocess
 
 import attr
 
@@ -29,20 +31,15 @@ class ManagedFile:
     resource = attr.ib(
         validator=attr.validators.instance_of(Resource),
     )
+    detect_nfs = attr.ib(default=True, validator=attr.validators.instance_of(bool))
 
     def __attrs_post_init__(self):
         if not os.path.isfile(self.local_path):
             raise FileNotFoundError("Local file {} not found".format(self.local_path))
-
-        username = get_user()
-        hasher = hashlib.sha256()
-        with open(self.local_path, 'rb') as f:
-            for block in iter(lambda: f.read(1048576), b''):
-                hasher.update(block)
-        self.hash = hasher.hexdigest()
-        self.rpath = "/tmp/labgrid-{user}/{hash}/".format(
-            user=username, hash=self.hash
-        )
+        self.logger = logging.getLogger("{}".format(self))
+        self.hash = None
+        self.rpath = None
+        self._on_nfs_cached = None
 
     def sync_to_resource(self):
         """sync the file to the host specified in a resource
@@ -53,11 +50,53 @@ class ManagedFile:
         if isinstance(self.resource, NetworkResource):
             host = self.resource.host
             conn = sshmanager.open(host)
+
+            if self._on_nfs(conn):
+                return # nothing to do
+
+            self.rpath = "/tmp/labgrid-{user}/{hash}/".format(
+                user=get_user(), hash=self.get_hash()
+            )
             conn.run_check("mkdir -p {}".format(self.rpath))
             conn.put_file(
                 self.local_path,
                 "{}{}".format(self.rpath, os.path.basename(self.local_path))
             )
+
+    def _on_nfs(self, conn):
+        if self._on_nfs_cached is not None:
+            return self._on_nfs_cached
+
+        if not self.detect_nfs:
+            return False
+
+        self._on_nfs_cached = False
+
+        fmt = "inode=%i,size=%s,birth=%W,modified=%Y"
+        local = subprocess.run(["stat", "--format", fmt, self.local_path],
+                               stdout=subprocess.PIPE)
+        if local.returncode != 0:
+            self.logger.debug("local: stat: unsuccessful error code %d", local.returncode)
+            return False
+
+        remote = conn.run("stat --format '{}' {}".format(fmt, self.local_path),
+                          decodeerrors="backslashreplace")
+        if remote[2] != 0:
+            self.logger.debug("remote: stat: unsuccessful error code %d", remote[2])
+            return False
+
+        localout = local.stdout.decode("utf-8", "backslashreplace").split('\n')
+        localout.pop() # remove trailing empty element
+
+        if remote[0] != localout:
+            self.logger.debug("state: local (%s) and remote (%s) output don't match",
+                              remote[0], localout)
+            return False
+
+        self.rpath = os.path.dirname(self.local_path) + "/"
+        self._on_nfs_cached = True
+
+        return True
 
     def get_remote_path(self):
         """Retrieve the remote file path
@@ -76,4 +115,14 @@ class ManagedFile:
         Returns:
             str: SHA256 hexdigest of the file
         """
+
+        if self.hash is not None:
+            return self.hash
+
+        hasher = hashlib.sha256()
+        with open(self.local_path, 'rb') as f:
+            for block in iter(lambda: f.read(1048576), b''):
+                hasher.update(block)
+        self.hash = hasher.hexdigest()
+
         return self.hash

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -225,7 +225,7 @@ class SSHConnection:
     @_check_connected
     def put_file(self, local_file, remote_path):
         """Put a file onto the remote host"""
-        complete_cmd = ["rsync", "--copy-links", "-e",
+        complete_cmd = ["rsync", "--compress=1", "--sparse", "--copy-links", "-e",
                         " ".join(['ssh'] + self._get_ssh_args())]
         complete_cmd += [
             "{}".format(local_file),

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -3,6 +3,7 @@ import tempfile
 import logging
 import subprocess
 import os
+from select import select
 import socket
 from functools import wraps
 
@@ -191,23 +192,110 @@ class SSHConnection:
         return wrapper
 
     @_check_connected
-    def run_command(self, command):
+    def run(self, command, *, codec="utf-8", decodeerrors="strict",
+            force_tty=False, stderr_merge=False, stderr_loglevel=None,
+            stdout_loglevel=None):
+
         """Run a command over the SSHConnection
 
         Args:
             command (string): The command to run
+            codec (string, optional): output encoding. Defaults to "utf-8".
+            decodeerrors (string, optional): behavior on decode errors. Defaults
+                 to "strict". Refer to stdtypes' bytes.decode for details.
+            force_tty (bool, optional): force allocate a tty (ssh -tt). Defaults
+                 to False
+            stderr_merge (bool, optional): merge ssh subprocess stderr into
+                 stdout. Defaults to False.
+            stdout_loglevel (int, optional): log stdout with specific log level
+                 as well. Defaults to None, i.e. don't log.
+            stderr_loglevel (int, optional): log stderr with specific log level
+                 as well. Defaults to None, i.e. don't log.
+
+        returns:
+            (stdout, stderr, returncode)
+        """
+
+        complete_cmd = ["ssh"] + self._get_ssh_args()
+        if force_tty:
+            complete_cmd += ["-tt"]
+        complete_cmd += [self.host, command]
+        self._logger.debug("Sending command: %s", complete_cmd)
+        if stderr_merge:
+            stderr_pipe = subprocess.STDOUT
+        else:
+            stderr_pipe = subprocess.PIPE
+        try:
+            sub = subprocess.Popen(
+                complete_cmd, stdout=subprocess.PIPE, stderr=stderr_pipe,
+                stdin=subprocess.DEVNULL
+            )
+        except:
+            raise ExecutionError(
+                "error executing command: {}".format(complete_cmd)
+            )
+
+        stdout = []
+        stderr = []
+
+        readable = {
+            sub.stdout.fileno(): (sub.stdout, stdout, stdout_loglevel),
+        }
+
+        if sub.stderr is not None:
+            readable[sub.stderr.fileno()] = (sub.stderr, stderr, stderr_loglevel)
+
+        while readable:
+            for fd in select(readable, [], [])[0]:
+                stream, output, loglevel = readable[fd]
+                line = stream.readline().decode(codec, decodeerrors)
+                if line == "": # EOF
+                    del readable[fd]
+                else:
+                    line = line.rstrip('\n')
+                    output.append(line)
+                    if loglevel is not None:
+                        self._logger.log(loglevel, line)
+
+        return stdout, stderr, sub.wait()
+
+    def run_check(self, command, *, codec="utf-8", decodeerrors="strict",
+        force_tty=False, stderr_merge=False, stderr_loglevel=None,
+        stdout_loglevel=None):
+        """
+        Runs a command over the SSHConnection
+        returns the output if successful, raises ExecutionError otherwise.
+
+        Except for the means of returning the value, this is equivalent to
+        run.
+
+        Args:
+            command (string): The command to run
+            codec (string, optional): output encoding. Defaults to "utf-8".
+            decodeerrors (string, optional): behavior on decode errors. Defaults
+                 to "strict". Refer to stdtypes' bytes.decode for details.
+            force_tty (bool, optional): force allocate a tty (ssh -tt). Defaults
+                 to False
+            stderr_merge (bool, optional): merge ssh subprocess stderr into
+                 stdout. Defaults to False.
+            stdout_loglevel (int, optional): log stdout with specific log level
+                 as well. Defaults to None, i.e. don't log.
+            stderr_loglevel (int, optional): log stderr with specific log level
+                 as well. Defaults to None, i.e. don't log.
 
         Returns:
-            int: exitcode of the command
-        """
-        complete_cmd = ["ssh"] + self._get_ssh_args()
-        complete_cmd += [self.host, command]
-        res = subprocess.check_call(
-            complete_cmd,
-            stdin=subprocess.DEVNULL,
-        )
+            List[str]: stdout of the executed command if successful and
+                       otherwise an ExecutionError Exception
 
-        return res
+        """
+        stdout, stderr, exitcode = self.run(command, codec=codec,
+                decodeerrors=decodeerrors, force_tty=force_tty,
+                stderr_merge=stderr_merge, stdout_loglevel=stdout_loglevel,
+                stderr_loglevel=stderr_loglevel)
+
+        if exitcode != 0:
+            raise ExecutionError(command, stdout, stderr)
+        return stdout
 
     @_check_connected
     def get_file(self, remote_file, local_file):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -271,12 +271,26 @@ Test
 """
     )
     hash = hashlib.sha256(t.read().encode("utf-8")).hexdigest()
-    mf = ManagedFile(t, res)
+    mf = ManagedFile(t, res, detect_nfs=False)
     mf.sync_to_resource()
 
     assert os.path.isfile("/tmp/labgrid-{}/{}/test".format(getpass.getuser(), hash))
     assert hash == mf.get_hash()
     assert "/tmp/labgrid-{}/{}/test".format(getpass.getuser(), hash) == mf.get_remote_path()
+
+@pytest.mark.localsshmanager
+def test_remote_managedfile_on_nfs(target, tmpdir):
+    res = NetworkResource(target, "test", "localhost")
+    t = tmpdir.join("test")
+    t.write(
+"""
+Test
+"""
+    )
+    mf = ManagedFile(t, res, detect_nfs=True)
+    mf.sync_to_resource()
+
+    assert str(t) == mf.get_remote_path()
 
 def test_local_managedfile(target, tmpdir):
     import hashlib
@@ -289,7 +303,7 @@ Test
 """
     )
     hash = hashlib.sha256(t.read().encode("utf-8")).hexdigest()
-    mf = ManagedFile(t, res)
+    mf = ManagedFile(t, res, detect_nfs=False)
     mf.sync_to_resource()
 
     assert hash == mf.get_hash()


### PR DESCRIPTION
This PR aims at improving user experience with ManagedFile:

* use `rsync --compress=1 --sparse` to speed up sparse file upload
* heuristic for determining file is on NFS and foregoing the preceding transfer if it is

**What I intend to use this feature for:**

Save time when using labgrid-client.

**How does labgrid benefit as a testing library from the feature?**

The added `run`/`run_check` command can be used in tests where running commands on the exporter system is required. 

**How did you verify the feature works?**

I included some tests.

**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 

<!---
A library feature which other developers can use:
--->
- [x] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
