### PR TITLE
managedfile: change upload directory to /var/cache/labgrid

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - ssh -o StrictHostKeyChecking=no localhost echo OK
 install:
   - pip install -r travis-requirements.txt
+  - sudo mkdir /var/cache/labgrid && sudo chmod 1775 /var/cache/labgrid && sudo chown root:travis /var/cache/labgrid
 script:
   - pip install -e .
   - pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,17 @@ New Features in 0.3.0
 - ``labgrid-client ssh`` now also uses port from NetworkService resource if
   available
 
+Breaking changes in 0.3.0
+~~~~~~~~~~~~~~~~~~~~~~~~~
+- `ManagedFile` now saves the files in a different directory on the exporter.
+  Previously ``/tmp`` was used, labgrid now uses ``/var/cache/labgrid``.
+  A tmpfiles example configuration for systemd is provided in the ``/contrib``
+  directory.
+  It is also highly recommended to enable ``fs.protected_regular=1`` and
+  ``fs.protected_fifos=1`` for kernels>=4.19.
+  This requires user intervention after the upgrade to create the directory and
+  setup the cleanup job.
+
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------
 

--- a/contrib/systemd/tmpfiles.d/labgrid.conf
+++ b/contrib/systemd/tmpfiles.d/labgrid.conf
@@ -1,0 +1,7 @@
+# Labgrid saves files uploaded to the exporter in /var/cache
+# This configuration file creates the directory and is meant as a starting point
+# it is advised to at least change the group from the default for your
+# environment
+# Path			Mode	UID	GID	Age Argument
+d /var/cache/labgrid	1775	root	users	-
+e /var/cache/labgrid/*	-	-	-	2d

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -238,11 +238,17 @@ Additional groups and resources can be added:
 Restart the exporter to activate the new configuration.
 
 .. Attention::
-   The `ManagedFile` will create temporary uploads in the exporters ``/tmp``
-   filesystem. It is recommended to install a cron job or systemd timer to
-   remove old temporary files. All uploads done by labgrid are stored in the
-   ``/tmp/labgrid`` directory.
+   The `ManagedFile` will create temporary uploads in the exporters
+   ``/var/cache/labgrid`` directory. This directory needs to be created manually
+   and should allow write access for users. The ``/contrib`` directory in the
+   labgrid-project contains a tmpfiles configuration example to automatically
+   create and clean the directory.
+   It is also highly recommended to enable ``fs.protected_regular=1`` and
+   ``fs.protected_fifos=1`` for kernels>=4.19, to protect the users from opening
+   files not owned by them in world writeable sticky directories.
+   For more information see `this kernel commit`_.
 
+.. _`this kernel commit`: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=30aba6656f
 
 Client
 ~~~~~~

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -54,7 +54,7 @@ class ManagedFile:
             if self._on_nfs(conn):
                 return # nothing to do
 
-            self.rpath = "/tmp/labgrid-{user}/{hash}/".format(
+            self.rpath = "/var/cache/labgrid/{user}/{hash}/".format(
                 user=get_user(), hash=self.get_hash()
             )
             conn.run_check("mkdir -p {}".format(self.rpath))

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -274,9 +274,9 @@ Test
     mf = ManagedFile(t, res, detect_nfs=False)
     mf.sync_to_resource()
 
-    assert os.path.isfile("/tmp/labgrid-{}/{}/test".format(getpass.getuser(), hash))
+    assert os.path.isfile("/var/cache/labgrid/{}/{}/test".format(getpass.getuser(), hash))
     assert hash == mf.get_hash()
-    assert "/tmp/labgrid-{}/{}/test".format(getpass.getuser(), hash) == mf.get_remote_path()
+    assert "/var/cache/labgrid/{}/{}/test".format(getpass.getuser(), hash) == mf.get_remote_path()
 
 @pytest.mark.localsshmanager
 def test_remote_managedfile_on_nfs(target, tmpdir):


### PR DESCRIPTION
**Description**
Move the cache directory for managedfile uploads to `/var/cache/labgrid` and also provide a configuration example in contrib.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] CHANGES.rst has been updated
- [x] PR has been tested