### PR TITLE
docker: coordinator: fix port number

### DIFF
--- a/docker/README.rst
+++ b/docker/README.rst
@@ -96,7 +96,7 @@ Start it with something like:
 
    $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws \
        -v $HOME/exporter-conf:/opt/conf \
-	 labgrid-coordinator
+	 labgrid-exporter
 
 If using ser2net,
 the devices needed must be added to Docker container

--- a/docker/coordinator/Dockerfile
+++ b/docker/coordinator/Dockerfile
@@ -8,7 +8,7 @@ RUN cd /opt/labgrid \
  && python setup.py install
 
 VOLUME /opt/crossbar
-EXPOSE 40208
+EXPOSE 20408
 
 ENV CROSSBAR_DIR=/opt/crossbar
 CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]


### PR DESCRIPTION
The default port for coordinator, defined in crossbar configuration
file, is 20408.

Signed-off-by: Andreas Schmidt <mail@schmidt-andreas.de>
