### PR TITLE
Allow use of Python3.7 features

### DIFF
--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER eha@deif.com
 
 RUN mkdir -p /opt/labgrid

--- a/docker/coordinator/Dockerfile
+++ b/docker/coordinator/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER eha@deif.com
 
 RUN mkdir -p /opt/labgrid

--- a/docker/exporter/Dockerfile
+++ b/docker/exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 MAINTAINER eha@deif.com
 
 RUN mkdir -p /opt/labgrid

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36
+envlist = py35, py36, py37
 
 [testenv]
 deps = -rdev-requirements.txt


### PR DESCRIPTION
Signed-off-by: Anders Gammelgaard <anga@triax.com>

**Description**

Python 3.7 has new asyncio-based features. To use these together with labgrid from within a docker container, it helps to base the container on Python 3.7. This is easy to accomplish if labgrid can use Python 3.7 directly. This seems to be the case already for the tip of master and only needs to be stated explicitly. Besides, the 3.7 version should be used in relevant places - in particular docker. There may be more places, however, than I am aware of.

**Checklist**
Added new tox.ini environment py37 and ``tox -r`` seems to run flawlessly.

Summary for CHANGES.rst file:
- docker images for client, exporter and coordinator will now use Python3.7.
