### PR TITLE
Modbus coil power driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ New Features in 0.3.0
 - labgrid-client ``write-image`` subcommand: labgrid client now has a
   ``write-image`` command to write images onto block devices.
 
+New and Updated Drivers in 0.3.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- The new `ModbusTCPCoilPowerDriver` supports power management over ModbusTCP.
+
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -968,6 +968,26 @@ Arguments:
   - cycle (str): optional command to switch the board off and on
   - delay (float): configurable delay in seconds between off and on if cycle is not set
 
+ModbusTCPCoilPowerDriver
+~~~~~~~~~~~~~~~~~~~~~~~~
+A ModbusTCPCoilPowerDriver controls a `ModbusTCPCoil`, allowing control of the
+target power state without user ineraction.
+
+Binds to:
+    coil:
+      - `ModbusTCPCoil`_
+
+Implements:
+  - :any:`PowerProtocol`
+
+.. code-block:: yaml
+
+    ModbusTCPCoilPowerDriver:
+      delay: 5.0
+
+Arguments:
+  - delay (float): optional delay in seconds between off and on
+
 NetworkPowerDriver
 ~~~~~~~~~~~~~~~~~~
 A NetworkPowerDriver controls a `NetworkPowerPort`, allowing control of the

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -624,9 +624,10 @@ class ClientSession(ApplicationSession):
         action = self.args.action
         delay = self.args.delay
         target = self._get_target(place)
-        from ..driver.powerdriver import NetworkPowerDriver, USBPowerDriver
+        from ..driver.powerdriver import NetworkPowerDriver, USBPowerDriver, ModbusTCPCoilPowerDriver
         from ..resource.power import NetworkPowerPort
         from ..resource.remote import NetworkUSBPowerPort
+        from ..resource.modbus import ModbusTCPCoil
         drv = None
         for resource in target.resources:
             if isinstance(resource, NetworkPowerPort):
@@ -640,6 +641,12 @@ class ClientSession(ApplicationSession):
                     drv = target.get_driver(USBPowerDriver)
                 except NoDriverFoundError:
                     drv = USBPowerDriver(target, name=None, delay=delay)
+                break
+            elif isinstance(resource, ModbusTCPCoil):
+                try:
+                    drv = target.get_driver(ModbusTCPCoilPowerDriver)
+                except NoDriverFoundError:
+                    drv = ModbusTCPCoilPowerDriver(target, name=None, delay=delay)
                 break
         if not drv:
             raise UserError("target has no compatible resource available")


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

This PR add power driver for ModbusTCP Coil.

I tested it on WAGO PFC200-8215 PLC with DigitalOutput as ModbusTCP-Client.
- First test was using ModbusTCPCoilPowerDriver in a local test python script.
- Second test was labgrid-client power on/off.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
