### PR TITLE
travis: remove python directive for docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ after_success:
 matrix:
   include:
     - stage: docker
-      python: "3.7"
       services:
         - docker
       script: ./docker/build.sh


### PR DESCRIPTION
Fixes the docker build. It still shows a python version, probably from the main configuration.