### PR TITLE
contrib: tmpfiles: fix tmpfiles directives

### DIFF
--- a/contrib/systemd/tmpfiles.d/labgrid.conf
+++ b/contrib/systemd/tmpfiles.d/labgrid.conf
@@ -3,5 +3,4 @@
 # it is advised to at least change the group from the default for your
 # environment
 # Path			Mode	UID	GID	Age Argument
-d /var/cache/labgrid	1775	root	users	-
-e /var/cache/labgrid/*	-	-	-	2d
+d /var/cache/labgrid	1775	root	users	2d


### PR DESCRIPTION
Merge the two lines in the configuration into one.

**Description**
The tmpfiles configuration had two lines which could be merged, merge those.
