### PR TITLE
treewide: fix is not with literal

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -63,7 +63,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         self.process = subprocess.Popen(args, env=env)
 
         try:
-            if self.process.wait(timeout=30) is not 0:
+            if self.process.wait(timeout=30) != 0:
                 raise ExecutionError(
                     "failed to connect to {} with {} and {}".
                     format(self.networkservice.address, args, self.process.wait())
@@ -169,7 +169,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             raise ExecutionError(
                 "error executing command: {}".format(transfer_cmd)
             )
-        if sub is not 0:
+        if sub != 0:
             raise ExecutionError(
                 "error executing command: {}".format(transfer_cmd)
             )
@@ -193,7 +193,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             raise ExecutionError(
                 "error executing command: {}".format(transfer_cmd)
             )
-        if sub is not 0:
+        if sub != 0:
             raise ExecutionError(
                 "error executing command: {}".format(transfer_cmd)
             )

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -419,7 +419,7 @@ class SSHConnection:
         )
 
         try:
-            if self._master.wait(timeout=30) is not 0:
+            if self._master.wait(timeout=30) != 0:
                 raise ExecutionError(
                     "failed to connect to {} with args {}, returncode={} {},{} ".format(
                         self.host, args, self._master.wait(),


### PR DESCRIPTION
**Description**
Python3.8 reports a SyntaxWarning for "is not" usage with literals.
Replace the "is not" with "!=".

**Checklist**
- [x] Tests for the feature 