### PR TITLE
Make UBootDriver's autoboot string configurable

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -750,6 +750,7 @@ Implements:
 
 Arguments:
   - prompt (regex): u-boot prompt to match
+  - autoboot (regex, default="stop autoboot"): autoboot message to match
   - password (str): optional, u-boot unlock password
   - interrupt (str, default="\\n"): string to interrupt autoboot (use "\\x03" for CTRL-C)
   - init_commands (tuple): tuple of commands to execute after matching the

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -33,6 +33,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     """
     bindings = {"console": ConsoleProtocol, }
     prompt = attr.ib(default="", validator=attr.validators.instance_of(str))
+    autoboot = attr.ib(default="stop autoboot", validator=attr.validators.instance_of(str))
     password = attr.ib(default="", validator=attr.validators.instance_of(str))
     interrupt = attr.ib(default="\n", validator=attr.validators.instance_of(str))
     init_commands = attr.ib(default=attr.Factory(tuple), convert=tuple)
@@ -147,7 +148,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """
         self.console.expect(self.boot_expression, timeout=self.login_timeout)
         index, _, _, _ = self.console.expect(
-            [self.prompt, "stop autoboot", self.password_prompt]
+            [self.prompt, self.autoboot, self.password_prompt]
         )
         if index == 0:
             self._status = 1


### PR DESCRIPTION
**Description**
In UBootDriver, make the hardwired string "stop autoboot" that is supposed to match the message about stopping U-Boot's autoboot configurable as a new attribute "autoboot".
Use the old value as a default.
This is implemented in the same way by the BareboxDriver.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #402.