### PR TITLE
Add a GpioDigitalOutputDriver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Release 0.3.0 (unreleased)
 New Features in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~
 
+- The new `GpioDigitalOutputDriver` controls the state of a GPIO via libgpiod.
 - The InfoDriver was removed. The functions have been integrated into the
   labgridhelper library, please use the library for the old functionality.
 - labgrid-client ``write-image`` subcommand: labgrid client now has a

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1028,6 +1028,25 @@ Implements:
 Arguments:
   - delay (float): optional delay in seconds between off and on
 
+GpioDigitalOutputDriver
+~~~~~~~~~~~~~~~~~~~~~~~
+The GpioDigitalOutputDriver writes a digital signal to a GPIO line.
+
+This driver uses the libgpiod python bindings.
+Make sure to have them installed.
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   GpioDigitalOutputDriver:
+     offset: 42
+
+Arguments:
+  - chip (str): A GPIO device's path, name, label or number (default: "0")
+  - offset (int): The offset to a GPIO line
+
 SerialPortDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The SerialPortDigitalOutputDriver makes it possible to use a UART

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -22,5 +22,6 @@ from .modbusdriver import ModbusCoilDriver
 from .sigrokdriver import SigrokDriver
 from .networkusbstoragedriver import NetworkUSBStorageDriver
 from .resetdriver import DigitalOutputResetDriver
+from .gpiodriver import GpioDigitalOutputDriver
 from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver

--- a/labgrid/driver/gpiodriver.py
+++ b/labgrid/driver/gpiodriver.py
@@ -1,0 +1,51 @@
+"""All GPIO-related drivers"""
+import attr
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol
+from ..step import step
+from .common import Driver
+
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class GpioDigitalOutputDriver(Driver, DigitalOutputProtocol):
+    """
+    Controls the state of a GPIO using libgpiod.
+
+    Takes a string property 'chip' which refers to the GPIO device.
+    You can use its path, name, label or number (default: 0).
+    The offset to the GPIO line is set by the integer property 'offset'.
+    """
+
+    bindings = {}
+    offset = attr.ib(validator=attr.validators.instance_of(int))
+    chip = attr.ib(default="0", validator=attr.validators.instance_of(str))
+    gpio_chip = None
+    gpio_state = True
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def on_activate(self):
+        import gpiod
+        self.gpio_chip = gpiod.Chip(self.chip)
+        gpio_line = self.gpio_chip.get_line(self.offset)
+        gpio_line.request("labgrid", gpiod.LINE_REQ_DIR_OUT)
+
+    def on_deactivate(self):
+        gpio_line = self.gpio_chip.get_line(self.offset)
+        gpio_line.release()
+        self.gpio_chip.close()
+
+    @Driver.check_active
+    @step()
+    def get(self):
+        return self.gpio_state
+
+    @Driver.check_active
+    @step()
+    def set(self, status):
+        gpio_line = self.gpio_chip.get_line(self.offset)
+        gpio_line.set_value(int(status))
+        self.gpio_state = status


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
This PR is a follow-up on #234. It adds GpioDigitalOutputDriver which uses libgpiod to write a digital signal to a GPIO line.
The minimum requirement to use libgpiod's kernel interface is Linux 4.8.
The python binding is quite new and neither commonly available in Linux distributions nor on PyPI, so import it only on usage.
I tested it in combination with DigitalOutputPowerDriver on a Banana PI which uses a GPIO line to power a connected device.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested