### PR TITLE
Add a FileDigitalOutputDriver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Release 0.3.0 (unreleased)
 New Features in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~
 
+- The new `FileDigitalOutputDriver` respresents a digital signal with a file.
 - The new `GpioDigitalOutputDriver` controls the state of a GPIO via the sysfs interface.
 - Crossbar and autobahn have been updated to 19.3.3 and 19.3.5 respectively.
 - The InfoDriver was removed. The functions have been integrated into the

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1130,6 +1130,32 @@ Arguments:
     SerialDriver in your environment (what is likely to be the case
     if you are using this driver).
 
+FileDigitalOutputDriver
+~~~~~~~~~~~~~~~~~~~~~~~
+The FileDigitalOutputDriver uses a file
+to write arbitrary string representations of booleans
+to a file and read from it.
+
+The file is checked to exist at configuration time.
+
+If the file's content does not match any of the representations
+reading defaults to False.
+
+A prime example for using this driver is Linux's sysfs.
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   FileDigitalOutputDriver:
+     filepath: "/sys/class/leds/myled/brightness"
+
+Arguments:
+  - filepath (str): A file that is used for reads and writes.
+  - false_repr (str): A representation for False (default: "0\n")
+  - true_repr (str): A representation for True (default: "1\n")
+
 ModbusCoilDriver
 ~~~~~~~~~~~~~~~~
 A ModbusCoilDriver controls a `ModbusTCPCoil` resource.

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -24,5 +24,6 @@ from .sigrokdriver import SigrokDriver
 from .networkusbstoragedriver import NetworkUSBStorageDriver, Mode
 from .resetdriver import DigitalOutputResetDriver
 from .gpiodriver import GpioDigitalOutputDriver
+from .filedigitaloutput import FileDigitalOutputDriver
 from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver

--- a/labgrid/driver/filedigitaloutput.py
+++ b/labgrid/driver/filedigitaloutput.py
@@ -1,0 +1,46 @@
+import os
+
+import attr
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol
+from ..step import step
+from .common import Driver
+
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class FileDigitalOutputDriver(Driver, DigitalOutputProtocol):
+    """
+    Two arbitrary string values false_repr and true_repr
+    are defined as representations for False and True.
+    These values are written to a file and read from it.
+    If the file's content does not match any of the
+    representations it defaults to False.
+    A prime example for using this driver is Linux's sysfs.
+    """
+
+    bindings = {}
+    filepath = attr.ib(validator=attr.validators.instance_of(str))
+    false_repr = attr.ib(default='0\n', validator=attr.validators.instance_of(str))
+    true_repr = attr.ib(default='1\n', validator=attr.validators.instance_of(str))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        if not os.path.isfile(self.filepath):
+            raise Exception("{} is not a file.".format(self.filepath))
+
+    @Driver.check_active
+    @step()
+    def get(self):
+        with open(self.filepath) as fdes:
+            from_file = fdes.read()
+        return from_file == self.true_repr
+
+    @Driver.check_active
+    @step()
+    def set(self, status):
+        out = self.true_repr if status else self.false_repr
+        with open(self.filepath, "w") as fdes:
+            fdes.write(out)

--- a/tests/test_filedigitaloutput.py
+++ b/tests/test_filedigitaloutput.py
@@ -1,0 +1,31 @@
+import pytest
+import mock
+
+from labgrid.driver import FileDigitalOutputDriver
+
+def test_filedigital_instance(target, mocker):
+    m_isfile = mocker.patch('os.path.isfile', return_value=True)
+    d = FileDigitalOutputDriver(target, name=None, filepath='/dev/null')
+    target.activate(d)
+    assert isinstance(d, FileDigitalOutputDriver)
+    m_isfile.assert_called_once_with('/dev/null')
+
+def test_filedigital_set(target, mocker):
+    m_isfile = mocker.patch('os.path.isfile', return_value=True)
+    m_open = mocker.patch('builtins.open', mock.mock_open())
+    d = FileDigitalOutputDriver(target, name=None, filepath='/dev/null')
+    target.activate(d)
+    d.set(True)
+    m_isfile.assert_called_once_with('/dev/null')
+    m_open.assert_called_once_with('/dev/null', 'w')
+    m_open.return_value.write.assert_called_once_with('1\n')
+
+def test_filedigital_get(target, mocker):
+    m_isfile = mocker.patch('os.path.isfile', return_value=True)
+    m_open = mocker.patch('builtins.open', mock.mock_open(read_data='1\n'))
+    d = FileDigitalOutputDriver(target, name=None, filepath='/dev/null')
+    target.activate(d)
+    assert d.get() is True
+    m_isfile.assert_called_once_with('/dev/null')
+    m_open.assert_called_once_with('/dev/null')
+    m_open.return_value.read.assert_called_once()


### PR DESCRIPTION
**Description**
This PR adds a FileDigitalOutputDriver. It writes arbitrary string representations of booleans to a file and reads string representations from it.

I tested it with a led available in sysfs.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested
