### PR TITLE
Update crossbar and fix authid

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,7 @@ Release 0.3.0 (unreleased)
 New Features in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~
 
+- Crossbar and autobahn have been updated to 19.3.3 and 19.3.5 respectively.
 - The InfoDriver was removed. The functions have been integrated into the
   labgridhelper library, please use the library for the old functionality.
 - labgrid-client ``write-image`` subcommand: labgrid client now has a

--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -1,5 +1,6 @@
 -r requirements.txt
 setuptools>=38.0.0
-crossbar==18.12.1
+crossbar==19.3.5
 # For crossbar
 idna==2.5
+msgpack==0.6.1

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -57,8 +57,8 @@ class ClientSession(ApplicationSession):
         self.monitor = self.config.extra.get('monitor', False)
         enable_tcp_nodelay(self)
         self.join(
-            self.config.realm, ["ticket"],
-            "client/{}/{}".format(gethostname(), getuser())
+            self.config.realm, authmethods=["ticket"],
+            authid="client/{}/{}".format(gethostname(), getuser())
         )
 
     def onChallenge(self, challenge):

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -318,14 +318,14 @@ class ExporterSession(ApplicationSession):
         self.name = self.config.extra['name']
         self.hostname = self.config.extra['hostname']
         self.isolated = self.config.extra['isolated']
-        self.authid = "exporter/{}".format(self.name)
         self.address = self._transport.transport.get_extra_info('sockname')[0]
         self.poll_task = None
 
         self.groups = {}
 
         enable_tcp_nodelay(self)
-        self.join(self.config.realm, ["ticket"], self.authid)
+        self.join(self.config.realm, authmethods=["ticket"], authid="exporter/{}".format(
+            self.name))
 
     def onChallenge(self, challenge):
         """Function invoked on received challege, returns just a dummy ticket

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ pytest==4.0.2
 pyudev==0.21.0
 requests==2.19.1
 xmodem==0.4.5
-autobahn==18.12.1
-PyYAML==3.13
+autobahn==19.3.3
+PyYAML==5.1
 ansicolors==1.1.8


### PR DESCRIPTION
**Description**
Update Crossbar and autobahn to the latest released versions. We are currently seeing a bug in out setup which results in the following log output:
```
Apr 01 09:23:16 labgrid crossbar[27698]: [Router      27705] INTERNAL WARNING: event for publication 1671249291329997 not in event store
Apr 01 09:23:16 labgrid crossbar[27698]: [Router      27705] INTERNAL WARNING: subscription 3503552087680833 for publication 1671249291329997 not in event store
```
A similar bugreport upstream (crossbario/crossbar#1459) has been closed as not reproducible on an updated version, so this bump should fix the bug.
**Checklist**
- [x] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #406
