### PR TITLE
setup.py: add labgrid.util.agents

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
         'labgrid.resource',
         'labgrid.strategy',
         'labgrid.util',
+        'labgrid.util.agents',
     ],
     # the following makes a plugin available to pytest
     entry_points={


### PR DESCRIPTION
PR #397 introduced new Python module `labgrid.util.agents`. The module wasn't entered into `setup.py`, however.

When I use `tox -r` to test tip of master (currently commit 897b3a5), two tests in `tests/test_agent.py` fail. But with the proposed change all tests pass.

I have no idea why Travis didn't catch this error.