### PR TITLE
driver/usbvideodriver: fix: select correct camera for stream

### DIFF
--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -39,7 +39,7 @@ class USBVideoDriver(Driver):
         caps = self.select_caps(caps_hint)
 
         tx_cmd = self.video.command_prefix + ["gst-launch-1.0"]
-        tx_cmd += "v4l2src ! {} ! h264parse ! fdsink".format(caps).split()
+        tx_cmd += "v4l2src device={} ! {} ! h264parse ! fdsink".format(self.video.path, caps).split()
         rx_cmd = ["gst-launch-1.0"]
         rx_cmd += "fdsrc ! h264parse ! avdec_h264 ! glimagesink sync=false".split()
 


### PR DESCRIPTION
The default device of v4l2src is /dev/video0. If the device is not specified and more than
one camera is connected, the default camera video0 will always be used.
The fix uses the devices video path to get the correct video device.

Tested with 2 cameras:
Without the fix:
labgrid-client -p board-1 video -> returns the stream of board-1
labgrid-client -p board-2 video -> returns the stream of board-1

With the fix:
labgrid-client -p board-1 video -> returns the stream of board-1
labgrid-client -p board-2 video -> returns the stream of board-2

**Checklist**
- [x] PR has been tested


