### PR TITLE
drivers: fastbootdriver: fix flashing and allow booting of preconfigured images

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,8 +18,8 @@ New Features in 0.4.0
 - Network controlled relay providing GET/PUT based REST API
 - Improved LG_PROXY documentation in docs/usage.rst.
 - Exporter now checks /usr/sbin/ser2net for SerialPortExport
-- AndroidFastbootDriver now supports booting images preconfigured in the
-  environment configuration.
+- AndroidFastbootDriver now supports booting/flashing images preconfigured in
+  the environment configuration.
 
 Bug fixes in 0.4.0
 ~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Features in 0.4.0
 - Network controlled relay providing GET/PUT based REST API
 - Improved LG_PROXY documentation in docs/usage.rst.
 - Exporter now checks /usr/sbin/ser2net for SerialPortExport
+- AndroidFastbootDriver now supports booting images preconfigured in the
+  environment configuration.
 
 Bug fixes in 0.4.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1411,7 +1411,7 @@ Implements:
      sparse_size: 100M
 
 Arguments:
-  - image (str): optional, filename of an image to upload to the device
+  - boot_image (str): image key referring to the image to boot
   - sparse_size (str): optional, sparse files greater than given size (see
     fastboot manpage -S option for allowed size suffixes). The default is the
     same as the fastboot default, which is computed after querying the target's

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1412,6 +1412,8 @@ Implements:
 
 Arguments:
   - boot_image (str): image key referring to the image to boot
+  - flash_images (dict): partition to image key mapping referring to images to
+    flash to the device
   - sparse_size (str): optional, sparse files greater than given size (see
     fastboot manpage -S option for allowed size suffixes). The default is the
     same as the fastboot default, which is computed after querying the target's

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -99,6 +99,12 @@ class AndroidFastbootDriver(Driver):
         self("flash", partition, mf.get_remote_path())
 
     @Driver.check_active
+    @step()
+    def flash_all(self):
+        for partition in self.flash_images.keys():
+            self.flash(partition)
+
+    @Driver.check_active
     @step(args=['cmd'])
     def run(self, cmd):
         self("oem", "exec", "--", cmd)


### PR DESCRIPTION
**Description**
This fixes and improves ways to use preconfigured images in the yaml config for the AndroidFastbootDriver.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [x] CHANGES.rst has been updated
- [x] PR has been tested

