### PR TITLE
SSHDriver/ShellDriver: make keyfile paths consistent with image paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ New Features in 0.3.0
   available
 - The SSHDriver's keyfile attribute is now specified relative to the config
   file just like the images are.
+- The ShellDriver's keyfile attribute is now specified relative to the config
+  file just like the images are.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ New Features in 0.3.0
   ``write-image`` command to write images onto block devices.
 - ``labgrid-client ssh`` now also uses port from NetworkService resource if
   available
+- The SSHDriver's keyfile attribute is now specified relative to the config
+  file just like the images are.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -59,8 +59,14 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         if self._status == 0:
             self._await_login()
             self._inject_run()
+
         if self.keyfile:
-            self._put_ssh_key(self.keyfile)
+            keyfile_path = self.keyfile
+            if self.target.env:
+                keyfile_path = self.target.env.config.resolve_path(self.keyfile)
+
+            self._put_ssh_key(keyfile_path)
+
         # Turn off Kernel Messages to the console
         self._run("dmesg -n 1")
 

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -32,8 +32,11 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def on_activate(self):
         self.ssh_prefix = "-o LogLevel=ERROR"
-        self.ssh_prefix += " -i {}".format(os.path.abspath(self.keyfile)
-                                          ) if self.keyfile else ""
+        if self.keyfile:
+            keyfile_path = self.keyfile
+            if self.target.env:
+                keyfile_path = self.target.env.config.resolve_path(self.keyfile)
+            self.ssh_prefix += " -i {}".format(keyfile_path)
         self.ssh_prefix += " -o PasswordAuthentication=no" if (
             not self.networkservice.password) else ""
         self.control = self._check_master()


### PR DESCRIPTION
**Description**
The keyfile path is given relative to the current working directory,
whereas the images are given relative to the config.

Handle the keyfile path just like the image paths to gain consistency.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated
