### PR TITLE
driver: fastbootdriver: allow setting sparse option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -875,9 +875,12 @@ Implements:
 
    AndroidFastbootDriver:
      image: mylocal.image
+     sparse_size: 100M
 
 Arguments:
   - image (str): filename of the image to upload to the device
+  - sparse_size (str): optional, sparse files greater than given size (see
+    fastboot manpage -S option for allowed size suffixes)
 
 OpenOCDDriver
 ~~~~~~~~~~~~~

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -18,6 +18,7 @@ class AndroidFastbootDriver(Driver):
     }
 
     image = attr.ib(default=None)
+    sparse_size = attr.ib(default='0', validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -32,6 +33,7 @@ class AndroidFastbootDriver(Driver):
             self.tool,
             "-i", hex(self.fastboot.vendor_id),
             "-s", "usb:{}".format(self.fastboot.path),
+            "-S", self.sparse_size,
         ]
 
     def on_activate(self):


### PR DESCRIPTION
**Description**
Always set fastboot's '-S' option with given value. fastboot ignores the
option for non-image commands and in case the image size is smaller than
the given sparse size. Default is to disable sparse support altogether
(as before).

Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated