### PR TITLE
driver: fastbootdriver: echo command before executing it on run()

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -61,7 +61,10 @@ class AndroidFastbootDriver(Driver):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run(self, cmd):
+    def run(self, cmd, *, echo_cmd=False):
+        if echo_cmd:
+            self("oem", "exec", "--", "echo {}".format(cmd))
+
         self("oem", "exec", "--", cmd)
 
     @Driver.check_active


### PR DESCRIPTION
**Description**
The output of commands executed via 'fastboot oem exec <cmd>' cannot be
seen on the host. The command itself cannot be seen via serial on the
barebox shell.

This adds the possibility to echo the command before executing it. This
allows to see which commands lead to which (error) messages on the
serial interface without looking at labgrid's log files. This is
especially useful for scenarios without a SerialDriver, but with a
non-regular serial terminal connected for debugging only.

Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested