### PR TITLE
driver: fastboot: return fastboot output on __call__()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features in 0.3.0
   ``write-image`` command to write images onto block devices.
 - ``labgrid-client ssh`` now also uses port from NetworkService resource if
   available
+- AndroidFastbootDriver's __call__() now returns cleaned stdout/stderr of the
+  fastboot command executed.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -43,7 +43,13 @@ class AndroidFastbootDriver(Driver):
     @Driver.check_active
     @step(title='call', args=['args'])
     def __call__(self, *args):
-        subprocess.check_call(self._get_fastboot_prefix() + list(args))
+        # unfortunately fastboot uses stderr for normal output
+        proc = subprocess.run(self._get_fastboot_prefix() + list(args), stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT, check=True, universal_newlines=True)
+        stdout = proc.stdout.split('\n')
+        out_prefix = '(bootloader) '
+        # ignore lines with status and timing information, also remove message prefix
+        return list(line[len(out_prefix):] for line in stdout if line.startswith(out_prefix))
 
     @Driver.check_active
     @step(args=['filename'])


### PR DESCRIPTION
**Description**
Some fastboot commands print output to stdout/stderr, e.g.:

- fastboot getvar
- fastboot getvar all
- fastboot oem getenv

In order to use these in scripts and tests let ``__call__`` return their
output.

Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] CHANGES.rst has been updated
- [x] PR has been tested