### PR TITLE
remote/client: support env variables in namespace

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1036,8 +1036,11 @@ def main():
         stream=sys.stderr,
     )
 
+    # Support both legacy variables and properly namespaced ones
     place = os.environ.get('PLACE', None)
+    place = os.environ.get('LG_PLACE', place)
     state = os.environ.get('STATE', None)
+    state = os.environ.get('LG_STATE', state)
 
     parser = argparse.ArgumentParser()
     parser.add_argument(

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -76,10 +76,10 @@ The configuration file follows the description in \fBlabgrid\-device\-config\fP(
 .SH ENVIRONMENT VARIABLES
 .sp
 Various labgrid\-client commands use the following environment variable:
-.SS PLACE
+.SS LG_PLACE
 .sp
 This variable can be used to specify a place without using the \fB\-p\fP option, the \fB\-p\fP option overrides it.
-.SS STATE
+.SS LG_STATE
 .sp
 This variable can be used to specify a state which the device transitions into
 before executing a command. Requires a configuration file and a Strategy

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -60,12 +60,12 @@ ENVIRONMENT VARIABLES
 ---------------------
 Various labgrid-client commands use the following environment variable:
 
-PLACE
-~~~~~
+LG_PLACE
+~~~~~~~~
 This variable can be used to specify a place without using the ``-p`` option, the ``-p`` option overrides it.
 
-STATE
-~~~~~
+LG_STATE
+~~~~~~~~
 This variable can be used to specify a state which the device transitions into
 before executing a command. Requires a configuration file and a Strategy
 specified for the device.


### PR DESCRIPTION
**Description**
Previously both STATE and PLACE were not namespaced with the LG prefix.
Add support for both and prefer them over the old variables.
The old variables are still supported.


- [ ] PR has been tested
- [x] Man pages have been regenerated
