### PR TITLE
Extended SSH Proxy Support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,11 @@ New Features in 0.3.0
   file just like the images are.
 - The ShellDriver's keyfile attribute is now specified relative to the config
   file just like the images are.
+- ``labgrid-client -P <PROXY>`` and the ``LG_PROXY`` enviroment variable can be
+  used to access the coordinator and network resources via that SSH proxy host.
+  Drivers which run commands via SSH to the exporter still connect directly,
+  allowing custom configuration in the user's ``.ssh/config`` as needed.
+  Note that not all drivers have been updated to use the ProxyManager yet.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -171,6 +171,11 @@ Influences the color scheme used for the Colored Step Reporter. ``dark``
 ``light`` is optimized for light terminal background.
 Takes effect only when used with ``--lg-colored-steps``.
 
+LG_PROXY
+^^^^^^^^
+Specifies a SSH proxy host to be used for port forwards to access the
+coordinator and network resources.
+
 Simple Example
 ~~~~~~~~~~~~~~
 

--- a/labgrid/driver/onewiredriver.py
+++ b/labgrid/driver/onewiredriver.py
@@ -1,3 +1,4 @@
+from importlib import import_module
 import attr
 
 from ..factory import target_factory
@@ -13,17 +14,16 @@ class OneWirePIODriver(Driver, DigitalOutputProtocol):
     bindings = {"port": OneWirePIO, }
 
     def __attrs_post_init__(self):
-        import onewire
         super().__attrs_post_init__()
+        self._module = import_module('onewire')
         self._onewire = None
         self._host = None
         self._port = None
 
     def on_activate(self):
-        import onewire
         # we can only forward if the backend knows which port to use
         self._host, self._port = proxymanager.get_host_and_port(self.port)
-        self._onewire = onewire.Onewire(
+        self._onewire = self._module.Onewire(
             "{}:{}".format(self._host, self._port)
         )
 

--- a/labgrid/driver/onewiredriver.py
+++ b/labgrid/driver/onewiredriver.py
@@ -3,6 +3,7 @@ import attr
 from ..factory import target_factory
 from ..resource import OneWirePIO
 from ..protocol import DigitalOutputProtocol
+from ..util.proxy import proxymanager
 from .common import Driver
 
 @target_factory.reg_driver
@@ -14,20 +15,33 @@ class OneWirePIODriver(Driver, DigitalOutputProtocol):
     def __attrs_post_init__(self):
         import onewire
         super().__attrs_post_init__()
-        self.onewire = onewire.Onewire(self.port.host)
+        self._onewire = None
+        self._host = None
+        self._port = None
+
+    def on_activate(self):
+        import onewire
+        # we can only forward if the backend knows which port to use
+        self._host, self._port = proxymanager.get_host_and_port(self.port)
+        self._onewire = onewire.Onewire(
+            "{}:{}".format(self._host, self._port)
+        )
+
+    def on_deactivate(self):
+        self._onewire = None
 
     @Driver.check_active
     def set(self, status):
         if self.port.invert:
             status = not status
         if status:
-            self.onewire.set(self.port.path, '1')
+            self._onewire.set(self.port.path, '1')
         else:
-            self.onewire.set(self.port.path, '0')
+            self._onewire.set(self.port.path, '0')
 
     @Driver.check_active
     def get(self):
-        status = self.onewire.get(self.port.path)
+        status = self._onewire.get(self.port.path)
         if self.port.invert:
             status = not status
         return status == '1'

--- a/labgrid/driver/power/apc.py
+++ b/labgrid/driver/power/apc.py
@@ -27,7 +27,9 @@ def _snmp_set(host, oid, value):
         raise ExecutionError("failed to set SNMP value") from e
 
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
+    assert port is None
+
     index = int(index)
     value = 1 if value else 2
     assert 1 <= index <= 8
@@ -35,7 +37,9 @@ def power_set(host, index, value):
     _snmp_set(host, "{}.{}".format(OID, index), "int {}".format(value))
 
 
-def power_get(host, index):
+def power_get(host, port, index):
+    assert port is None
+
     index = int(index)
     assert 1 <= index <= 8
 

--- a/labgrid/driver/power/digipower.py
+++ b/labgrid/driver/power/digipower.py
@@ -1,7 +1,8 @@
 import requests
 
+PORT = 80
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
     index = int(index)
     assert 1 <= index <= 8
 
@@ -22,18 +23,18 @@ def power_set(host, index, value):
         "8": "00000001",
     }
     r = requests.get(
-        "http://{}/{}?led={}".format(host, cgi, portstring[index] + suffixstring),
+        "http://{}:{}/{}?led={}".format(host, port, cgi, portstring[index] + suffixstring),
         auth=("snmp", "1234"),
     )
     r.raise_for_status()
 
 
-def power_get(host, index):
+def power_get(host, port, index):
     index = int(index)
     assert 1 <= index <= 8
 
     # get the contents of the status page
-    r = requests.get("http://" + host + "/status.xml", auth=("snmp", "1234"))
+    r = requests.get("http://{}:{}/status.xml".format(host, port), auth=("snmp", "1234"))
     r.raise_for_status()
     states = {"0": False, "1": True}
     ports = {

--- a/labgrid/driver/power/gude.py
+++ b/labgrid/driver/power/gude.py
@@ -2,23 +2,24 @@ import requests
 
 from ..exception import ExecutionError
 
+PORT = 80
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
     index = int(index)
     assert 1 <= index <= 8
     # access the web interface...
     value = 1 if value else 0
     r = requests.get(
-        "http://{}/switch.html?cmd=1&p={}&s={}".format(host, index, value)
+        "http://{}:{}/switch.html?cmd=1&p={}&s={}".format(host, port, index, value)
     )
     r.raise_for_status()
 
 
-def power_get(host, index):
+def power_get(host, port, index):
     index = int(index)
     assert 1 <= index <= 8
     # get the contents of the main page
-    r = requests.get("http://{}/".format(host))
+    r = requests.get("http://{}:{}/".format(host, port))
     r.raise_for_status()
     for line in r.text.splitlines():
         power_pattern = "Power Port {}</td>".format(index)

--- a/labgrid/driver/power/gude24.py
+++ b/labgrid/driver/power/gude24.py
@@ -11,7 +11,9 @@ from ..exception import ExecutionError
 # Driver has been tested with:
 # * Gude Expert Power Control 8080
 
-def power_set(host, index, value):
+PORT = 80
+
+def power_set(host, port, index, value):
     # The gude web-interface uses different pages for the three groups of
     # switches. The web-interface always uses the 'correct' page to set a
     # value. But commands for all pages are accepted on all pages.
@@ -20,12 +22,12 @@ def power_set(host, index, value):
     # access the web interface...
     value = 1 if value else 0
     r = requests.get(
-        "http://{}/ov.html?cmd=1&p={}&s={}".format(host, index, value)
+        "http://{}:{}/ov.html?cmd=1&p={}&s={}".format(host, port, index, value)
     )
     r.raise_for_status()
 
 
-def power_get(host, index):
+def power_get(host, port, index):
     # The status of the ports is made available via a html <meta>-tag using the
     # following format:
     # <meta http-equiv="powerstate" content="Power Port 1,0">
@@ -33,7 +35,7 @@ def power_get(host, index):
     index = int(index)
     assert 1 <= index <= 24
     # get the contents of the main page
-    r = requests.get("http://{}/ov.html".format(host))
+    r = requests.get("http://{}:{}/ov.html".format(host, port))
     r.raise_for_status()
     for line in r.text.splitlines():
         if line.find("content=\"Power Port {}".format(index)) > 0:

--- a/labgrid/driver/power/gude8316.py
+++ b/labgrid/driver/power/gude8316.py
@@ -13,7 +13,9 @@ from ..exception import ExecutionError
 # Driver has been tested with:
 # * Gude Expert Power Control 8316 (firmware v1.2.0)
 
-def power_set(host, index, value):
+PORT = 80
+
+def power_set(host, port, index, value):
     # The gude web-interface uses different pages for the three groups of
     # switches. The web-interface always uses the 'correct' page to set a
     # value. But commands for all pages are accepted on all pages.
@@ -22,12 +24,12 @@ def power_set(host, index, value):
     # access the web interface...
     value = 1 if value else 0
     r = requests.get(
-        "http://{}/ov.html?cmd=1&p={}&s={}".format(host, index, value)
+        "http://{}:{}/ov.html?cmd=1&p={}&s={}".format(host, port, index, value)
     )
     r.raise_for_status()
 
 
-def power_get(host, index):
+def power_get(host, port, index):
     # The status of the ports is made available via a html <meta>-tag using the
     # following format:
     # <meta http-equiv="powerstate" content="Power Port ,0">
@@ -40,7 +42,7 @@ def power_get(host, index):
     index = int(index)
     assert 1 <= index <= 8
     # get the contents of the main page
-    r = requests.get("http://{}/ov.html".format(host))
+    r = requests.get("http://{}:{}/ov.html".format(host, port))
     r.raise_for_status()
     for line_no, line in enumerate(r.text.splitlines()):
         if line_no == index and line.find("content=\"Power Port ") > 0:

--- a/labgrid/driver/power/netio.py
+++ b/labgrid/driver/power/netio.py
@@ -1,8 +1,9 @@
 import re
 import requests
 
+PORT = 80
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
     index = int(index)
     assert 1 <= index <= 4
     # access the web interface...
@@ -11,17 +12,17 @@ def power_set(host, index, value):
     else:
         portstring = {1: "0uuu", 2: "u0uu", 3: "uu0u", 4: "uuu0"}
     r = requests.get(
-        "http://{}/tgi/control.tgi?l=p:admin:admin&p={}".
-        format(host, portstring[index])
+        "http://{}:{}/tgi/control.tgi?l=p:admin:admin&p={}".
+        format(host, port, portstring[index])
     )
     r.raise_for_status()
 
 
-def power_get(host, index):
+def power_get(host, port, index):
     index = int(index)
     assert 1 <= index <= 4
     # get the contents of the main page
-    r = requests.get("http://" + host + "/tgi/control.tgi?l=p:admin:admin&p=l")
+    r = requests.get("http://{}:{}/tgi/control.tgi?l=p:admin:admin&p=l".format(host, port))
     r.raise_for_status()
     m = re.match(r".*(\d) (\d) (\d) (\d).*", r.text)
     states = {"0": False, "1": True}

--- a/labgrid/driver/power/netio_kshell.py
+++ b/labgrid/driver/power/netio_kshell.py
@@ -3,12 +3,13 @@
 import re
 import telnetlib
 
+PORT = 1234
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
     index = int(index)
     assert 1 <= index <= 4
     value = "1" if value else "0"
-    tn = telnetlib.Telnet(host, 1234, 1)
+    tn = telnetlib.Telnet(host, port, 1)
     tn.read_until(b"\r\n", 0.5)
     tn.write(b"login admin admin\n")
     tn.read_until(b"250 OK\r\n", 0.5)
@@ -18,10 +19,10 @@ def power_set(host, index, value):
     tn.close()
 
 
-def power_get(host, index):
+def power_get(host, port, index):
     index = int(index)
     assert 1 <= index <= 4
-    tn = telnetlib.Telnet(host, 1234, 1)
+    tn = telnetlib.Telnet(host, port, 1)
     tn.read_until(b"\r\n", 0.5)
     tn.write(b"login admin admin\n")
     tn.read_until(b"250 OK\r\n", 0.5)

--- a/labgrid/driver/power/simplerest.py
+++ b/labgrid/driver/power/simplerest.py
@@ -12,12 +12,16 @@
 
 import requests
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
+    assert port is None
+
     index = int(index)
     value = 1 if value else 0
     requests.get(host.format(value=value, index=index))
 
-def power_get(host, index):
+def power_get(host, port, index):
+    assert port is None
+
     index = int(index)
     # remove trailing /
     r = requests.get(host.format(value='', index=index).rstrip('/'))

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -109,16 +109,18 @@ class NetworkPowerDriver(Driver, PowerResetMixin, PowerProtocol):
             ".power.{}".format(self.port.model),
             __package__
         )
+        self._host = self.port.host
+        self._port = None
 
     @Driver.check_active
     @step()
     def on(self):
-        self.backend.power_set(self.port.host, self.port.index, True)
+        self.backend.power_set(self._host, self._port, self.port.index, True)
 
     @Driver.check_active
     @step()
     def off(self):
-        self.backend.power_set(self.port.host, self.port.index, False)
+        self.backend.power_set(self._host, self._port, self.port.index, False)
 
     @Driver.check_active
     @step()
@@ -129,7 +131,7 @@ class NetworkPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 
     @Driver.check_active
     def get(self):
-        return self.backend.power_get(self.port.host, self.port.index)
+        return self.backend.power_get(self._host, self._port, self.port.index)
 
 @target_factory.reg_driver
 @attr.s(cmp=False)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -694,7 +694,7 @@ class ClientSession(ApplicationSession):
         target = self._get_target(place)
         from ..resource import NetworkSerialPort
         resource = target.get_resource(NetworkSerialPort, name=name)
-        host, port = proxymanager.get_host_and_port(resource, self.args.proxy)
+        host, port = proxymanager.get_host_and_port(resource)
 
         # check for valid resources
         assert port is not None, "Port is not set"
@@ -1001,6 +1001,8 @@ def start_session(url, realm, extra):
 
     session = [None]
 
+    url = proxymanager.get_url(url)
+
     def create():
         nonlocal session
         cfg = ComponentConfig(realm, extra)
@@ -1091,9 +1093,8 @@ def main():
     parser.add_argument(
         '-P',
         '--proxy',
-        type=bool,
-        default=False,
-        help="proxy connections over ssh"
+        type=str,
+        help="proxy connections via given ssh host"
     )
     subparsers = parser.add_subparsers(
         dest='command',
@@ -1296,6 +1297,9 @@ def main():
     if not args.config and args.state:
         print("Setting the state requires a configuration file")
         exit(1)
+
+    if args.proxy:
+        proxymanager.force_proxy(args.proxy)
 
     env = None
     if args.config:

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1001,7 +1001,7 @@ def start_session(url, realm, extra):
 
     session = [None]
 
-    url = proxymanager.get_url(url)
+    url = proxymanager.get_url(url, default_port=20408)
 
     def create():
         nonlocal session

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -1,6 +1,7 @@
 import attr
 
 from ..binding import BindingMixin
+from ..util.ssh import sshmanager
 
 
 @attr.s(cmp=False)
@@ -61,10 +62,15 @@ class NetworkResource(Resource):
 
     @property
     def command_prefix(self):
-        return ['ssh', '-x',
-                '-o', 'ConnectTimeout=5',
-                '-o', 'PasswordAuthentication=no',
-                self.host, '--']
+        host = self.host
+
+        if hasattr(self, 'extra'):
+            host = self.extra.get('proxy')
+
+        conn = sshmanager.get(host)
+        prefix = conn.get_prefix()
+
+        return prefix + ['--']
 
 
 @attr.s(cmp=False)

--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -21,11 +21,13 @@ class ProxyManager:
         cls._force_proxy = force_proxy
 
     @classmethod
-    def get_host_and_port(cls, res):
+    def get_host_and_port(cls, res, force_port=None):
         """ get host and port for a proxy connection from a Resource
 
         Args:
             res (Resource): The resource to retrieve the proxy for
+            force_port (optional): TCP port to use instead of the one
+                configured for the resource
 
         Returns:
             (host, port) host and port for the proxy connection
@@ -35,7 +37,8 @@ class ProxyManager:
         """
         assert isinstance(res, Resource)
 
-        host, port = res.host, res.port
+        host = res.host
+        port = force_port or res.port
 
         if cls._force_proxy:
             port = sshmanager.request_forward(cls._force_proxy, host, port)

--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -1,21 +1,31 @@
+import os
+
+from urllib.parse import urlsplit, urlunsplit
+
 from .ssh import sshmanager
 
-from ..resource.common import NetworkResource, Resource
+from ..resource.common import Resource
 
 __all__ = ['proxymanager']
+
 
 class ProxyManager:
     """The ProxyManager class is only used inside labgrid.util.proxy (similar
     to a singleton), don't instanciate this class, use the exported
     proxymanager instead."""
-    @staticmethod
-    def get_host_and_port(res, force_proxy=False):
+    _force_proxy = os.environ.get("LG_PROXY", None)
+
+    @classmethod
+    def force_proxy(cls, force_proxy):
+        assert isinstance(force_proxy, str)
+        cls._force_proxy = force_proxy
+
+    @classmethod
+    def get_host_and_port(cls, res):
         """ get host and port for a proxy connection from a Resource
 
         Args:
             res (Resource): The resource to retrieve the proxy for
-            force_proxy (:obj:`bool`, optional): whether to always proxy the
-                connection, defaults to False
 
         Returns:
             (host, port) host and port for the proxy connection
@@ -25,21 +35,33 @@ class ProxyManager:
         """
         assert isinstance(res, Resource)
 
-        if not hasattr(res, 'extra'):
-            return res.host, res.port
+        host, port = res.host, res.port
 
-        if not res.extra.get('proxy') or not res.extra.get("proxy_required"):
-            return res.host, res.port
-
-        # res must be a NetworkResource now
-        assert isinstance(res, NetworkResource)
-
-        proxy_required = res.extra['proxy_required']
-        proxy = res.extra['proxy']
-        if proxy_required or force_proxy:
-            port = sshmanager.request_forward(proxy, res.host, res.port)
+        if cls._force_proxy:
+            port = sshmanager.request_forward(cls._force_proxy, host, port)
             host = 'localhost'
-            return host, port
-        return res.host, res.port
+
+        extra = getattr(res, 'extra', {})
+        if extra:
+            proxy_required = extra.get('proxy_required')
+            proxy = extra.get('proxy')
+            if proxy_required:
+                port = sshmanager.request_forward(proxy, host, port)
+                host = 'localhost'
+
+        return host, port
+
+    @classmethod
+    def get_url(cls, url):
+        assert isinstance(url, str)
+
+        s = urlsplit(url)
+
+        if cls._force_proxy:
+            port = sshmanager.request_forward(s.hostname, '127.0.0.1', s.port)
+            s = s._replace(netloc="{}:{}".format('127.0.0.1', port))
+
+        return urlunsplit(s)
+
 
 proxymanager = ProxyManager()

--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -37,8 +37,14 @@ class ProxyManager:
         """
         assert isinstance(res, Resource)
 
-        host = res.host
-        port = force_port or res.port
+        s = urlsplit('//'+res.host)
+        host = s.hostname
+        if force_port:
+            port = force_port
+        elif s.port:
+            port = s.port
+        else:
+            port = res.port
 
         if cls._force_proxy:
             port = sshmanager.request_forward(cls._force_proxy, host, port)

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -190,6 +190,10 @@ class SSHConnection:
         return wrapper
 
     @_check_connected
+    def get_prefix(self):
+        return ["ssh"] + self._get_ssh_args() + [self.host]
+
+    @_check_connected
     def run(self, command, *, codec="utf-8", decodeerrors="strict",
             force_tty=False, stderr_merge=False, stderr_loglevel=None,
             stdout_loglevel=None):

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -4,7 +4,6 @@ import logging
 import subprocess
 import os
 from select import select
-import socket
 from functools import wraps
 
 import attr
@@ -38,7 +37,6 @@ class SSHConnectionManager:
 
         Returns:
             :obj:`SSHConnection`: the SSHConnection for the host"""
-        host = socket.getfqdn(host)
         instance = self._connections.get(host)
         if instance is None:
             # pylint: disable=unsupported-assignment-operation

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -96,6 +96,11 @@ This variable can be used to set the default crossbar URL (instead of using the
 .sp
 This variable can be used to set the default crossbar realm to use instead of
 \fBrealm1\fP\&.
+.SS LG_PROXY
+.sp
+This variable can be used to specify a SSH proxy hostname which should be used
+to connect to the coordinator and any resources which are normally accessed
+directly.
 .SH MATCHES
 .sp
 Match patterns are used to assign a resource to a specific place. The format is:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -85,6 +85,12 @@ LG_CROSSBAR_REALM
 This variable can be used to set the default crossbar realm to use instead of
 ``realm1``.
 
+LG_PROXY
+~~~~~~~~
+This variable can be used to specify a SSH proxy hostname which should be used
+to connect to the coordinator and any resources which are normally accessed
+directly.
+
 MATCHES
 -------
 Match patterns are used to assign a resource to a specific place. The format is:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -72,7 +72,6 @@ specified for the device.
 
 LG_ENV
 ~~~~~~
-
 This variable can be used to specify the configuration file to use without
 using the ``--config`` option, the ``--config`` option overrides it.
 
@@ -161,7 +160,6 @@ To retrieve a list of places run:
 
    $ labgrid-client places
 
-
 To access a place, it needs to be acquired first, this can be done by running
 the ``acquire command`` and passing the placename as a -p parameter:
 
@@ -180,7 +178,6 @@ Add all resources with the group "example-group" to the place example-place:
 .. code-block:: bash
 
    $ labgrid-client -p example-place add-match */example-group/*/*
-
 
 SEE ALSO
 --------

--- a/tests/test_onewire.py
+++ b/tests/test_onewire.py
@@ -29,12 +29,12 @@ def test_onewire_driver_instance(target, onewire_driver):
 
 def test_onewire_set(onewire_driver):
     onewire_driver.set(True)
-    onewire_driver.onewire.set.assert_called_once_with("path", '1')
+    onewire_driver._onewire.set.assert_called_once_with("path", '1')
 
 def test_onewire_unset(onewire_driver):
     onewire_driver.set(False)
-    onewire_driver.onewire.set.assert_called_once_with("path", '0')
+    onewire_driver._onewire.set.assert_called_once_with("path", '0')
 
 def test_onewire_get(onewire_driver):
     onewire_driver.get()
-    onewire_driver.onewire.get.assert_called_once_with("path")
+    onewire_driver._onewire.get.assert_called_once_with("path")


### PR DESCRIPTION
**Description**
This PR implements support for using a SSH proxy host for connections to the coordinator and network resources. Note that so far only SerialDriver, NetworkPowerDriver (most backends), ModbusCoilDriver and OneWirePIODriver have been modified to use the ProxyManager.

This should also solve the use-case described in #186.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/usage.rst
- [x] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated