### PR TITLE
driver: fastbootdriver: don't disable sparsing by default

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -881,7 +881,9 @@ Implements:
 Arguments:
   - image (str): filename of the image to upload to the device
   - sparse_size (str): optional, sparse files greater than given size (see
-    fastboot manpage -S option for allowed size suffixes)
+    fastboot manpage -S option for allowed size suffixes). The default is the
+    same as the fastboot default, which is computed after querying the target's
+    ``max-download-size`` variable.
 
 OpenOCDDriver
 ~~~~~~~~~~~~~

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -18,7 +18,7 @@ class AndroidFastbootDriver(Driver):
     }
 
     image = attr.ib(default=None)
-    sparse_size = attr.ib(default='0', validator=attr.validators.instance_of(str))
+    sparse_size = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -29,12 +29,16 @@ class AndroidFastbootDriver(Driver):
             self.tool = 'fastboot'
 
     def _get_fastboot_prefix(self):
-        return self.fastboot.command_prefix+[
+        prefix = self.fastboot.command_prefix+[
             self.tool,
             "-i", hex(self.fastboot.vendor_id),
             "-s", "usb:{}".format(self.fastboot.path),
-            "-S", self.sparse_size,
         ]
+
+        if self.sparse_size is not None:
+            prefix += ["-S", self.sparse_size]
+
+        return prefix
 
     def on_activate(self):
         pass


### PR DESCRIPTION
**Description**

By default, the sparse threshold is computed by querying the
target's `max-download-size` variable.

With #416, labgrid adopted the behavior of passing `-S 0` as
default value to fastboot. This is problematic as different
fastboot versions interpret `-S 0` differently:

- Fastboot releases containing [542370dead ("Move fastboot over
  to ParseByteCount."](https://github.com/aosp-mirror/platform_system_core/commit/542370dead58e854c477549bf0b3333aaf23b299)) treat `-S 0` and its absence the same:
  The target's `max-download-size` variable is queried.
- Older fastboot releases, e.g. 1:7.0.0+r33-1 shipped by Debian
  Stretch, instead completely disables sparse when `-S 0`, while not
  supplying it queries the target.

To have the fastbootdriver interoperate with both versions,
supply `-S` only, when there's a user set value, and otherwise
do not supply the option at all.

Fixes: #416, 1bf8952 ("driver: fastbootdriver: allow setting sparse option")
Signed-off-by: Ahmad Fatoum &lt;a.fatoum@pengutronix.de&gt;

------

Bug fix has been tested by running `labgrid-client fastboot flash`, which no longer passes around a `-S 0`. I also tested that the old behavior still works, e.g. a config of
```
targets:
  main:
    drivers:
      AndroidFastbootDriver:
        sparse_size: 0M
```

yields the old behavior of no sparsing.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated

Everything else is IMO not applicable, because it's just a bug fix.