### PR TITLE
Add agent module, resource and driver for Dedidec Relais 8 device

### DIFF
--- a/examples/deditec-relais8/deditec.py
+++ b/examples/deditec-relais8/deditec.py
@@ -1,0 +1,33 @@
+import sys
+import labgrid
+import logging
+import time
+
+from labgrid import Environment, StepReporter
+from labgrid.strategy.bareboxstrategy import Status
+from labgrid.driver.deditecrelaisdriver import DeditecRelaisDriver
+
+# enable debug logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(levelname)7s: %(message)s',
+    stream=sys.stderr,
+)
+
+# show labgrid steps on the console
+StepReporter()
+
+t = labgrid.Target('main')
+r = labgrid.resource.udev.DeditecRelais8(t, name=None, index=1)
+d = DeditecRelaisDriver(t, name=None)
+
+p = t.get_driver("DigitalOutputProtocol")
+print(t.resources)
+p.set(True)
+print(p.get())
+time.sleep(2)
+p.set(False)
+print(p.get())
+time.sleep(2)
+p.set(True)
+print(p.get())

--- a/examples/deditec-relais8/deditec_remote.py
+++ b/examples/deditec-relais8/deditec_remote.py
@@ -1,0 +1,32 @@
+import sys
+import labgrid
+import logging
+import time
+
+from labgrid import Environment, StepReporter
+from labgrid.strategy.bareboxstrategy import Status
+from labgrid.driver.deditecrelaisdriver import DeditecRelaisDriver
+
+# enable debug logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(levelname)7s: %(message)s',
+    stream=sys.stderr,
+)
+
+# show labgrid steps on the console
+StepReporter()
+
+e = labgrid.Environment('import-dedicontrol.yaml')
+t = e.get_target()
+
+p = t.get_driver("DigitalOutputProtocol")
+print(t.resources)
+p.set(True)
+print(p.get())
+time.sleep(2)
+p.set(False)
+print(p.get())
+time.sleep(2)
+p.set(True)
+print(p.get())

--- a/examples/deditec-relais8/export-didicontrol.yaml
+++ b/examples/deditec-relais8/export-didicontrol.yaml
@@ -1,0 +1,3 @@
+desk:
+    DeditecRelais8:
+        index: 2

--- a/examples/deditec-relais8/import-dedicontrol.yaml
+++ b/examples/deditec-relais8/import-dedicontrol.yaml
@@ -1,0 +1,9 @@
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: dedi
+    drivers:
+      DeditecRelaisDriver: {}
+options:
+  crossbar_url: 'ws://labgrid:20408/ws'

--- a/labgrid/driver/deditecrelaisdriver.py
+++ b/labgrid/driver/deditecrelaisdriver.py
@@ -5,6 +5,7 @@ import attr
 from .common import Driver
 from ..factory import target_factory
 from ..resource.udev import DeditecRelais8
+from ..resource.remote import NetworkDeditecRelais8
 from ..step import step
 from ..protocol import DigitalOutputProtocol
 from ..util.agentwrapper import AgentWrapper
@@ -14,7 +15,7 @@ from ..util.agentwrapper import AgentWrapper
 @attr.s(cmp=False)
 class DeditecRelaisDriver(Driver, DigitalOutputProtocol):
     bindings = {
-        "relais": {DeditecRelais8},
+        "relais": {DeditecRelais8, NetworkDeditecRelais8},
     }
 
     def __attrs_post_init__(self):
@@ -22,7 +23,11 @@ class DeditecRelaisDriver(Driver, DigitalOutputProtocol):
         self.wrapper = None
 
     def on_activate(self):
-        self.wrapper = AgentWrapper(None)
+        if isinstance(self.relais, NetworkDeditecRelais8):
+            host = self.relais.host
+        else:
+            host = None
+        self.wrapper = AgentWrapper(host)
         self.proxy = self.wrapper.load('deditec_relais8')
 
     def on_deactivate(self):

--- a/labgrid/driver/deditecrelaisdriver.py
+++ b/labgrid/driver/deditecrelaisdriver.py
@@ -1,0 +1,41 @@
+# pylint: disable=no-member
+import subprocess
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..resource.udev import DeditecRelais8
+from ..step import step
+from ..protocol import DigitalOutputProtocol
+from ..util.agentwrapper import AgentWrapper
+
+
+@target_factory.reg_driver
+@attr.s(cmp=False)
+class DeditecRelaisDriver(Driver, DigitalOutputProtocol):
+    bindings = {
+        "relais": {DeditecRelais8},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.wrapper = None
+
+    def on_activate(self):
+        self.wrapper = AgentWrapper(None)
+        self.proxy = self.wrapper.load('deditec_relais8')
+
+    def on_deactivate(self):
+        self.wrapper.close()
+        self.wrapper = None
+        self.proxy = None
+
+    @Driver.check_active
+    @step(args=['status'])
+    def set(self, status):
+        self.proxy.set(self.relais.busnum, self.relais.devnum, self.relais.index, status)
+
+    @Driver.check_active
+    @step(result=True)
+    def get(self):
+        return self.proxy.get(self.relais.busnum, self.relais.devnum, self.relais.index)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -660,8 +660,10 @@ class ClientSession(ApplicationSession):
         target = self._get_target(place)
         from ..resource.modbus import ModbusTCPCoil
         from ..resource.onewireport import OneWirePIO
+        from ..resource.remote import NetworkDeditecRelais8
         from ..driver.modbusdriver import ModbusCoilDriver
         from ..driver.onewiredriver import OneWirePIODriver
+        from ..driver.deditecrelaisdriver import DeditecRelaisDriver
         drv = None
         for resource in target.resources:
             if isinstance(resource, ModbusTCPCoil):
@@ -677,6 +679,13 @@ class ClientSession(ApplicationSession):
                 except NoDriverFoundError:
                     target.set_binding_map({"port": name})
                     drv = OneWirePIODriver(target, name=name)
+                break
+            elif isinstance(resource, NetworkDeditecRelais8):
+                try:
+                    drv = target.get_driver(DeditecRelaisDriver, name=name)
+                except NoDriverFoundError:
+                    target.set_binding_map({"relais": name})
+                    drv = DeditecRelaisDriver(target, name=name)
                 break
         if not drv:
             raise UserError("target has no compatible resource available")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -274,6 +274,25 @@ class USBPowerPortExport(USBGenericExport):
             'index': self.local.index,
         }
 
+@attr.s(cmp=False)
+class USBDeditecRelaisExport(USBGenericExport):
+    """ResourceExport for outputs on deditec relais"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': self.host,
+            'busnum': self.local.busnum,
+            'devnum': self.local.devnum,
+            'path': self.local.path,
+            'vendor_id': self.local.vendor_id,
+            'model_id': self.local.model_id,
+            'index': self.local.index,
+        }
+
 
 exports["AndroidFastboot"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
@@ -286,6 +305,7 @@ exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport
 exports["USBTMC"] = USBGenericExport
 exports["USBPowerPort"] = USBPowerPortExport
+exports["DeditecRelais8"] = USBDeditecRelaisExport
 
 
 @attr.s

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -199,3 +199,13 @@ class NetworkUSBTMC(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(cmp=False)
+class NetworkDeditecRelais8(RemoteUSBResource):
+    """The NetworkDeditecRelais8 describes a remotely accessible USB relais port"""
+    index = attr.ib(default=None, validator=attr.validators.instance_of(int))
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -385,3 +385,21 @@ class USBTMC(USBResource):
             return self.device.device_node
 
         return None
+
+@target_factory.reg_resource
+@attr.s(cmp=False)
+class DeditecRelais8(USBResource):
+    index = attr.ib(default=None, validator=attr.validators.instance_of(int))
+
+    def __attrs_post_init__(self):
+        self.match['ID_VENDOR'] = 'DEDITEC'
+        # the serial is the same for all boards with the same model
+        self.match['ID_SERIAL_SHORT'] = 'DT000014'
+        super().__attrs_post_init__()
+
+    @property
+    def path(self):
+        if self.device is not None:
+            return self.device.device_path
+
+        return None

--- a/labgrid/util/agent.py
+++ b/labgrid/util/agent.py
@@ -16,6 +16,7 @@ class Agent:
     def __init__(self):
         self.methods = {}
         self.register('load', self.load)
+        self.register('list', self.list)
 
         # use real stdin/stdout
         self.stdin = sys.stdin
@@ -37,6 +38,9 @@ class Agent:
         exec(compile(source, '<loaded {}>'.format(name), 'exec'), module.__dict__)
         for k, v in module.methods.items():
             self.register('{}.{}'.format(name, k), v)
+
+    def list(self):
+        return list(self.methods.keys())
 
     def run(self):
         for line in self.stdin:

--- a/labgrid/util/agents/deditec_relais8.py
+++ b/labgrid/util/agents/deditec_relais8.py
@@ -1,0 +1,148 @@
+"""
+This module implements the communication protocol to switch the digital outputs
+on the Deditec Relais8 board.
+
+Supported modules:
+
+- Relais8
+
+Supported Functionality:
+
+- Turn digital output on and off
+"""
+import logging
+
+from binascii import unhexlify, hexlify
+
+import usb.core
+import usb.util
+
+
+class Relais8:
+    _padding = 'FEFEFEFEFEFEFEFEFF'
+    _post_padding = '000000'
+
+    _configuration_sequence = [
+        '3430FF',
+        '3434FF',
+        '34C0FF',
+        '3400FF',
+        '3402FF',
+        '340CFF',
+        '340EFF',
+        '3404FF',
+        '3406FF',
+        '3408FF',
+        '340AFF',
+        '3410FF',
+        '3412FF',
+        '3414FF',
+        '3416FF',
+        '34F4FF',
+        '34F5FF',
+        '34F6FF',
+        '34F7FF',
+        '34F0FF',
+        '34ECFF']
+
+    def __init__(self, **args):
+        self._dev = usb.core.find(**args)
+        if self._dev is None:
+            raise ValueError("Device not found")
+        if self._dev.is_kernel_driver_active(0):
+            self._dev.detach_kernel_driver(0)
+
+        cfg = self._dev.get_active_configuration()
+        intf = cfg[(0, 0)]
+        self._dev.set_configuration()
+        usb.util.claim_interface(self._dev, 0)
+        self._dev.ctrl_transfer(64, 0, 0, 0, 0, 5000)
+        self._dev.ctrl_transfer(64, 3, 20, 0, 0, 5000)
+        self._dev.ctrl_transfer(64, 9, 2, 0, 0, 5000)
+        self._ep_out = usb.util.find_descriptor(
+                intf,
+                custom_match=lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_OUT)
+        self._ep_in = usb.util.find_descriptor(
+                intf,
+                custom_match=lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_IN)
+        self._sequence_number = 0
+        self._logger = logging.getLogger("Device: ")
+        self._run_configuration_sequence()
+
+    def _run_configuration_sequence(self):
+        for d in Relais8._configuration_sequence:
+            self.write_config_request(d)
+            self.read(255)
+
+    def read(self, size):
+        data = self._ep_in.read(size)
+        self._logger.debug("Read data: {}".format(hexlify(data)))
+        return data
+
+    def write_config_request(self, address):
+        complete_request = unhexlify(Relais8._padding)
+        complete_request += bytes([self._sequence_number])
+        complete_request += unhexlify(address + Relais8._post_padding)
+        self._logger.debug(
+                "Sending Request: {}".format(hexlify(complete_request)))
+        self.write(complete_request)
+
+    def write(self, data):
+        self._sequence_number = (self._sequence_number + 1) & 0xff
+        self._logger.debug("Writing data: {}".format(hexlify(data)))
+        self._ep_out.write(data)
+
+    def set_all_outputs(self, status, reset=False):
+        assert isinstance(status, int)
+        if status == 0:
+            reset = True
+        if status > 255 or status < 0:
+            return
+        data = '0123{}000000001{:02X}00000000000000'.format(
+                0 if reset else 8, status)
+        self.write(unhexlify(Relais8._padding + data))
+        self.read(255)
+
+    def set_output(self, number, status):
+        if status:
+            data = '238000000001{:02X}00000000000000'.format(1 << (number - 1))
+        else:
+            data = '23A000000001{:02X}00000000000000'.format(1 << (number - 1))
+        complete_request = unhexlify(Relais8._padding)
+        complete_request += bytes([self._sequence_number])
+        complete_request += unhexlify(data)
+        self.write(complete_request)
+        self.read(255)
+
+    def get_output(self, number):
+        data = '34000000000F'
+        complete_request = unhexlify(Relais8._padding)
+        complete_request += bytes([self._sequence_number])
+        complete_request += unhexlify(data)
+        self.write(complete_request)
+        read_data = self.read(255).tobytes()
+        index = read_data.find(b'\x1a')
+        if read_data[index+1] == self._sequence_number - 1:
+            outputs = read_data[index+2]
+        else:
+            raise IOError("Could not read outputs from device")
+        return outputs & (1 << (number - 1)) > 0
+
+    def __del__(self):
+        usb.util.release_interface(self._dev, 0)
+
+
+def handle_set(busnum, devnum, number, status):
+    relais8 = Relais8(bus=busnum, address=devnum)
+    relais8.set_output(number, status)
+
+
+def handle_get(busnum, devnum, number):
+    relais8 = Relais8(bus=busnum, address=devnum)
+    return relais8.get_output(number)
+
+
+methods = {
+    'set': handle_set,
+    'get': handle_get,
+}

--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -37,6 +37,7 @@ class ModuleProxy:
 class AgentWrapper:
 
     def __init__(self, host=None):
+        self.agent = None
         self.loaded = {}
         self.logger = logging.getLogger("ResourceExport({})".format(host))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ xmodem==0.4.5
 autobahn==19.3.3
 PyYAML==5.1
 ansicolors==1.1.8
+pyusb==1.0.2

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -95,3 +95,7 @@ def test_local():
 
     dummy = aw.load('dummy')
     assert dummy.neg(1) == -1
+
+def test_all_modules():
+    aw = AgentWrapper(None)
+    aw.load('deditec_relais8')

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -102,3 +102,8 @@ def test_all_modules():
     methods = aw.list()
     assert 'deditec_relais8.set' in methods
     assert 'deditec_relais8.get' in methods
+
+def test_import_modules():
+    import labgrid.util.agents
+    import labgrid.util.agents.dummy
+    import labgrid.util.agents.deditec_relais8

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -99,3 +99,6 @@ def test_local():
 def test_all_modules():
     aw = AgentWrapper(None)
     aw.load('deditec_relais8')
+    methods = aw.list()
+    assert 'deditec_relais8.set' in methods
+    assert 'deditec_relais8.get' in methods


### PR DESCRIPTION
**Description**

This PR first adds an agent module to control the device remotely. Then it adds a resource and driver to allow local and remote control via the agent. An example for both variants is also included

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested