### PR TITLE
labgrid-client: fastboot: use AndroidFastbootDriver.run() for 'oem exec'

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -746,6 +746,9 @@ class ClientSession(ApplicationSession):
         if args[0] == 'boot':
             drv.boot(args[1])
             return
+        if args[0:2] == ['oem', 'exec']:
+            drv.run(" ".join(args[2:]))
+            return
         drv(*args)
 
     def bootstrap(self):


### PR DESCRIPTION
Currently, the fastboot command on the exporter will try to parse parameters from the command which we want to run on the target:

```
$ labgrid-client fastboot oem exec state -s
fastboot: option requires an argument -- 's'
[.. traceback ..]
subprocess.CalledProcessError: Command '['ssh', '-x', '-o', 'ConnectTimeout=5', '-o', 'PasswordAuthentication=no', 'labgrid-exporter-hostname', '--', 'fastboot', '-i', '0x1337', '-s', 'usb:2-2.3.2', 'oem', 'exec', 'state', '-s']' returned non-zero exit status 1.
```

AndroidFastbootDriver.run() already adds a '--' after the `fastboot oem exec` part, so use that method for `labgrid-client fastboot` to fix this behaviour.