### PR TITLE
driver: fastbootdriver: implement 'getvar' and 'oem getenv' commands

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,7 @@ New Features in 0.3.0
 - Flashrom support added, by hard-wiring e.g. an exporter to the DUT, the ROM
   on the DUT can be written directly. The flashrom driver implements the
   bootstrap protocol.
+- AndroidFastbootDriver now supports 'getvar' and 'oem getenv' subcommands.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -40,6 +40,14 @@ class AndroidFastbootDriver(Driver):
 
         return prefix
 
+    @staticmethod
+    def _filter_fastboot_output(output, prefix='(bootloader) '):
+        """
+        Splits output by '\n' and returns only elements starting with prefix. The prefix is
+        removed.
+        """
+        return [line[len(prefix):] for line in output.split('\n') if line.startswith(prefix)]
+
     def on_activate(self):
         pass
 
@@ -74,3 +82,28 @@ class AndroidFastbootDriver(Driver):
     @step(title='continue')
     def continue_boot(self):
         self("continue")
+
+    @Driver.check_active
+    @step(args=['var'])
+    def getvar(self, var):
+        """Return variable value via 'fastboot getvar <var>'."""
+        if var == 'all':
+            raise NotImplementedError('Retrieving a list of all variables is not supported yet')
+
+        cmd = ['getvar', var]
+        proc = subprocess.run(self._get_fastboot_prefix() + cmd, stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT, check=True, universal_newlines=True)
+        values = AndroidFastbootDriver._filter_fastboot_output(proc.stdout, '{}: '.format(var))
+        assert len(values) == 1, 'fastboot did not return exactly one line'
+        return values[0]
+
+    @Driver.check_active
+    @step(args=['var'])
+    def oem_getenv(self, var):
+        """Return barebox environment variable value via 'fastboot oem getenv <var>'."""
+        cmd = ['oem', 'getenv', var]
+        proc = subprocess.run(self._get_fastboot_prefix() + cmd, stdout=subprocess.PIPE,
+                              stderr=subprocess.STDOUT, check=True, universal_newlines=True)
+        values = AndroidFastbootDriver._filter_fastboot_output(proc.stdout)
+        assert len(values) == 1, 'fastboot did not return exactly one line'
+        return values[0]


### PR DESCRIPTION
**Description**
These commands allow reading variables. The value is returned in a
pretty obfuscated way, so clean up is performed and only the value of
the (environment) variable is then returned.

Note: there is no way to distinguish non-existent variables and
variables with an empty value. This is a fastboot limitation.

Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested
