### PR TITLE
util: ssh: make ssh_connection_manager reuse existing connections

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -37,8 +37,9 @@ class SSHConnectionManager:
 
         Returns:
             :obj:`SSHConnection`: the SSHConnection for the host"""
-        instance = self._connections.get(host)
-        if instance is None:
+        if host in self._connections:
+            instance = self._connections[host]
+        else:
             # pylint: disable=unsupported-assignment-operation
             self.logger.debug("Creating SSHConnection for %s", host)
             instance = SSHConnection(host)


### PR DESCRIPTION
**Description**
Check if ssh connection exists. Previous "instance = self._connections.get(host)" always results in instance = None.

Signed-off-by: Jonathan Goetzinger <j.goetzinger@eckelmann.de>

**Checklist**
- [x] PR has been tested

