### PR TITLE
resource: common.py only use proxy when 'proxy_required' is true

### DIFF
--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -65,7 +65,8 @@ class NetworkResource(Resource):
         host = self.host
 
         if hasattr(self, 'extra'):
-            host = self.extra.get('proxy')
+            if self.extra.get('proxy_required'): 
+                host = self.extra.get('proxy')
 
         conn = sshmanager.get(host)
         prefix = conn.get_prefix()


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
With the new labgrid-client -P option using:

labgrid-client -P labgrid01 -p board-1 video
labgrid-client -P labgrid01 -p board-1 bootstrap
labgrid-client -P labgrid01 -p board-1 fastboot

results in a timeout or ssh connect error.

When the the self.video.command_prefix is evaluated, labgrid tries to
create a second connection to the exporter with the hostname from 
self.extra.proxy instead of the one specified with the -P option. Since
self.extra.proxy is a default variable, it should only be evaluated when
"proxy_required" is True.

Signed-off-by: Jonathan Goetzinger <j.goetzinger@eckelmann.de>
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested