### PR TITLE
driver: openocddriver: use AlteraUSBBlaster's USB path

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -889,6 +889,15 @@ OpenOCDDriver
 ~~~~~~~~~~~~~
 An OpenOCDDriver controls OpenOCD to bootstrap a target with a bootloader.
 
+Note that OpenOCD supports specifying USB paths since
+`a1b308ab <https://sourceforge.net/p/openocd/code/ci/a1b308ab/>`_ which is not
+part of a release yet.
+The OpenOCDDriver passes the resource's USB path.
+Depending on which OpenOCD version is installed it is either used correctly or
+a warning is displayed and the first resource seen is used, which might be the
+wrong USB device.
+Consider updating your OpenOCD version when using multiple USB Blasters.
+
 Binds to:
   interface:
     - `AlteraUSBBlaster`_


### PR DESCRIPTION
**Description**
Until now the USB Blaster device had to be configured via OpenOCD
configs. Since OpenOCD's a1b308ab ("jtag: drivers: provide initial
support for usb path filtering") it is now possible to identify the
device via USB path.

Set the USB path via "adapter usb location" via OpenOCD's --command
argument to the path of the AlteraUSBBlaster resource.

Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated

