### PR TITLE
resource/udev: add VID and PID for i.MX8MQ

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -219,7 +219,8 @@ class IMXUSBLoader(USBResource):
                          ("15a2", "0063"), ("15a2", "0071"),
                          ("15a2", "007d"), ("15a2", "0076"),
                          ("15a2", "0080"), ("15a2", "003a"),
-                         ("1fc9", "0128"), ("1fc9", "0126")]:
+                         ("1fc9", "0128"), ("1fc9", "0126"),
+                         ("1fc9", "012b")]:
             return False
 
         return super().filter_match(device)


### PR DESCRIPTION
**Description**
The i.MX8MQ in serial download mode identifies as:
```
Bus 001 Device 057: ID 1fc9:012b NXP Semiconductors i.MX 8M Dual/8M QuadLite/8M Quad Serial Downloader
```
add the VID and PID to the IMXUSBLoader resource.

- [x] PR has been tested