### PR TITLE
close labgrid-client console connection on place release

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1342,10 +1342,13 @@ def main():
         try:
             session = start_session(args.crossbar, os.environ.get("LG_CROSSBAR_REALM", "realm1"),
                                     extra)
-            if asyncio.iscoroutinefunction(args.func):
-                session.loop.run_until_complete(args.func(session))
-            else:
-                args.func(session)
+            try:
+                if asyncio.iscoroutinefunction(args.func):
+                    session.loop.run_until_complete(args.func(session))
+                else:
+                    args.func(session)
+            finally:
+                session.loop.close()
         except NoResourceFoundError as e:
             if args.debug:
                 traceback.print_exc()

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -712,7 +712,7 @@ class ClientSession(ApplicationSession):
             'microcom', '-s', str(resource.speed), '-t',
             "{}:{}".format(host, port)
         ]
-        print("connecting to ", resource, "calling ", " ".join(call))
+        print("connecting to {} calling {}".format(resource, " ".join(call)))
         res = subprocess.call(call)
         if res:
             print("connection lost")

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -128,18 +128,20 @@ class ClientSession(ApplicationSession):
         config['matches'] = [ResourceMatch(**match) \
             for match in config['matches']]
         config = filter_dict(config, Place, warn=True)
-        place = Place(**config)
         if name not in self.places:
+            place = Place(**config)
+            self.places[name] = place
             if self.monitor:
                 print("Place {} created: {}".format(name, place))
         else:
+            place = self.places[name]
+            old = flat_dict(place.asdict())
+            place.update(config)
+            new = flat_dict(place.asdict())
             if self.monitor:
                 print("Place {} changed:".format(name))
-                for k, v_old, v_new in diff_dict(
-                        flat_dict(self.places[name].asdict()),
-                        flat_dict(place.asdict())):
+                for k, v_old, v_new in diff_dict(old, new):
                     print("  {}: {} -> {}".format(k, v_old, v_new))
-        self.places[name] = place
 
     async def do_monitor(self):
         self.monitor = True

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -112,6 +112,16 @@ class Place:
         del result['name']  # the name is the key in the places dict
         return result
 
+    def update(self, config):
+        fields = attr.fields_dict(type(self))
+        for k, v in config.items():
+            assert k in fields
+            if k == 'name':
+                # we cannot rename places
+                assert v == self.name
+                continue
+            setattr(self, k, v)
+
     def show(self, level=0):
         indent = '  ' * level
         print(indent + "aliases: {}".format(', '.join(self.aliases)))


### PR DESCRIPTION
**Description**
Currently, a `labgrid-client console` connection is left open even if the place is released (either normally or with `--kick`). With this change, we monitor the place's state and terminate microcom when we detect that the place is no longer acquired.

**Checklist**
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #449 
