### PR TITLE
resource/udev: use timeout helper

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -11,6 +11,7 @@ import pyudev
 from ..factory import target_factory
 from .common import ManagedResource, ResourceManager
 from .base import SerialPort, EthernetInterface
+from ..util import Timeout
 
 
 @attr.s(cmp=False)
@@ -37,8 +38,8 @@ class UdevManager(ResourceManager):
         self.queue.put(device)
 
     def poll(self):
-        deadline = time.monotonic() + 0.1
-        while time.monotonic() < deadline:
+        timeout = Timeout(0.1)
+        while not timeout.expired:
             try:
                 device = self.queue.get(False)
             except queue.Empty:


### PR DESCRIPTION
**Description**
Use the labgrid internal Timeout class instead of open coding the
timeout implementation.

Small correction I just realized talking to @jluebbe.

- [ ] PR has been tested
