### PR TITLE
remote/client: use idle place helper for delete

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -373,7 +373,14 @@ class ClientSession(ApplicationSession):
 
     async def del_place(self):
         """Delete a place from the coordinator"""
-        name = self.args.place
+        pattern = self.args.place
+        if pattern not in self.places:
+            raise UserError("deletes require an exact place name")
+        place = self.places[pattern]
+        if place.acquired:
+            raise UserError("place {} is not idle (acquired by {})".format(
+                place.name, place.acquired))
+        name = place.name
         if not name:
             raise UserError("missing place name. Set with -p <place> or via env var $PLACE")
         if name not in self.places:

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -117,7 +117,7 @@ def test_place_add_no_name(crossbar):
 
 def test_place_del_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client delete') as spawn:
-        spawn.expect("missing place name")
+        spawn.expect("deletes require an exact place name")
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus != 0


### PR DESCRIPTION
**Description**
The del_place function used the pure argument instead of going through
the idle place helper, allowing the user to delete acquired places. Use
the idle place helper to ensure that only idle places are deleted

- [ ] PR has been tested
