### PR TITLE
crossbar: remove event store enabled by default

### DIFF
--- a/.crossbar/config.yaml
+++ b/.crossbar/config.yaml
@@ -30,12 +30,6 @@ workers:
           caller: true
           publisher: true
         cache: true
-    store:
-      type: memory
-      event-history:
-      - uri: org.labgrid.
-        match: prefix
-        limit: 100
   transports:
   - type: web
     endpoint:


### PR DESCRIPTION
**Description**
We currently don't make use of the event store, removed it since we see
errors in the coordinator log otherwise.

- [x] PR has been tested
