### PR TITLE
update pytest to 4.6.3

### DIFF
--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import warnings
 import pytest
 
 from .. import Environment
@@ -29,10 +30,9 @@ def pytest_configure(config):
 
     if lg_env is None:
         if env_config is not None:
-            config.warn(
-                'LG-C1',
+            warnings.warn(pytest.PytestWarning(
                 "deprecated option --env-config (use --lg-env instead)",
-                __file__)
+                __file__))
             lg_env = env_config
 
     env = None

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==19.1.0
 jinja2==2.10.1
 pexpect==4.7
 https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial
-pytest==4.0.2
+pytest==4.6.3
 pyudev==0.21.0
 requests==2.22.0
 xmodem==0.4.5


### PR DESCRIPTION
Update pytest to 4.6.3, so the subtests plugin can be used. We've tested this internally for two weeks.

- [x] PR has been tested
