### PR TITLE
fix onewire PIO input

### DIFF
--- a/labgrid/driver/onewiredriver.py
+++ b/labgrid/driver/onewiredriver.py
@@ -17,14 +17,12 @@ class OneWirePIODriver(Driver, DigitalOutputProtocol):
         super().__attrs_post_init__()
         self._module = import_module('onewire')
         self._onewire = None
-        self._host = None
-        self._port = None
 
     def on_activate(self):
         # we can only forward if the backend knows which port to use
-        self._host, self._port = proxymanager.get_host_and_port(self.port)
+        host, port = proxymanager.get_host_and_port(self.port)
         self._onewire = self._module.Onewire(
-            "{}:{}".format(self._host, self._port)
+            "{}:{}".format(host, port)
         )
 
     def on_deactivate(self):
@@ -41,6 +39,7 @@ class OneWirePIODriver(Driver, DigitalOutputProtocol):
 
     @Driver.check_active
     def get(self):
+
         status = self._onewire.get(self.port.path)
         if self.port.invert:
             status = not status

--- a/tests/test_onewire.py
+++ b/tests/test_onewire.py
@@ -7,13 +7,13 @@ from labgrid.resource import OneWirePIO
 
 @pytest.fixture(scope='function')
 def onewire_port(target):
-    return OneWirePIO(target, "pio", "testhost", "path")
+    return OneWirePIO(target, "pio", "testhost", "29.123450000000/PIO.6")
 
 @pytest.fixture(scope='function')
 def onewire_driver(target, onewire_port, monkeypatch, mocker):
     onewire_mock = mocker.MagicMock
     onewire_mock.set = mocker.MagicMock()
-    onewire_mock.get = mocker.MagicMock()
+    onewire_mock.get = mocker.MagicMock(return_value='1')
     import onewire
     monkeypatch.setattr(onewire, 'Onewire', onewire_mock)
     s = OneWirePIODriver(target, "pio")
@@ -29,12 +29,13 @@ def test_onewire_driver_instance(target, onewire_driver):
 
 def test_onewire_set(onewire_driver):
     onewire_driver.set(True)
-    onewire_driver._onewire.set.assert_called_once_with("path", '1')
+    onewire_driver._onewire.set.assert_called_once_with("29.123450000000/PIO.6", '1')
 
 def test_onewire_unset(onewire_driver):
     onewire_driver.set(False)
-    onewire_driver._onewire.set.assert_called_once_with("path", '0')
+    onewire_driver._onewire.set.assert_called_once_with("29.123450000000/PIO.6", '0')
 
 def test_onewire_get(onewire_driver):
-    onewire_driver.get()
-    onewire_driver._onewire.get.assert_called_once_with("path")
+    val = onewire_driver.get()
+    onewire_driver._onewire.get.assert_called_once_with("29.123450000000/sensed.6")
+    assert val == True


### PR DESCRIPTION
**Description**
Previously, the OneWireDriver only read back the configure output value instead of the real physical line value.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested