### PR TITLE
Subprocess Wrapper

### DIFF
--- a/labgrid/driver/flashromdriver.py
+++ b/labgrid/driver/flashromdriver.py
@@ -10,6 +10,7 @@ from ..step import step
 from ..protocol import BootstrapProtocol
 from .common import Driver, check_file
 from ..util.managedfile import ManagedFile
+from ..util.helper import processwrapper
 
 
 @target_factory.reg_driver
@@ -50,7 +51,7 @@ class FlashromDriver(Driver, BootstrapProtocol):
         arg_list.append('-p')
         arg_list.append('{}'.format(self.flashrom_resource.programmer))
         self.logger.debug('Call: {} with args: {}'.format(self.tool, arg_list))
-        subprocess.check_call(self._get_flashrom_prefix() + arg_list)
+        processwrapper.check_output(self._get_flashrom_prefix() + arg_list)
 
     @Driver.check_active
     @step(args=['filename'])

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -13,6 +13,8 @@ from ..util.managedfile import ManagedFile
 from .common import Driver
 from ..driver.exception import ExecutionError
 
+from ..util.helper import processwrapper
+
 
 class Mode(enum.Enum):
     DD = 1
@@ -77,7 +79,7 @@ class NetworkUSBStorageDriver(Driver):
         else:
             raise ValueError
 
-        subprocess.check_call(
+        processwrapper.check_output(
             self.storage.command_prefix + args
         )
 
@@ -88,5 +90,5 @@ class NetworkUSBStorageDriver(Driver):
                 "{} is not available".format(self.storage_path)
             )
         args = ["cat", "/sys/class/block/{}/size" % self.storage.path[5:]]
-        size = subprocess.check_output(self.storage.command_prefix + args)
+        size = processwrapper.check_output(self.storage.command_prefix + args)
         return int(size)

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -10,6 +10,7 @@ from ..resource.remote import NetworkAlteraUSBBlaster
 from ..resource.udev import AlteraUSBBlaster
 from ..step import step
 from ..util.managedfile import ManagedFile
+from ..util.helper import processwrapper
 from .common import Driver
 
 
@@ -93,7 +94,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
             "--command", "'bootstrap {}'".format(mf.get_remote_path()),
             "--command", "'shutdown'",
         ]
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)
 
     @Driver.check_active
     @step(args=['commands'])
@@ -113,4 +114,4 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
             cmd.append(mconfig.get_remote_path())
 
         cmd += chain.from_iterable(("--command", "'{}'".format(command)) for command in commands)
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)

--- a/labgrid/driver/power/apc.py
+++ b/labgrid/driver/power/apc.py
@@ -1,11 +1,12 @@
 import subprocess
 
 from ..exception import ExecutionError
+from ...util.helper import processwrapper
 
 OID = ".1.3.6.1.4.1.318.1.1.4.4.2.1.3"
 
 def _snmp_get(host, oid):
-    out = subprocess.check_output(
+    out = processwrapper.check_output(
         "snmpget -v1 -c private -O qn {} {}".format(host, oid).split()
     ).decode('ascii')
     out_oid, value = out.strip().split(' ', 1)
@@ -20,7 +21,7 @@ def _snmp_get(host, oid):
 
 def _snmp_set(host, oid, value):
     try:
-        subprocess.check_output(
+        processwrapper.check_output(
             "snmpset -v1 -c private {} {} {}".format(host, oid, value).split()
         )
     except Exception as e:

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -13,6 +13,7 @@ from ..resource.remote import NetworkUSBPowerPort
 from ..resource.udev import USBPowerPort
 from ..step import step
 from ..util.proxy import proxymanager
+from ..util.helper import processwrapper
 from .common import Driver
 from .exception import ExecutionError
 
@@ -76,20 +77,20 @@ class ExternalPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     @step()
     def on(self):
         cmd = shlex.split(self.cmd_on)
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)
 
     @Driver.check_active
     @step()
     def off(self):
         cmd = shlex.split(self.cmd_off)
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)
 
     @Driver.check_active
     @step()
     def cycle(self):
         if self.cmd_cycle is not None:
             cmd = shlex.split(self.cmd_cycle)
-            subprocess.check_call(cmd)
+            processwrapper.check_output(cmd)
         else:
             self.off()
             time.sleep(self.delay)
@@ -239,7 +240,7 @@ class USBPowerDriver(Driver, PowerResetMixin, PowerProtocol):
             "-r", "100", # use 100 retries for now
             "-a", cmd,
         ]
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)
 
     @Driver.check_active
     @step()
@@ -265,7 +266,7 @@ class USBPowerDriver(Driver, PowerResetMixin, PowerProtocol):
             "-l", self.hub.path,
             "-p", str(self.hub.index),
         ]
-        output = subprocess.check_output(cmd)
+        output = processwrapper.check_output(cmd)
         for line in output.splitlines():
             if not line or not line.startswith(b' '):
                 continue

--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -9,6 +9,7 @@ from ..resource.udev import AlteraUSBBlaster
 from ..step import step
 from .common import Driver
 from .exception import ExecutionError
+from ..util.helper import processwrapper
 from ..util.managedfile import ManagedFile
 
 
@@ -75,4 +76,4 @@ class QuartusHPSDriver(Driver):
             "--addr=0x{:X}".format(address),
             "--operation=P {}".format(mf.get_remote_path()),
         ]
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -11,6 +11,7 @@ from ..step import step
 from .common import Driver
 from ..util.managedfile import ManagedFile
 from ..util.timeout import Timeout
+from ..util.helper import processwrapper
 
 
 @target_factory.reg_driver
@@ -44,7 +45,7 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
         mf = ManagedFile(filename, self.loader)
         mf.sync_to_resource()
 
-        subprocess.check_call(
+        processwrapper.check_output(
             self.loader.command_prefix + [self.tool, "0", mf.get_remote_path()]
         )
 
@@ -80,7 +81,7 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
         mf = ManagedFile(filename, self.loader)
         mf.sync_to_resource()
 
-        subprocess.check_call(
+        processwrapper.check_output(
             self.loader.command_prefix +
             [self.tool, "-p", str(self.loader.path), "-c", mf.get_remote_path()]
         )
@@ -121,7 +122,7 @@ class RKUSBDriver(Driver, BootstrapProtocol):
         timeout = Timeout(3.0)
         while True:
             try:
-                subprocess.check_call(
+                processwrapper.check_output(
                     self.loader.command_prefix +
                     [self.tool, 'db', mf.get_remote_path()]
                 )
@@ -138,7 +139,7 @@ class RKUSBDriver(Driver, BootstrapProtocol):
         timeout = Timeout(3.0)
         while True:
             try:
-                subprocess.check_call(
+                processwrapper.check_output(
                     self.loader.command_prefix +
                     [self.tool, 'wl', '0x40', mf.get_remote_path()]
                 )

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -8,6 +8,7 @@ from ..resource.remote import NetworkUSBSDMuxDevice
 from ..resource.udev import USBSDMuxDevice
 from ..step import step
 from .exception import ExecutionError
+from ..util.helper import processwrapper
 
 @target_factory.reg_driver
 @attr.s(cmp=False)
@@ -41,4 +42,4 @@ class USBSDMuxDriver(Driver):
             self.mux.control_path,
             mode.lower()
         ]
-        subprocess.check_call(cmd)
+        processwrapper.check_output(cmd)

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -6,6 +6,7 @@ import pytest
 from .. import Environment
 from ..consoleloggingreporter import ConsoleLoggingReporter
 from .reporter import StepReporter, ColoredStepReporter
+from ..util.helper import processwrapper
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
@@ -45,6 +46,8 @@ def pytest_configure(config):
         if lg_coordinator is not None:
             env.config.set_option('crossbar_url', lg_coordinator)
     config._labgrid_env = env
+
+    processwrapper.enable_logging()
 
 @pytest.hookimpl()
 def pytest_collection_modifyitems(config, items):

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -25,6 +25,7 @@ from ..util.dict import diff_dict, flat_dict, filter_dict
 from ..util.yaml import dump
 from .. import Target, target_factory
 from ..util.proxy import proxymanager
+from ..util.helper import processwrapper
 
 txaio.use_asyncio()
 txaio.config.loop = asyncio.get_event_loop()
@@ -1079,6 +1080,7 @@ def find_any_role_with_place(config):
     return None, None
 
 def main():
+    processwrapper.enable_print()
     logging.basicConfig(
         level=logging.INFO,
         format='%(levelname)7s: %(message)s',

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -89,5 +89,20 @@ class ProcessWrapper:
         assert callback in self.callbacks
         self.callbacks.remove(callback)
 
+    def enable_logging(self):
+        """Enables process output to the logging interface.
+        Loglevel is logging.INFO."""
+        def log_callback(message):
+            import logging
+            logger = logging.getLogger("Process")
+            logger.info(message.decode(encoding="utf-8", errors="replace"))
+        self.register(log_callback)
+
+    def enable_print(self):
+        """Enables process output to print."""
+        def print_callback(message):
+            print(message.decode(encoding="utf-8", errors="replace"))
+        self.register(print_callback)
+
 
 processwrapper = ProcessWrapper()

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -1,6 +1,14 @@
+import fcntl
 import os
+import pty
+import select
+import subprocess
 from socket import socket, AF_INET, SOCK_STREAM
 from contextlib import closing
+
+import attr
+
+from ..step import step
 
 def get_free_port():
     """Helper function to always return an unused port."""
@@ -8,9 +16,78 @@ def get_free_port():
         s.bind(('', 0))
         return s.getsockname()[1]
 
+
 def get_user():
+    """Get the username of the current user."""
     user = os.environ.get("USER")
     if user:
         return user
     import pwd
     return pwd.getpwuid(os.getuid())[0]
+
+@attr.s
+class ProcessWrapper:
+    callbacks = attr.ib(default=attr.Factory(list))
+
+    @step(args=['command'], result=True, tag='process')
+    def check_output(self, command):
+        """Run a command and supply the output to callback functions"""
+        res = []
+        mfd, sfd = pty.openpty()
+        flags = fcntl.fcntl(mfd, fcntl.F_GETFL)
+        fcntl.fcntl(mfd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        process = subprocess.Popen(command, stderr=sfd,
+                                   stdout=sfd, bufsize=0)
+        # close sfd so we notice when the child is gone
+        os.close(sfd)
+        # get a file object from the fd
+        omfd = os.fdopen(mfd, 'rb')
+        buf = b""
+        while True:
+            try:
+                raw = omfd.read(4096)
+            except OSError as e:
+                if e.errno == 5:
+                    break
+                raise
+            if raw is None:
+                # wait for new data and retry
+                select.select([mfd], [], [mfd], 0.1)
+                continue
+            if raw:
+                buf += raw
+                *parts, buf = buf.split(b'\r\n')
+                res.extend(parts)
+                for part in parts:
+                    for callback in self.callbacks:
+                        callback(part)
+            process.poll()
+            if process.returncode is not None:
+                break
+        omfd.close()
+        process.wait()
+        if process.returncode != 0:
+            raise subprocess.CalledProcessError(process.returncode,
+                                                command,
+                                                output="\n".join(res))
+        if buf:
+            # process incomplete line
+            res.append(buf)
+            for callback in self.callbacks:
+                callback(buf)
+        # this converts '\r\n' to '\n' to be more compatible to the behaviour
+        # of the normal subprocess module
+        return b'\n'.join(res)
+
+    def register(self, callback):
+        """Register a callback with the ProcessWrapper"""
+        assert callback not in self.callbacks
+        self.callbacks.append(callback)
+
+    def unregister(self, callback):
+        """Unregister a callback with the ProcessWrapper"""
+        assert callback in self.callbacks
+        self.callbacks.remove(callback)
+
+
+processwrapper = ProcessWrapper()

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -47,7 +47,18 @@ class TestExternalPowerDriver:
         assert (isinstance(d, ExternalPowerDriver))
 
     def test_on(self, target, mocker):
-        m = mocker.patch('subprocess.check_call')
+        pty = mocker.patch('pty.openpty')
+        mocker.patch('fcntl.fcntl')
+        fdopen = mocker.patch('os.fdopen')
+        close = mocker.patch('os.close')
+        popen = mocker.patch('subprocess.Popen')
+        fd_mock = mocker.MagicMock()
+        instance_mock = mocker.MagicMock()
+        popen.return_value = instance_mock
+        fdopen.return_value = fd_mock
+        pty.return_value = (instance_mock, 2)
+        fd_mock.read.return_value = b'Done\nDone'
+        instance_mock.returncode = 0
 
         d = ExternalPowerDriver(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
@@ -55,10 +66,22 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.on()
 
-        m.assert_called_once_with(['set', '-1', 'foo-board'])
+        popen.assert_called_once_with(['set', '-1', 'foo-board'], bufsize=0,
+                                      stderr=2, stdout=2)
 
     def test_off(self, target, mocker):
-        m = mocker.patch('subprocess.check_call')
+        pty = mocker.patch('pty.openpty')
+        mocker.patch('fcntl.fcntl')
+        fdopen = mocker.patch('os.fdopen')
+        close = mocker.patch('os.close')
+        popen = mocker.patch('subprocess.Popen')
+        fd_mock = mocker.MagicMock()
+        instance_mock = mocker.MagicMock()
+        popen.return_value = instance_mock
+        fdopen.return_value = fd_mock
+        pty.return_value = (instance_mock, 2)
+        fd_mock.read.return_value = b'Done\nDone'
+        instance_mock.returncode = 0
 
         d = ExternalPowerDriver(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
@@ -66,11 +89,24 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.off()
 
-        m.assert_called_once_with(['set', '-0', 'foo-board'])
+        popen.assert_called_once_with(['set', '-0', 'foo-board'], bufsize=0,
+                                      stderr=2, stdout=2)
 
     def test_cycle(self, target, mocker):
+        pty = mocker.patch('pty.openpty')
+        mocker.patch('fcntl.fcntl')
+        fdopen = mocker.patch('os.fdopen')
+        close = mocker.patch('os.close')
+        popen = mocker.patch('subprocess.Popen')
+        fd_mock = mocker.MagicMock()
+        instance_mock = mocker.MagicMock()
+        popen.return_value = instance_mock
+        fdopen.return_value = fd_mock
+        pty.return_value = (instance_mock, 2)
+        fd_mock.read.return_value = b'Done\nDone'
+        instance_mock.returncode = 0
+
         m_sleep = mocker.patch('time.sleep')
-        m = mocker.patch('subprocess.check_call')
 
         d = ExternalPowerDriver(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
@@ -78,15 +114,29 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.cycle()
 
-        assert m.call_args_list == [
-            mocker.call(['set', '-0', 'foo-board']),
-            mocker.call(['set', '-1', 'foo-board']),
+        assert popen.call_args_list == [
+            mocker.call(['set', '-0', 'foo-board'], bufsize=0, stderr=2,
+                        stdout=2),
+            mocker.call(['set', '-1', 'foo-board'], bufsize=0, stderr=2,
+                        stdout=2),
         ]
         m_sleep.assert_called_once_with(2.0)
 
     def test_cycle_explicit(self, target, mocker):
+        pty = mocker.patch('pty.openpty')
+        mocker.patch('fcntl.fcntl')
+        fdopen = mocker.patch('os.fdopen')
+        close = mocker.patch('os.close')
+        popen = mocker.patch('subprocess.Popen')
+        fd_mock = mocker.MagicMock()
+        instance_mock = mocker.MagicMock()
+        popen.return_value = instance_mock
+        fdopen.return_value = fd_mock
+        pty.return_value = (instance_mock, 2)
+        fd_mock.read.return_value = b'Done\nDone'
+        instance_mock.returncode = 0
+
         m_sleep = mocker.patch('time.sleep')
-        m = mocker.patch('subprocess.check_call')
 
         d = ExternalPowerDriver(
             target, 'power',
@@ -97,7 +147,8 @@ class TestExternalPowerDriver:
         target.activate(d)
         d.cycle()
 
-        m.assert_called_once_with(['set', '-c', 'foo-board'])
+        popen.assert_called_once_with(['set', '-c', 'foo-board'], bufsize=0,
+                                      stderr=2, stdout=2)
         m_sleep.assert_not_called()
 
 class TestNetworkPowerDriver:


### PR DESCRIPTION
**Description**
This PR adds a subprocess wrapper which acts like `subprocess.check_output`, but takes callbacks to send the output of the command to.
`processmanager.register` adds a callback, `processmanager.unregister` removes the callback. Callbacks receive the process output line based.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] PR has been tested

**TODO List**
- [x] Logging callback for pytest
- [x] Print callback for library usage