### PR TITLE
graphstrategy: raise if via is not list or None

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -103,6 +103,10 @@ class GraphStrategy(Strategy):
 
     @step(args=['state'])
     def transition(self, state, via=None):
+        if not isinstance(via, (type(None), list)):
+            raise GraphStrategyRuntimeError(
+                "'via' has to be a list or None"
+                )
         # for use with labgrid-client -s, if only state is set, try to extract
         # the via states
         if ':' in state and via is None:

--- a/tests/test_graphstrategy.py
+++ b/tests/test_graphstrategy.py
@@ -255,4 +255,7 @@ def test_transition_error(target):
     with pytest.raises(Exception):
         strategy.transition('B')
 
+    with pytest.raises(Exception):
+        strategy.transition('B', via='B')
+
     assert strategy.path == []


### PR DESCRIPTION
**Description**
This prevents debugging sessions where a string is passed accidentally
to via and handled like a list.

**Checklist**
- [x] Tests for the feature 
