### PR TITLE
Acquire resources on exporter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,9 @@ New Features in 0.3.0
   on the DUT can be written directly. The flashrom driver implements the
   bootstrap protocol.
 - AndroidFastbootDriver now supports 'getvar' and 'oem getenv' subcommands.
+- The coordinator now updates the resource acquired state at the exporter.
+  Accordingly, the exporter now starts ser2net only when a resources is
+  aquired. Furthermore, resource conflicts between places are now detected.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -47,6 +47,11 @@ class ResourceEntry:
             'avail': self.avail,
         }
 
+    def update(self, data):
+        data = data.copy()
+        data.setdefault('avail', False)
+        self.data = data
+
 
 @attr.s(cmp=True, repr=False, str=False)
 # This class requires cmp=True, since we put the matches into a list and require

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -10,10 +10,14 @@ import attr
 @attr.s(cmp=False)
 class ResourceEntry:
     data = attr.ib()  # cls, params
-    acquired = attr.ib(default=None)
 
     def __attrs_post_init__(self):
+        self.data.setdefault('acquired', None)
         self.data.setdefault('avail', False)
+
+    @property
+    def acquired(self):
+        return self.data['acquired']
 
     @property
     def avail(self):
@@ -48,9 +52,19 @@ class ResourceEntry:
         }
 
     def update(self, data):
+        """apply updated information from the exporter on the coordinator"""
         data = data.copy()
+        data.setdefault('acquired', None)
         data.setdefault('avail', False)
         self.data = data
+
+    def acquire(self, place_name):
+        assert self.data['acquired'] is None
+        self.data['acquired'] = place_name
+
+    def release(self):
+        # ignore repeated releases
+        self.data['acquired'] = None
 
 
 @attr.s(cmp=True, repr=False, str=False)

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -113,9 +113,24 @@ class Place:
     changed = attr.ib(default=attr.Factory(time.time))
 
     def asdict(self):
-        result = attr.asdict(self)
-        del result['name']  # the name is the key in the places dict
-        return result
+        # in the coordinator, we have resource objects, otherwise just a path
+        acquired_resources = []
+        for resource in self.acquired_resources:  # pylint: disable=not-an-iterable
+            if isinstance(resource, (tuple, list)):
+                acquired_resources.append(resource)
+            else:
+                acquired_resources.append(resource.path)
+
+        return {
+            'aliases': list(self.aliases),
+            'comment': self.comment,
+            'matches': [attr.asdict(x) for x in self.matches],
+            'acquired': self.acquired,
+            'acquired_resources': acquired_resources,
+            'allowed': list(self.allowed),
+            'created': self.created,
+            'changed': self.changed,
+        }
 
     def update(self, config):
         fields = attr.fields_dict(type(self))
@@ -136,7 +151,12 @@ class Place:
             print(indent + "  {}".format(match))
         print(indent + "acquired: {}".format(self.acquired))
         print(indent + "acquired resources:")
-        for resource_path in self.acquired_resources:  # pylint: disable=not-an-iterable
+        # in the coordinator, we have resource objects, otherwise just a path
+        for resource in self.acquired_resources:  # pylint: disable=not-an-iterable
+            if isinstance(resource, (tuple, list)):
+                resource_path = resource
+            else:
+                resource_path = resource.path
             match = self.getmatch(resource_path)
             if match.rename:
                 print(indent + "  {} → {}".format(

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -302,11 +302,11 @@ class CoordinatorComponent(ApplicationSession):
             # only add if there is no conflict
             if len(places) != 1:
                 return
-            place.acquired_resources.append(resource.path)
+            place.acquired_resources.append(resource)
             self._publish_place(place)
         else:
             for place in places:
-                place.acquired_resources.remove(resource.path)
+                place.acquired_resources.remove(resource)
             self._publish_place(place)
 
     def _publish_place(self, place):
@@ -482,7 +482,7 @@ class CoordinatorComponent(ApplicationSession):
                 for _, resource in sorted(group.items()):
                     if not place.hasmatch(resource.path):
                         continue
-                    place.acquired_resources.append(resource.path)
+                    place.acquired_resources.append(resource)
         place.touch()
         self._publish_place(place)
         self.save_later()

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -484,18 +484,17 @@ class CoordinatorComponent(ApplicationSession):
         acquired = []
         try:
             for resource in resources:
-                acquired.append(resource)
                 # this triggers an update from the exporter which is published
                 # to the clients
                 await self.call('org.labgrid.exporter.{}.acquire'.format(resource.path[0]),
-                        resource.path[1], resource.path[3])
+                        resource.path[1], resource.path[3], place.name)
+                acquired.append(resource)
         except:
             # cleanup
             await self.release_resources(place, acquired)
             return False
 
         for resource in resources:
-            resource.acquired = place
             place.acquired_resources.append(resource)
 
         return True
@@ -504,7 +503,6 @@ class CoordinatorComponent(ApplicationSession):
         resources = resources.copy() # we may modify the list
 
         for resource in resources:
-            resource.acquired = None
             try:
                 place.acquired_resources.remove(resource)
             except ValueError:

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -424,16 +424,16 @@ class ExporterSession(ApplicationSession):
             await asyncio.sleep(0.5) # give others a chance to clean up
         self.loop.stop()
 
-    async def acquire(self, group_name, resource_name):
+    async def acquire(self, group_name, resource_name, place_name):
         # TODO: perform local actions when a resource is acquired
-        #resource = self.groups[group_name][resource_name]
-        #resource.acquire()
+        resource = self.groups[group_name][resource_name]
+        resource.acquire(place_name)
         await self.update_resource(group_name, resource_name)
 
     async def release(self, group_name, resource_name):
         # TODO: perform local actions when a resource is released
-        #resource = self.groups[group_name][resource_name]
-        #resource.release()
+        resource = self.groups[group_name][resource_name]
+        resource.release()
         await self.update_resource(group_name, resource_name)
 
     async def version(self):

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -381,6 +381,12 @@ class ExporterSession(ApplicationSession):
         - bail out if we are unsuccessful
         """
         print(details)
+
+        prefix = 'org.labgrid.exporter.{}'.format(self.name)
+        await self.register(self.acquire, '{}.acquire'.format(prefix))
+        await self.register(self.release, '{}.release'.format(prefix))
+        await self.register(self.version, '{}.version'.format(prefix))
+
         try:
             resource_config = ResourceConfig(self.config.extra['resources'])
             for group_name, group in resource_config.data.items():
@@ -391,6 +397,7 @@ class ExporterSession(ApplicationSession):
                         continue
                     cls = params.pop('cls', resource_name)
 
+                    # this may call back to acquire the resource immediately
                     await self.add_resource(
                         group_name, resource_name, cls, params
                     )
@@ -401,11 +408,6 @@ class ExporterSession(ApplicationSession):
             return
 
         self.poll_task = self.loop.create_task(self.poll())
-
-        prefix = 'org.labgrid.exporter.{}'.format(self.name)
-        await self.register(self.acquire, '{}.acquire'.format(prefix))
-        await self.register(self.release, '{}.release'.format(prefix))
-        await self.register(self.version, '{}.version'.format(prefix))
 
     async def onLeave(self, details):
         """Cleanup after leaving the coordinator connection"""

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -453,13 +453,7 @@ class ExporterSession(ApplicationSession):
                     traceback.print_exc()
                     continue
                 if changed:
-                    # resource has changed
-                    data = resource.asdict()
-                    print(data)
-                    await self.call(
-                        'org.labgrid.coordinator.set_resource', group_name,
-                        resource_name, data
-                    )
+                    await self.update_resource(group_name, resource_name)
 
     async def poll(self):
         while True:

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -161,13 +161,15 @@ class USBSerialPortExport(ResourceExport):
         # stop ser2net
         child = self.child
         self.child = None
+        port = self.port
+        self.port = None
         child.terminate()
         try:
             child.wait(1.0)
         except subprocess.TimeoutExpired:
             child.kill()
             child.wait(1.0)
-        self.logger.info("stopped ser2net for %s on port %d", start_params['path'], self.port)
+        self.logger.info("stopped ser2net for %s on port %d", start_params['path'], port)
 
 
 exports["USBSerialPort"] = USBSerialPortExport

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -463,7 +463,7 @@ class ExporterSession(ApplicationSession):
     async def poll(self):
         while True:
             try:
-                await asyncio.sleep(1.0)
+                await asyncio.sleep(0.25)
                 await self._poll_step()
             except asyncio.CancelledError:
                 break

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -138,3 +138,24 @@ def test_remoteplace_target(place_acquire, tmpdir):
     e = Environment(str(p))
     t = e.get_target("test1")
     t.await_resources(t.resources)
+
+def test_resource_conflict(place_acquire, tmpdir):
+    with pexpect.spawn('python -m labgrid.remote.client -p test2 create') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test2 add-match "*/*/*"') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test2 acquire') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus != 0
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test2 delete') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0


### PR DESCRIPTION
**Description**
Currently, the coordinator doesn't track which resources are used by which places. Accordingly, it can't detect if two places configured for the same resource are acquired at the same time.
To solve this, we need to refactor the coordinator to track the acquired state of resources and let it detect conflicts.
Additionally, as the exporter now knows which resources are acquired, we can start any helper processes only when needed.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested