### PR TITLE
place reservation

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -585,17 +585,6 @@ The inactive Driver could then cause a preemption and would be activated.
 The current caller of the originally active driver would be notified via an
 exception.
 
-Remote Target Reservation
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-For integration with CI systems (like Jenkins), it would help if the CI job
-could reserve and wait for a specific target.
-This could be done by managing a list of waiting users in the coordinator and
-notifying the current user on each invocation of labgrid-client that another
-user is waiting.
-The reservation should expire after some time if it is not used to lock the
-target after it becomes available.
-
 Step Tracing
 ~~~~~~~~~~~~
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -157,6 +157,7 @@ The documentation is inside ``doc/``.  HTML-Documentation is build using:
 
 The HTML documentation is written to ``doc/.build/html/``.
 
+.. _remote-getting-started:
 
 Setting Up the Distributed Infrastructure
 -----------------------------------------
@@ -304,6 +305,7 @@ Now we can connect to the serial console:
 
     $ labgrid-client -p example-place console
 
+See :ref:`remote-usage` for some more advanced features.
 For a complete reference have a look at the :doc:`labgrid-client(1) <man/client>`
 man page.
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -217,6 +217,9 @@ These components communicate over the `WAMP <http://wamp-proto.org/>`_
 implementation `Autobahn <http://autobahn.ws/>`_ and the `Crossbar
 <http://crossbar.io/>`_ WAMP router.
 
+The following sections describe the resposibilities of each component. See
+:ref:`remote-usage` for usage information.
+
 Coordinator
 ~~~~~~~~~~~
 
@@ -245,6 +248,10 @@ Each place can have aliases to simplify accessing a specific board (which might
 be moved between generic places).
 It also has a comment, which is used to store a short description of the
 connected board.
+
+To support selecting a specific place from a group containing similar or
+identical hardware, key-value tags can be added to places and used for
+scheduling.
 
 Finally, a place is configured with one or more `resource matches`.
 A resource match pattern has the format ``<exporter>/<group>/<class>``, where

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -168,11 +168,14 @@ class Place:
 
     def show(self, level=0):
         indent = '  ' * level
-        print(indent + "aliases: {}".format(', '.join(self.aliases)))
-        print(indent + "comment: {}".format(self.comment))
-        print(indent + "tags: {}".format(
-            ', '.join(k+"="+v for k, v in sorted(self.tags.items()))
-        ))
+        if self.aliases:
+            print(indent + "aliases: {}".format(', '.join(self.aliases)))
+        if self.comment:
+            print(indent + "comment: {}".format(self.comment))
+        if self.tags:
+            print(indent + "tags: {}".format(
+                ', '.join(k+"="+v for k, v in sorted(self.tags.items()))
+            ))
         print(indent + "matches:")
         for match in self.matches:  # pylint: disable=not-an-iterable
             print(indent + "  {}".format(match))
@@ -191,7 +194,8 @@ class Place:
             else:
                 print(indent + "  {}".format(
                     '/'.join(resource_path)))
-        print(indent + "allowed: {}".format(', '.join(self.allowed)))
+        if self.allowed:
+            print(indent + "allowed: {}".format(', '.join(self.allowed)))
         print(indent + "created: {}".format(datetime.fromtimestamp(self.created)))
         print(indent + "changed: {}".format(datetime.fromtimestamp(self.changed)))
 

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -1,10 +1,18 @@
 # pylint: disable=unsubscriptable-object
 import socket
 import time
+import enum
+import random
+import re
+import string
 from datetime import datetime
 from fnmatch import fnmatchcase
 
 import attr
+
+
+TAG_KEY = re.compile(r"[a-z][a-z0-9_]+")
+TAG_VAL = re.compile(r"[a-z0-9_]?")
 
 
 @attr.s(cmp=False)
@@ -119,6 +127,7 @@ class Place:
     name = attr.ib()
     aliases = attr.ib(default=attr.Factory(set), converter=set)
     comment = attr.ib(default="")
+    tags = attr.ib(default=attr.Factory(dict))
     matches = attr.ib(default=attr.Factory(list))
     acquired = attr.ib(default=None)
     acquired_resources = attr.ib(default=attr.Factory(list))
@@ -138,6 +147,7 @@ class Place:
         return {
             'aliases': list(self.aliases),
             'comment': self.comment,
+            'tags': self.tags,
             'matches': [attr.asdict(x) for x in self.matches],
             'acquired': self.acquired,
             'acquired_resources': acquired_resources,
@@ -160,6 +170,9 @@ class Place:
         indent = '  ' * level
         print(indent + "aliases: {}".format(', '.join(self.aliases)))
         print(indent + "comment: {}".format(self.comment))
+        print(indent + "tags: {}".format(
+            ', '.join(k+"="+v for k, v in sorted(self.tags.items()))
+        ))
         print(indent + "matches:")
         for match in self.matches:  # pylint: disable=not-an-iterable
             print(indent + "  {}".format(match))

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -16,6 +16,7 @@ from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 from autobahn.wamp.types import RegisterOptions
 
 from .common import *
+from .scheduler import TagSet, schedule
 from ..util import atomic_replace
 
 
@@ -123,6 +124,7 @@ class CoordinatorComponent(ApplicationSession):
     async def onConnect(self):
         self.sessions = {}
         self.places = {}
+        self.reservations = {}
         self.poll_task = None
         self.save_scheduled = False
 
@@ -202,6 +204,25 @@ class CoordinatorComponent(ApplicationSession):
             self.get_places, 'org.labgrid.coordinator.get_places'
         )
 
+        # reservations
+        await self.register(
+            self.create_reservation,
+            'org.labgrid.coordinator.create_reservation',
+            options=RegisterOptions(details_arg='details'),
+        )
+        await self.register(
+            self.cancel_reservation,
+            'org.labgrid.coordinator.cancel_reservation',
+        )
+        await self.register(
+            self.poll_reservation,
+            'org.labgrid.coordinator.poll_reservation',
+        )
+        await self.register(
+            self.get_reservations,
+            'org.labgrid.coordinator.get_reservations',
+        )
+
         self.poll_task = asyncio.get_event_loop().create_task(self.poll())
 
         print("Coordinator ready.")
@@ -246,6 +267,8 @@ class CoordinatorComponent(ApplicationSession):
                         pass # disconnected
                     else:
                         raise
+        # update reservations
+        self.schedule_reservations()
 
     async def poll(self):
         loop = asyncio.get_event_loop()
@@ -288,6 +311,8 @@ class CoordinatorComponent(ApplicationSession):
                     del config['acquired_resources']
                 if 'allowed' in config:
                     del config['allowed']
+                if 'reservation' in config:
+                    del config['reservation']
                 config['matches'] = [ResourceMatch(**match) for match in config['matches']]
                 place = Place(**config)
                 self.places[placename] = place
@@ -602,6 +627,10 @@ class CoordinatorComponent(ApplicationSession):
             return False
         if place.acquired:
             return False
+        if place.reservation:
+            res = self.reservations[place.reservation]
+            if not res.owner == self.sessions[details.caller].name:
+                return False
         # FIXME use the session object instead? or something else which
         # survives disconnecting clients?
         place.acquired = self.sessions[details.caller].name
@@ -621,6 +650,7 @@ class CoordinatorComponent(ApplicationSession):
         place.touch()
         self._publish_place(place)
         self.save_later()
+        self.schedule_reservations()
         return True
 
     @locked
@@ -640,6 +670,7 @@ class CoordinatorComponent(ApplicationSession):
         place.touch()
         self._publish_place(place)
         self.save_later()
+        self.schedule_reservations()
         return True
 
     @locked
@@ -665,6 +696,155 @@ class CoordinatorComponent(ApplicationSession):
     async def get_places(self, details=None):
         return self._get_places()
 
+    def schedule_reservations(self):
+        # The primary information is stored in the reservations and the places
+        # only have a copy for convenience.
+
+        # expire reservations
+        for res in list(self.reservations.values()):
+            if res.state is ReservationState.acquired:
+                # acquired reservations do not expire
+                res.refresh()
+            if not res.expired:
+                continue
+            if res.state is not ReservationState.expired:
+                res.state = ReservationState.expired
+                res.allocations.clear()
+                res.refresh()
+                print('reservation ({}/{}) is now {}'.format(res.owner, res.token, res.state.name))
+            else:
+                del self.reservations[res.token]
+                print('removed {} reservation ({}/{})'.format(res.state.name, res.owner, res.token))
+
+        # check which places are already allocated and handle state transitions
+        allocated_places = set()
+        for res in self.reservations.values():
+            acquired_places = set()
+            for group in list(res.allocations.values()):
+                for name in group:
+                    place = self.places.get(name)
+                    if place is None:
+                        # the allocated place was deleted
+                        res.state = ReservationState.invalid
+                        res.allocations.clear()
+                        res.refresh(300)
+                        print('reservation ({}/{}) is now {}'.format(res.owner, res.token, res.state.name))
+                    if place.acquired is not None:
+                        acquired_places.add(name)
+                    assert name not in allocated_places, "conflicting allocation"
+                    allocated_places.add(name)
+            if acquired_places and res.state is ReservationState.allocated:
+                # an allocated place was acquired
+                res.state = ReservationState.acquired
+                res.refresh()
+                print('reservation ({}/{}) is now {}'.format(res.owner, res.token, res.state.name))
+            if not acquired_places and res.state is ReservationState.acquired:
+                # all allocated places were released
+                res.state = ReservationState.allocated
+                res.refresh()
+                print('reservation ({}/{}) is now {}'.format(res.owner, res.token, res.state.name))
+
+        # check which places are available for allocation
+        available_places = set()
+        for name, place in self.places.items():
+            if place.acquired is None and place.reservation is None:
+                available_places.add(name)
+        assert not (available_places & allocated_places), "inconsistent allocation"
+        available_places -= allocated_places
+
+        # check which reservations should be handled, ordered by priority and age
+        pending_reservations = []
+        for res in sorted(self.reservations.values(), key=lambda x: (-x.prio, x.created)):
+            if res.state is not ReservationState.waiting:
+                continue
+            pending_reservations.append(res)
+
+        # run scheduler
+        place_tagsets = []
+        for name in available_places:
+            tags = set(self.places[name].tags.items())
+            # support place names
+            tags |= {('name', name)}
+            # support place aliases
+            place_tagsets.append(TagSet(name, tags))
+        filter_tagsets = []
+        for res in pending_reservations:
+            filter_tagsets.append(TagSet(res.token, set(res.filters['main'].items())))
+        allocation = schedule(place_tagsets, filter_tagsets)
+
+        # apply allocations
+        for res_token, place_name in allocation.items():
+            res = self.reservations[res_token]
+            res.allocations = {'main': [place_name]}
+            res.state = ReservationState.allocated
+            res.refresh()
+            print('reservation ({}/{}) is now {}'.format(res.owner, res.token, res.state.name))
+
+        # update reservation property of each place and notify
+        old_map = {}
+        for place in self.places.values():
+            old_map[place.name] = place.reservation
+            place.reservation = None
+        new_map = {}
+        for res in self.reservations.values():
+            if not res.allocations:
+                continue
+            assert len(res.allocations) == 1, "only one filter group is implemented"
+            for group in res.allocations.values():
+                for name in group:
+                    assert name not in new_map, "conflicting allocation"
+                    new_map[name] = res.token
+                    place = self.places.get(name)
+                    assert place is not None, "invalid allocation"
+                    place.reservation = res.token
+        for name in old_map.keys() | new_map.keys():
+            if old_map.get(name) != new_map.get(name):
+                self._publish_place(place)
+
+    @locked
+    async def create_reservation(self, spec, prio=0.0, details=None):
+        filter = {}
+        for pair in spec.split():
+            try:
+                k, v = pair.split('=')
+            except ValueError:
+                return None
+            if not TAG_KEY.match(k):
+                return None
+            if not TAG_VAL.match(v):
+                return None
+            filter[k] = v
+
+        filters = {'main': filter} # currently, only one group is implemented
+
+        owner = self.sessions[details.caller].name
+        res = Reservation(owner=owner, prio=prio, filters=filters)
+        self.reservations[res.token] = res
+        self.schedule_reservations()
+        return {res.token: res.asdict()}
+
+    @locked
+    async def cancel_reservation(self, token, details=None):
+        if not isinstance(token, str):
+            return False
+        if token not in self.reservations:
+            return False
+        del self.reservations[token]
+        self.schedule_reservations()
+        return True
+
+    @locked
+    async def poll_reservation(self, token, details=None):
+        try:
+            res = self.reservations[token]
+        except KeyError:
+            return None
+        res.refresh()
+        return res.asdict()
+
+    @locked
+    async def get_reservations(self, details=None):
+        return {k: v.asdict() for k, v in self.reservations.items()}
 
 if __name__ == '__main__':
     runner = ApplicationRunner(

--- a/labgrid/remote/scheduler.py
+++ b/labgrid/remote/scheduler.py
@@ -1,0 +1,51 @@
+from collections import defaultdict
+
+import attr
+
+
+@attr.s(cmp=False)
+class TagSet:
+    name = attr.ib(validator=attr.validators.instance_of(str))
+    tags = attr.ib(validator=attr.validators.instance_of(set))
+
+
+def schedule_step(places, filters):
+    "Find the filters that can be directly allocated without overlap."
+    interest = defaultdict(list)
+    for f in filters:
+        for place in places:
+            if f.tags.issubset(place.tags):
+                interest[place].append(f)
+
+    if not interest:
+        return {}
+
+    limit = min(map(len, interest.values()))
+    allocation = {}
+    for place, filters in interest.items():
+        if len(filters) == limit:
+            allocation[filters.pop(0)] = place
+
+    return allocation
+
+
+def schedule_overlaps(places, filters):
+    "Iterate schedule_step until no more allocations are found."
+    places = places[:]
+    filters = filters[:]
+    allocation = {}
+    while True:
+        new = schedule_step(places, filters)
+        if not new:
+            break
+        for f, place in new.items():
+            assert f not in allocation
+            places.remove(place)
+            filters.remove(f)
+            allocation[f] = place
+    return allocation
+
+
+def schedule(places, filters):
+    allocation = schedule_overlaps(places, filters)
+    return {f.name: p.name for f, p in allocation.items()}

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -79,6 +79,10 @@ Various labgrid\-client commands use the following environment variable:
 .SS LG_PLACE
 .sp
 This variable can be used to specify a place without using the \fB\-p\fP option, the \fB\-p\fP option overrides it.
+.SS LG_TOKEN
+.sp
+This variable can be used to specify a reservation for the \fBwait\fP command and
+for the \fB+\fP place expansion.
 .SS LG_STATE
 .sp
 This variable can be used to specify a state which the device transitions into
@@ -130,6 +134,8 @@ matches anything.
 .sp
 \fBset\-comment\fP comment         Update or set the place comment
 .sp
+\fBset\-tags\fP comment            Set place tags (key=value)
+.sp
 \fBadd\-match\fP match             Add one (or multiple) match pattern(s) to a place, see MATCHES
 .sp
 \fBdel\-match\fP match             Delete one (or multiple) match pattern(s) from a place, see MATCHES
@@ -164,7 +170,15 @@ matches anything.
 .sp
 \fBtmc\fP command                 Control a USB TMC device
 .sp
-\fBwrite\-image\fP         Write images onto block devices (USBSDMux, USB Sticks, …)
+\fBwrite\-image\fP                 Write images onto block devices (USBSDMux, USB Sticks, …)
+.sp
+\fBreserve\fP filter              Create a reservation
+.sp
+\fBcancel\-reservation\fP token    Cancel a pending reservation
+.sp
+\fBwait\fP token                  Wait for a reservation to be allocated
+.sp
+\fBreservations\fP                List current reservations
 .SH EXAMPLES
 .sp
 To retrieve a list of places run:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -64,6 +64,11 @@ LG_PLACE
 ~~~~~~~~
 This variable can be used to specify a place without using the ``-p`` option, the ``-p`` option overrides it.
 
+LG_TOKEN
+~~~~~~~~
+This variable can be used to specify a reservation for the ``wait`` command and
+for the ``+`` place expansion.
+
 LG_STATE
 ~~~~~~~~
 This variable can be used to specify a state which the device transitions into
@@ -121,6 +126,8 @@ LABGRID-CLIENT COMMANDS
 
 ``set-comment`` comment         Update or set the place comment
 
+``set-tags`` comment            Set place tags (key=value)
+
 ``add-match`` match             Add one (or multiple) match pattern(s) to a place, see MATCHES
 
 ``del-match`` match             Delete one (or multiple) match pattern(s) from a place, see MATCHES
@@ -155,7 +162,16 @@ LABGRID-CLIENT COMMANDS
 
 ``tmc`` command                 Control a USB TMC device
 
-``write-image``         Write images onto block devices (USBSDMux, USB Sticks, …)
+``write-image``                 Write images onto block devices (USBSDMux, USB Sticks, …)
+
+``reserve`` filter              Create a reservation
+
+``cancel-reservation`` token    Cancel a pending reservation
+
+``wait`` token                  Wait for a reservation to be allocated
+
+``reservations``                List current reservations
+
 
 EXAMPLES
 --------

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -1,3 +1,6 @@
+import os
+import re
+
 from importlib.util import find_spec
 
 import pytest
@@ -12,6 +15,11 @@ def test_startup(crossbar):
 @pytest.fixture(scope='function')
 def place(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client -p test create') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test set-tags board=bar') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
@@ -156,6 +164,83 @@ def test_resource_conflict(place_acquire, tmpdir):
         assert spawn.exitstatus != 0
 
     with pexpect.spawn('python -m labgrid.remote.client -p test2 delete') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+def test_reservation(place_acquire, tmpdir):
+    with pexpect.spawn('python -m labgrid.remote.client reserve --shell board=bar name=test') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+        m = re.search(rb"^export LG_TOKEN=(\S+)$", spawn.before.replace(b'\r\n', b'\n'), re.MULTILINE)
+        assert m is not None
+        token = m.group(1)
+
+    env = os.environ.copy()
+    env['LG_TOKEN'] = token.decode('ASCII')
+
+    with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+        assert b'waiting' in spawn.before
+        assert token in spawn.before
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+        assert b'allocated' in spawn.before
+        assert token in spawn.before
+
+    with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+        assert b'allocated' in spawn.before
+        assert token in spawn.before
+
+    with pexpect.spawn('python -m labgrid.remote.client -p + acquire', env=env) as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client -p + show', env=env) as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert token in spawn.before
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client -p + release', env=env) as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+        assert b'allocated' in spawn.before
+        assert token in spawn.before
+
+    with pexpect.spawn('python -m labgrid.remote.client cancel-reservation', env=env) as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+    with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+        assert token not in spawn.before
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0

--- a/tests/test_sched.py
+++ b/tests/test_sched.py
@@ -1,0 +1,81 @@
+from labgrid.remote.scheduler import *
+
+def test_simple():
+    places = [
+        TagSet('place-1', {'name=place-1', 'soc=mx6'}),
+        TagSet('place-2', {'name=place-2', 'soc=mx8'}),
+    ]
+    filters = [
+        TagSet('res-1', {'soc=mx8'}),
+        TagSet('res-2', {'soc=mx6'}),
+    ]
+    expected = {
+        'res-1': 'place-2',
+        'res-2': 'place-1',
+    }
+
+    assert schedule(places, filters) == expected
+    assert schedule(places, filters[::-1]) == expected
+    assert schedule(places[::-1], filters) == expected
+    assert schedule(places[::-1], filters[::-1]) == expected
+
+
+def test_overlap():
+    places = [
+        TagSet('place-1', {'name=place-1', 'soc=mx6', 'arch=arm'}),
+        TagSet('place-2', {'name=place-2', 'soc=mx8', 'arch=arm'}),
+    ]
+    filters = [
+        TagSet('res-1', {'arch=arm'}),
+        TagSet('res-2', {'soc=mx6'}),
+    ]
+    expected = {
+        'res-1': 'place-2',
+        'res-2': 'place-1',
+    }
+
+    assert schedule(places, filters) == expected
+    assert schedule(places, filters[::-1]) == expected
+    assert schedule(places[::-1], filters) == expected
+    assert schedule(places[::-1], filters[::-1]) == expected
+
+
+def test_flexible():
+    places = [
+        TagSet('place-1', {'name=place-1', 'board=foo'}),
+        TagSet('place-2', {'name=place-2', 'board=foo'}),
+    ]
+    filters = [
+        TagSet('res-1', {'board=foo'}),
+        TagSet('res-2', {'board=foo'}),
+    ]
+    expected_keys = {'res-1', 'res-2'}
+    expected_vals = {'place-1', 'place-2'}
+
+    allocation = schedule(places, filters)
+    assert allocation.keys() == expected_keys
+    assert set(allocation.values()) == expected_vals
+    allocation = schedule(places, filters[::-1])
+    assert allocation.keys() == expected_keys
+    assert set(allocation.values()) == expected_vals
+    allocation = schedule(places[::-1], filters)
+    assert allocation.keys() == expected_keys
+    assert set(allocation.values()) == expected_vals
+    allocation = schedule(places[::-1], filters[::-1])
+    assert allocation.keys() == expected_keys
+    assert set(allocation.values()) == expected_vals
+
+
+def test_conflict():
+    places = [
+        TagSet('place-1', {'name=place-1', 'board=foo'}),
+    ]
+    filters = [
+        TagSet('res-1', {'board=foo'}),
+        TagSet('res-2', {'board=foo'}),
+    ]
+
+    assert schedule(places, filters) == {'res-1': 'place-1'}
+    assert schedule(places, filters[::-1]) == {'res-2': 'place-1'}
+    assert schedule(places[::-1], filters) == {'res-1': 'place-1'}
+    assert schedule(places[::-1], filters[::-1]) == {'res-2': 'place-1'}


### PR DESCRIPTION
**Description**
When using labgrid with Jenkins, it can happen that a place is already used by someone/something else. In that case, it would be useful to let the test job wait until a compatible place is available.

This PR implements an initial version of place reservation using tags and filters, and a scheduler which allocates places. Documentation is still missing and more tests are needed.

This builds on PR #481.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [x] Add a section on how to use the feature to doc/usage.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated