### PR TITLE
Add support for per-target options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,7 @@ New Features in 0.3.0
   ``--skip``, ``--seek``.
 - UBootDriver now allows overriding of default boot command (``run bootcmd``)
   via new ``boot_command`` argument.
+- The config file supports per-target options, in addition to global options.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1845,6 +1845,9 @@ The skeleton for an environment consists of:
          <resources>
        drivers:
          <drivers>
+       options:
+         <target-option-1-name>: <value for target-option-1>
+         <more target-options>
      <more targets>
    options:
      <option-1 name>: <value for option-1>

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -174,6 +174,64 @@ class Config:
         assert isinstance(value, str)
         self.data.setdefault('options', {})[name] = value
 
+    def get_target_option(self, target, name, default=None):
+        """Retrieve an entry from the options subkey under the specified target
+           subkey
+
+        Args:
+            target (str): name of the target
+            name (str): name of the option
+            default (str): A default parameter in case the option can not be
+                found
+
+        Returns:
+            str: value of the option or default parameter
+
+        Raises:
+            KeyError: if the requested key can not be found in the
+                configuration, or if the target can not be found in the
+                configuration.
+        """
+        if target not in self.data['targets']:
+            raise KeyError("No target '{}' found in configuration".format(target))
+
+        try:
+            return str(self.data['targets'][target]['options'][name])
+        except (KeyError, TypeError):
+            # Empty target declarations become None in the target dict, hence
+            # TypeError when we try to subscript it.
+            if default is None:
+                raise KeyError("No option '{}' found in configuration for target '{}'".format(name, target))
+            else:
+                return default
+
+    def set_target_option(self, target, name, value):
+        """Set an entry in the options subkey under the specified target subkey
+
+        Args:
+            target (str): name of the target
+            name (str): name of the option
+            value (str): the new value
+
+        Raises:
+            KeyError: if the requested target can not be found in the
+                configuration
+        """
+        assert isinstance(target, str)
+        assert isinstance(name, str)
+        assert isinstance(value, str)
+
+        if target not in self.data['targets']:
+            raise KeyError("No target '{}' found in configuration".format(target))
+
+        # Empty targets become None in the target dict. Delete it to enable
+        # setdefault below to work on the actual default instead of None.
+        if self.data['targets'][target] is None:
+            del self.data['targets'][target]
+
+        trg = self.data['targets'].setdefault(target, {})
+        trg.setdefault('options', {})[name] = value
+
     def get_targets(self):
         return self.data.get('targets', {})
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,45 @@ import pytest
 from labgrid.config import Config
 from labgrid.exceptions import InvalidConfigError
 
+def test_get_target_option(tmpdir):
+    p = tmpdir.join("config.yaml")
+    p.write(
+        """
+        targets:
+          main:
+            options:
+              foo: bar
+              spam: eggs
+        """
+    )
+    c = Config(str(p))
+    assert c.get_target_option("main", "spam") == "eggs"
+
+    with pytest.raises(KeyError) as err:
+        c.get_target_option("main", "blah")
+    assert "No option" in str(err)
+
+    with pytest.raises(KeyError) as err:
+        c.get_target_option("nonexist", "spam")
+    assert "No target" in str(err)
+
+def test_set_target_option(tmpdir):
+    p = tmpdir.join("config.yaml")
+    p.write(
+        """
+        targets:
+          main:
+        """
+    )
+    c = Config(str(p))
+
+    with pytest.raises(KeyError) as err:
+        c.get_target_option("main", "spam")
+    assert "No option" in str(err)
+
+    c.set_target_option("main", "spam", "eggs")
+    assert c.get_target_option("main", "spam") == "eggs"
+
 def test_template(tmpdir):
     p = tmpdir.join("config.yaml")
     p.write(


### PR DESCRIPTION
**Description**
In environments with multiple targets, having only the global options available requires using using prefix/suffix if those options differ between targets. Per-target options solve this issue and relate to the global options the same way per-target feature flags relate to the global feature flags.

**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature 
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] CHANGES.rst has been updated
- [X] PR has been tested
