### PR TITLE
remote/common: replace → to support C locale

### DIFF
--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -104,7 +104,7 @@ class ResourceMatch:
     def __str__(self):
         result = repr(self)
         if self.rename:
-            result += " → " + self.rename
+            result += " -> " + self.rename
         return result
 
     def ismatch(self, resource_path):
@@ -191,7 +191,7 @@ class Place:
                 resource_path = resource.path
             match = self.getmatch(resource_path)
             if match.rename:
-                print(indent + "  {} → {}".format(
+                print(indent + "  {} -> {}".format(
                     '/'.join(resource_path), match.rename))
             else:
                 print(indent + "  {}".format(


### PR DESCRIPTION
**Description**
UTF-8 is nice, but we shouldn't rely on the user having a UTF-8 locale.
$ grep -R --color='auto' -P -n "[^\x00-\x7F]" labgrid/*
was used to search for all None UTF-8 characters, the only other matches
are in a docstring.

Fixes https://github.com/labgrid-project/labgrid/issues/486