### PR TITLE
shelldriver: use remaining timeout after password

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -141,7 +141,8 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                 if index == 1:
                     if self.password:
                         self.console.sendline(self.password)
-                        self.console.expect(self.prompt, timeout=5)
+                        remaining_time = (start + self.login_timeout) - time.time()
+                        self.console.expect(self.prompt, timeout=remaining_time)
                     else:
                         raise Exception("Password entry needed but no password set")
                 self._check_prompt()


### PR DESCRIPTION
Instead of hard coding a 5 sec timeout, we can use whatever is left of the global timeout for getting shell, when waiting for the shell after inputting password.

This solves issues when the shell is delayed after inputting a password, which can happen with slow devices or slow authentication systems. The cause for this was discovered by Christoforos Markou (chma@hms.se)

- [X] PR has been tested locally (where without it the timeout was hit every time)
