### PR TITLE
Adjust to attrs 19.2.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -40,6 +40,8 @@ Breaking changes in 0.3.0
   ``fs.protected_fifos=1`` for kernels>=4.19.
   This requires user intervention after the upgrade to create the directory and
   setup the cleanup job.
+- ``@attr.s(cmp=False)`` is deprecated and all classes have been moved to
+  ``@attr.s(eq=False)``, this release requires attrs version 19.2.0
 
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -75,7 +75,7 @@ provided by connecting drivers and resources on a given target at runtime.
     from labgrid.driver.common import Driver
     from labgrid.protocol import ConsoleProtocol
 
-    @attr.s(cmp=False)
+    @attr.s(eq=False)
     class ExampleDriver(Driver, ConsoleProtocol):
         pass
 
@@ -93,7 +93,7 @@ be added into multiple drivers.
     from labgrid.driver.consoleexpectmixin import ConsoleExpectMixin
     from labgrid.protocol import ConsoleProtocol
 
-    @attr.s(cmp=False)
+    @attr.s(eq=False)
     class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol)
         pass
 
@@ -111,7 +111,7 @@ dependencies on other drivers or resources.
     from labgrid.protocol import ConsoleProtocol
 
     @target_factory.reg_driver
-    @attr.s(cmp=False)
+    @attr.s(eq=False)
     class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol)
         bindings = { "port": SerialPort }
         pass
@@ -145,7 +145,7 @@ The minimum requirement is a call to :code:`super().__attrs_post_init__()`.
     from labgrid.protocol import ConsoleProtocol
 
     @target_factory.reg_driver
-    @attr.s(cmp=False)
+    @attr.s(eq=False)
     class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol)
         bindings = { "port": SerialPort }
 
@@ -179,7 +179,7 @@ register it with the :any:`target_factory`.
     from labgrid.driver.common import Resource
 
     @target_factory.reg_resource
-    @attr.s(cmp=False)
+    @attr.s(eq=False)
     class ExampleResource(Resource):
         pass
 
@@ -194,7 +194,7 @@ variables.
     from labgrid.driver.common import Resource
 
     @target_factory.reg_resource
-    @attr.s(cmp=False)
+    @attr.s(eq=False)
     class ExampleResource(Resource):
         examplevar1 = attr.ib()
         examplevar2 = attr.ib()

--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -4,12 +4,12 @@ from functools import wraps
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class StateError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class BindingError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
 
@@ -22,7 +22,7 @@ class BindingState(enum.Enum):
     active = 2
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class BindingMixin:
     """
     Handles the binding and activation of drivers and their supplying resources

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -10,7 +10,7 @@ import attr
 from .exceptions import NoConfigFoundError, InvalidConfigError
 from .util.yaml import load, resolve_templates
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Config:
     filename = attr.ib(validator=attr.validators.instance_of(str))
 

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -15,7 +15,7 @@ from .commandmixin import CommandMixin
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     """BareboxDriver - Driver to control barebox via the console.
        BareboxDriver binds on top of a ConsoleProtocol.

--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -5,7 +5,7 @@ from ..binding import BindingError, BindingMixin
 from .exception import ExecutionError
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Driver(BindingMixin):
     """
     Represents a driver which is used externally or by other drivers. It

--- a/labgrid/driver/deditecrelaisdriver.py
+++ b/labgrid/driver/deditecrelaisdriver.py
@@ -12,7 +12,7 @@ from ..util.agentwrapper import AgentWrapper
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DeditecRelaisDriver(Driver, DigitalOutputProtocol):
     bindings = {
         "relais": {DeditecRelais8, NetworkDeditecRelais8},

--- a/labgrid/driver/dockerdriver.py
+++ b/labgrid/driver/dockerdriver.py
@@ -12,7 +12,7 @@ from labgrid.protocol.powerprotocol import PowerProtocol
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DockerDriver(PowerProtocol, Driver):
     """The DockerDriver is used to create docker containers.
     This is done via communication with a docker daemon.

--- a/labgrid/driver/exception.py
+++ b/labgrid/driver/exception.py
@@ -1,7 +1,7 @@
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ExecutionError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
     stdout = attr.ib(
@@ -14,6 +14,6 @@ class ExecutionError(Exception):
     )
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class CleanUpError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -15,7 +15,7 @@ from .exception import ExecutionError
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     """
     Driver implementing the ConsoleProtocol interface using a subprocess

--- a/labgrid/driver/fake.py
+++ b/labgrid/driver/fake.py
@@ -11,7 +11,7 @@ from .consoleexpectmixin import ConsoleExpectMixin
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class FakeConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
 
@@ -40,7 +40,7 @@ class FakeConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class FakeCommandDriver(CommandMixin, Driver, CommandProtocol):
     @Driver.check_active
     def run(self, *args, timeout=None): # pylint: disable=unused-argument
@@ -56,7 +56,7 @@ class FakeCommandDriver(CommandMixin, Driver, CommandProtocol):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class FakeFileTransferDriver(Driver, FileTransferProtocol):
     @Driver.check_active
     def get(self, *args):
@@ -67,7 +67,7 @@ class FakeFileTransferDriver(Driver, FileTransferProtocol):
         pass
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class FakePowerDriver(Driver, PowerProtocol):
     @Driver.check_active
     def on(self, *args):

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -12,7 +12,7 @@ from ..util.helper import processwrapper
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class AndroidFastbootDriver(Driver):
     bindings = {
         "fastboot": {AndroidFastboot, NetworkAndroidFastboot},

--- a/labgrid/driver/filedigitaloutput.py
+++ b/labgrid/driver/filedigitaloutput.py
@@ -9,7 +9,7 @@ from .common import Driver
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class FileDigitalOutputDriver(Driver, DigitalOutputProtocol):
     """
     Two arbitrary string values false_repr and true_repr

--- a/labgrid/driver/flashromdriver.py
+++ b/labgrid/driver/flashromdriver.py
@@ -14,7 +14,7 @@ from ..util.helper import processwrapper
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class FlashromDriver(Driver, BootstrapProtocol):
     """ The Flashrom driver used the flashrom utility to write an image to a raw rom.
     The driver is a pure wrapper of the flashrom utility"""

--- a/labgrid/driver/gpiodriver.py
+++ b/labgrid/driver/gpiodriver.py
@@ -11,7 +11,7 @@ from ..util.agentwrapper import AgentWrapper
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class GpioDigitalOutputDriver(Driver, DigitalOutputProtocol):
 
     bindings = {

--- a/labgrid/driver/modbusdriver.py
+++ b/labgrid/driver/modbusdriver.py
@@ -9,7 +9,7 @@ from .common import Driver
 from .exception import ExecutionError
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ModbusCoilDriver(Driver, DigitalOutputProtocol):
     bindings = {"coil": ModbusTCPCoil, }
 

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -22,7 +22,7 @@ class Mode(enum.Enum):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkUSBStorageDriver(Driver):
     bindings = {
         "storage": {

--- a/labgrid/driver/onewiredriver.py
+++ b/labgrid/driver/onewiredriver.py
@@ -11,7 +11,7 @@ from .exception import ExecutionError
 from ..step import step
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class OneWirePIODriver(Driver, DigitalOutputProtocol):
 
     bindings = {"port": OneWirePIO, }

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -15,7 +15,7 @@ from .common import Driver
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class OpenOCDDriver(Driver, BootstrapProtocol):
     bindings = {
         "interface": {AlteraUSBBlaster, NetworkAlteraUSBBlaster},

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -18,7 +18,7 @@ from .common import Driver
 from .exception import ExecutionError
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class PowerResetMixin(ResetProtocol):
     """
     ResetMixin implements the ResetProtocol for drivers which support the PowerProtocol
@@ -34,7 +34,7 @@ class PowerResetMixin(ResetProtocol):
         self.cycle()
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ManualPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """ManualPowerDriver - Driver to tell the user to control a target's power"""
 
@@ -62,7 +62,7 @@ class ManualPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ExternalPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """ExternalPowerDriver - Driver using an external command to control a target's power"""
     cmd_on = attr.ib(validator=attr.validators.instance_of(str))
@@ -97,7 +97,7 @@ class ExternalPowerDriver(Driver, PowerResetMixin, PowerProtocol):
             self.on()
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """NetworkPowerDriver - Driver using a networked power switch to control a target's power"""
     bindings = {"port": NetworkPowerPort, }
@@ -145,7 +145,7 @@ class NetworkPowerDriver(Driver, PowerResetMixin, PowerProtocol):
         return self.backend.power_get(self._host, self._port, self.port.index)
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DigitalOutputPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """
     DigitalOutputPowerDriver uses a DigitalOutput to control the power
@@ -180,7 +180,7 @@ class DigitalOutputPowerDriver(Driver, PowerResetMixin, PowerProtocol):
         return self.output.get()
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class YKUSHPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """YKUSHPowerDriver - Driver using a YEPKIT YKUSH switchable USB hub
         to control a target's power - https://www.yepkit.com/products/ykush"""
@@ -217,7 +217,7 @@ class YKUSHPowerDriver(Driver, PowerResetMixin, PowerProtocol):
         return self.pykush.get_port_state(self.port.index)
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """USBPowerDriver - Driver using a power switchable USB hub and the uhubctl
     tool (https://github.com/mvp/uhubctl) to control a target's power"""

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -21,7 +21,7 @@ from .exception import ExecutionError
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
     """
     The QEMUDriver implements an interface to start targets as qemu instances.

--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -14,7 +14,7 @@ from ..util.managedfile import ManagedFile
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class QuartusHPSDriver(Driver):
     bindings = {
         "interface": {AlteraUSBBlaster, NetworkAlteraUSBBlaster},

--- a/labgrid/driver/resetdriver.py
+++ b/labgrid/driver/resetdriver.py
@@ -8,7 +8,7 @@ from ..step import step
 from .common import Driver
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DigitalOutputResetDriver(Driver, ResetProtocol):
     """DigitalOutputResetDriver - Driver using a DigitalOutput to reset the
     target"""

--- a/labgrid/driver/serialdigitaloutput.py
+++ b/labgrid/driver/serialdigitaloutput.py
@@ -7,7 +7,7 @@ from .common import Driver
 from . import SerialDriver
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SerialPortDigitalOutputDriver(Driver, DigitalOutputProtocol):
     """
     Controls the state of a GPIO using the control lines of a serial port.

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -15,7 +15,7 @@ from ..util.proxy import proxymanager
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     """
     Driver implementing the ConsoleProtocol interface over a SerialPort connection

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -20,7 +20,7 @@ from .exception import ExecutionError
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     """ShellDriver - Driver to execute commands on the shell
     ShellDriver binds on top of a ConsoleProtocol.

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -22,7 +22,7 @@ from .common import Driver, check_file
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SigrokDriver(Driver):
     """The SigrokDriver uses sigrok-cli to record samples and expose them as python dictionaries.
 

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -8,7 +8,7 @@ from .common import Driver
 from .ubootdriver import UBootDriver
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SmallUBootDriver(UBootDriver):
     """
     SmallUBootDriver is meant as a driver for UBoot with only little

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -18,7 +18,7 @@ from .exception import ExecutionError
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     """SSHDriver - Driver to execute commands via SSH"""
     bindings = {"networkservice": NetworkService, }

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -15,7 +15,7 @@ from .commandmixin import CommandMixin
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     """UBootDriver - Driver to control uboot via the console.
     UBootDriver binds on top of a ConsoleProtocol.

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -36,7 +36,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     autoboot = attr.ib(default="stop autoboot", validator=attr.validators.instance_of(str))
     password = attr.ib(default="", validator=attr.validators.instance_of(str))
     interrupt = attr.ib(default="\n", validator=attr.validators.instance_of(str))
-    init_commands = attr.ib(default=attr.Factory(tuple), convert=tuple)
+    init_commands = attr.ib(default=attr.Factory(tuple), converter=tuple)
     password_prompt = attr.ib(default="enter Password:", validator=attr.validators.instance_of(str))
     boot_expression = attr.ib(default=r"U-Boot 20\d+", validator=attr.validators.instance_of(str))
     bootstring = attr.ib(default=r"Linux version \d", validator=attr.validators.instance_of(str))

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -15,7 +15,7 @@ from ..util.helper import processwrapper
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class MXSUSBDriver(Driver, BootstrapProtocol):
     bindings = {
         "loader": {MXSUSBLoader, NetworkMXSUSBLoader},
@@ -51,7 +51,7 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class IMXUSBDriver(Driver, BootstrapProtocol):
     bindings = {
         "loader": {IMXUSBLoader, NetworkIMXUSBLoader, MXSUSBLoader, NetworkMXSUSBLoader},
@@ -88,7 +88,7 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class RKUSBDriver(Driver, BootstrapProtocol):
     bindings = {
         "loader": {RKUSBLoader, NetworkRKUSBLoader},

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -11,7 +11,7 @@ from .exception import ExecutionError
 from ..util.helper import processwrapper
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBSDMuxDriver(Driver):
     """The USBSDMuxDriver uses the usbsdmux tool
     (https://github.com/pengutronix/usbsdmux) to control the USB-SD-Mux

--- a/labgrid/driver/usbstorage.py
+++ b/labgrid/driver/usbstorage.py
@@ -11,7 +11,7 @@ from .common import Driver
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBStorageDriver(Driver):
     bindings = {"storage": {USBMassStorage, USBSDMuxDevice}, }
 

--- a/labgrid/driver/usbtmcdriver.py
+++ b/labgrid/driver/usbtmcdriver.py
@@ -11,7 +11,7 @@ from ..exceptions import InvalidConfigError
 from ..util.agentwrapper import AgentWrapper, b2s, s2b
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBTMCDriver(Driver):
     bindings = {
         "tmc": {USBTMC, NetworkUSBTMC},

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -9,7 +9,7 @@ from ..resource.udev import USBVideo
 from ..exceptions import InvalidConfigError
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBVideoDriver(Driver):
     bindings = {
         "video": {USBVideo, NetworkUSBVideo},

--- a/labgrid/driver/xenadriver.py
+++ b/labgrid/driver/xenadriver.py
@@ -7,7 +7,7 @@ from .common import Driver
 from ..resource.xenamanager import XenaManager
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class XenaDriver(Driver):
     """
     Xena Driver

--- a/labgrid/environment.py
+++ b/labgrid/environment.py
@@ -5,7 +5,7 @@ from .target import Target
 from .config import Config
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Environment:
     """An environment encapsulates targets."""
     config_file = attr.ib(

--- a/labgrid/exceptions.py
+++ b/labgrid/exceptions.py
@@ -1,12 +1,12 @@
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NoConfigFoundError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NoSupplierFoundError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
     filter = attr.ib(
@@ -15,16 +15,16 @@ class NoSupplierFoundError(Exception):
     )
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class InvalidConfigError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NoDriverFoundError(NoSupplierFoundError):
     pass
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NoResourceFoundError(NoSupplierFoundError):
     pass

--- a/labgrid/external/hawkbit.py
+++ b/labgrid/external/hawkbit.py
@@ -1,7 +1,7 @@
 import attr
 import requests as r
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class HawkbitTestClient:
     host = attr.ib(validator=attr.validators.instance_of(str))
     port = attr.ib(validator=attr.validators.instance_of(str))
@@ -200,6 +200,6 @@ class HawkbitTestClient:
         return req.json()
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class HawkbitError(Exception):
     msg = attr.ib()

--- a/labgrid/external/usbstick.py
+++ b/labgrid/external/usbstick.py
@@ -17,7 +17,7 @@ class USBStatus(enum.Enum):
     mounted = 2
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBStick:
     """The USBStick class provides an easy to use interface to describe a
     target as an USB Stick."""
@@ -140,7 +140,7 @@ class USBStick:
         self.image_name = image_name
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class StateError(Exception):
     """Exception which indicates a error in the state handling of the test"""
     msg = attr.ib()

--- a/labgrid/provider/mediafileprovider.py
+++ b/labgrid/provider/mediafileprovider.py
@@ -3,7 +3,7 @@ import attr
 from .fileprovider import FileProvider
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class MediaFileProvider(FileProvider):
     groups = attr.ib(default={}, validator=attr.validators.instance_of(dict))
 

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -15,7 +15,7 @@ TAG_KEY = re.compile(r"[a-z][a-z0-9_]+")
 TAG_VAL = re.compile(r"[a-z0-9_]?")
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ResourceEntry:
     data = attr.ib()  # cls, params
 
@@ -84,7 +84,7 @@ class ResourceMatch:
     cls = attr.ib()
     name = attr.ib(default=None)
     # rename is just metadata, so don't use it for comparing matches
-    rename = attr.ib(default=None, cmp=False)
+    rename = attr.ib(default=None, eq=False)
 
     @classmethod
     def fromstr(cls, pattern):
@@ -122,7 +122,7 @@ class ResourceMatch:
         return True
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Place:
     name = attr.ib()
     aliases = attr.ib(default=attr.Factory(set), converter=set)
@@ -233,7 +233,7 @@ class ReservationState(enum.Enum):
     invalid = 4
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Reservation:
     owner = attr.ib(validator=attr.validators.instance_of(str))
     token = attr.ib(default=attr.Factory(

--- a/labgrid/remote/config.py
+++ b/labgrid/remote/config.py
@@ -7,7 +7,7 @@ from ..util.yaml import load
 from ..exceptions import NoConfigFoundError
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ResourceConfig:
     filename = attr.ib(validator=attr.validators.instance_of(str))
 

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -26,7 +26,7 @@ class Action(Enum):
     UPD = 2
 
 
-@attr.s(init=False, cmp=False)
+@attr.s(init=False, eq=False)
 class RemoteSession:
     """class encapsulating a session, used by ExporterSession and ClientSession"""
     coordinator = attr.ib()
@@ -45,7 +45,7 @@ class RemoteSession:
         return self.authid.split('/', 1)[1]
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ExporterSession(RemoteSession):
     """An ExporterSession is opened for each Exporter connecting to the
     coordinator, allowing the Exporter to get and set resources"""
@@ -94,12 +94,12 @@ class ExporterSession(RemoteSession):
         return result
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ClientSession(RemoteSession):
     pass
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ResourceImport(ResourceEntry):
     """Represents a local resource exported from an exporter.
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -26,7 +26,7 @@ except pkg_resources.DistributionNotFound:
 exports = {}
 reexec = False
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ResourceExport(ResourceEntry):
     """Represents a local resource exported via a specific protocol.
 
@@ -112,7 +112,7 @@ class ResourceExport(ResourceEntry):
         self.poll()
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBSerialPortExport(ResourceExport):
     """ResourceExport for a USB SerialPort"""
 
@@ -179,7 +179,7 @@ class USBSerialPortExport(ResourceExport):
 
 exports["USBSerialPort"] = USBSerialPortExport
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBEthernetExport(ResourceExport):
     """ResourceExport for a USB ethernet interface"""
 
@@ -200,7 +200,7 @@ class USBEthernetExport(ResourceExport):
 
 exports["USBEthernetInterface"] = USBEthernetExport
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBGenericExport(ResourceExport):
     """ResourceExport for USB devices accessed directly from userspace"""
 
@@ -223,7 +223,7 @@ class USBGenericExport(ResourceExport):
             'model_id': self.local.model_id,
         }
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBSigrokExport(USBGenericExport):
     """ResourceExport for USB devices accessed directly from userspace"""
 
@@ -243,7 +243,7 @@ class USBSigrokExport(USBGenericExport):
             'channels': self.local.channels
         }
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBSDMuxExport(USBGenericExport):
     """ResourceExport for USB devices accessed directly from userspace"""
 
@@ -262,7 +262,7 @@ class USBSDMuxExport(USBGenericExport):
             'control_path': self.local.control_path,
         }
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBPowerPortExport(USBGenericExport):
     """ResourceExport for ports on switchable USB hubs"""
 
@@ -281,7 +281,7 @@ class USBPowerPortExport(USBGenericExport):
             'index': self.local.index,
         }
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBDeditecRelaisExport(USBGenericExport):
     """ResourceExport for outputs on deditec relais"""
 
@@ -337,7 +337,7 @@ class EthernetPortExport(ResourceExport):
 exports["SNMPEthernetPort"] = EthernetPortExport
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class GPIOGenericExport(ResourceExport):
     """ResourceExport for GPIO lines accessed directly from userspace"""
 

--- a/labgrid/remote/scheduler.py
+++ b/labgrid/remote/scheduler.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class TagSet:
     name = attr.ib(validator=attr.validators.instance_of(str))
     tags = attr.ib(validator=attr.validators.instance_of(set))

--- a/labgrid/resource/base.py
+++ b/labgrid/resource/base.py
@@ -4,7 +4,7 @@ from ..factory import target_factory
 from .common import Resource
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SerialPort(Resource):
     """The basic SerialPort describes port and speed
 
@@ -15,7 +15,7 @@ class SerialPort(Resource):
     speed = attr.ib(default=115200, validator=attr.validators.instance_of(int))
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class EthernetInterface(Resource):
     """The basic EthernetInterface contains an interfacename
 
@@ -36,7 +36,7 @@ class EthernetPort(Resource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SysfsGPIO(Resource):
     """The basic SysfsGPIO contains an index
 

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -4,7 +4,7 @@ from ..binding import BindingMixin
 from ..util.ssh import sshmanager
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Resource(BindingMixin):
     """
     Represents a resource which is used by drivers. It only stores information
@@ -47,7 +47,7 @@ class Resource(BindingMixin):
         return self._parent.get_managed_parent() if self._parent else None
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkResource(Resource):
     """
     Represents a remote Resource available on another computer.
@@ -74,7 +74,7 @@ class NetworkResource(Resource):
         return prefix + ['--']
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ResourceManager:
     instances = {}
 
@@ -100,7 +100,7 @@ class ResourceManager:
         pass
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ManagedResource(Resource):
     """
     Represents a resource which can appear and disappear at runtime. Every

--- a/labgrid/resource/docker.py
+++ b/labgrid/resource/docker.py
@@ -23,7 +23,7 @@ class DockerConstants:
     DOCKER_LG_CLEANUP_TYPE_AUTO = "auto"
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DockerManager(ResourceManager):
     """The DockerManager is responsible for cleaning up dangling
     containers and managing the managed NetworkService
@@ -76,7 +76,7 @@ class DockerManager(ResourceManager):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DockerDaemon(ManagedResource):
     """ A resource identifying a docker daemon """
     docker_daemon_url = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/resource/flashrom.py
+++ b/labgrid/resource/flashrom.py
@@ -5,12 +5,12 @@ from .common import NetworkResource, Resource
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Flashrom(Resource):
     """Programmer is the programmer parameter described in man(8) of flashrom"""
     programmer = attr.ib(validator=attr.validators.instance_of(str))
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkFlashrom(NetworkResource):
     programmer = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/resource/modbus.py
+++ b/labgrid/resource/modbus.py
@@ -5,7 +5,7 @@ from .common import Resource
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ModbusTCPCoil(Resource):
     """This resource describes Modbus TCP coil.
 

--- a/labgrid/resource/networkservice.py
+++ b/labgrid/resource/networkservice.py
@@ -5,7 +5,7 @@ from .common import Resource
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkService(Resource):
     address = attr.ib(validator=attr.validators.instance_of(str))
     username = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/resource/onewireport.py
+++ b/labgrid/resource/onewireport.py
@@ -5,7 +5,7 @@ from .common import Resource
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class OneWirePIO(Resource):
     """This resource describes a Onewire PIO Port.
 

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -5,7 +5,7 @@ from .common import Resource
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkPowerPort(Resource):
     """The NetworkPowerPort describes a remotely switchable PowerPort
 

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -6,7 +6,7 @@ from ..factory import target_factory
 from .common import NetworkResource, ManagedResource, ResourceManager
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class RemotePlaceManager(ResourceManager):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -92,7 +92,7 @@ class RemotePlaceManager(ResourceManager):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class RemotePlace(ManagedResource):
     manager_cls = RemotePlaceManager
 
@@ -100,7 +100,7 @@ class RemotePlace(ManagedResource):
         self.timeout = 10.0
         super().__attrs_post_init__()
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class RemoteUSBResource(NetworkResource, ManagedResource):
     manager_cls = RemotePlaceManager
 
@@ -112,7 +112,7 @@ class RemoteUSBResource(NetworkResource, ManagedResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkAndroidFastboot(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
@@ -120,7 +120,7 @@ class NetworkAndroidFastboot(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkIMXUSBLoader(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
@@ -128,7 +128,7 @@ class NetworkIMXUSBLoader(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkMXSUSBLoader(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
@@ -136,7 +136,7 @@ class NetworkMXSUSBLoader(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkRKUSBLoader(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
@@ -144,7 +144,7 @@ class NetworkRKUSBLoader(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkAlteraUSBBlaster(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
@@ -152,7 +152,7 @@ class NetworkAlteraUSBBlaster(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkSigrokUSBDevice(RemoteUSBResource):
     """The NetworkSigrokUSBDevice describes a remotely accessible sigrok USB device"""
     driver = attr.ib(default=None, validator=attr.validators.instance_of(str))
@@ -163,7 +163,7 @@ class NetworkSigrokUSBDevice(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkUSBMassStorage(RemoteUSBResource):
     """The NetworkUSBMassStorage describes a remotely accessible USB storage device"""
     def __attrs_post_init__(self):
@@ -172,7 +172,7 @@ class NetworkUSBMassStorage(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkUSBSDMuxDevice(RemoteUSBResource):
     """The NetworkUSBSDMuxDevice describes a remotely accessible USBSDMux device"""
     control_path = attr.ib(default=None, validator=attr.validators.instance_of(str))
@@ -182,7 +182,7 @@ class NetworkUSBSDMuxDevice(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkUSBPowerPort(RemoteUSBResource):
     """The NetworkUSBPowerPort describes a remotely accessible USB hub port with power switching"""
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
@@ -192,7 +192,7 @@ class NetworkUSBPowerPort(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkUSBVideo(RemoteUSBResource):
     """The NetworkUSBVideo describes a remotely accessible USB video device"""
     def __attrs_post_init__(self):
@@ -201,7 +201,7 @@ class NetworkUSBVideo(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkUSBTMC(RemoteUSBResource):
     """The NetworkUSBTMC describes a remotely accessible USB TMC device"""
     def __attrs_post_init__(self):
@@ -210,7 +210,7 @@ class NetworkUSBTMC(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkDeditecRelais8(RemoteUSBResource):
     """The NetworkDeditecRelais8 describes a remotely accessible USB relais port"""
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
@@ -220,7 +220,7 @@ class NetworkDeditecRelais8(RemoteUSBResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkSysfsGPIO(NetworkResource, ManagedResource):
     manager_cls = RemotePlaceManager
 

--- a/labgrid/resource/serialport.py
+++ b/labgrid/resource/serialport.py
@@ -6,7 +6,7 @@ from .base import SerialPort
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class RawSerialPort(SerialPort, Resource):
     """RawSerialPort describes a serialport which is available on the local computer."""
     def __attrs_post_init__(self):
@@ -16,7 +16,7 @@ class RawSerialPort(SerialPort, Resource):
 
 # This does not derive from SerialPort because it is not directly accessible
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NetworkSerialPort(NetworkResource):
     """A NetworkSerialPort is a remotely accessable serialport, usually
     accessed via rfc2217 or tcp raw.

--- a/labgrid/resource/sigrok.py
+++ b/labgrid/resource/sigrok.py
@@ -4,7 +4,7 @@ from ..factory import target_factory
 from .common import Resource
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SigrokDevice(Resource):
     """The SigrokDevice describes an attached sigrok device with driver and
     channel mapping

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -14,7 +14,7 @@ from .base import SerialPort, EthernetInterface
 from ..util import Timeout
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class UdevManager(ResourceManager):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -50,7 +50,7 @@ class UdevManager(ResourceManager):
                 if resource.try_match(device):
                     break
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBResource(ManagedResource):
     manager_cls = UdevManager
 
@@ -176,7 +176,7 @@ class USBResource(ManagedResource):
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBSerialPort(USBResource, SerialPort):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'tty'
@@ -195,7 +195,7 @@ class USBSerialPort(USBResource, SerialPort):
             self.port = None
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBMassStorage(USBResource):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'block'
@@ -211,7 +211,7 @@ class USBMassStorage(USBResource):
         return None
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class IMXUSBLoader(USBResource):
     def filter_match(self, device):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
@@ -227,7 +227,7 @@ class IMXUSBLoader(USBResource):
         return super().filter_match(device)
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class RKUSBLoader(USBResource):
     def filter_match(self, device):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
@@ -238,7 +238,7 @@ class RKUSBLoader(USBResource):
         return super().filter_match(device)
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class MXSUSBLoader(USBResource):
     def filter_match(self, device):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
@@ -249,7 +249,7 @@ class MXSUSBLoader(USBResource):
         return super().filter_match(device)
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class AndroidFastboot(USBResource):
     usb_vendor_id = attr.ib(default='1d6b', validator=attr.validators.instance_of(str))
     usb_product_id = attr.ib(default='0104', validator=attr.validators.instance_of(str))
@@ -261,7 +261,7 @@ class AndroidFastboot(USBResource):
         return super().filter_match(device)
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBEthernetInterface(USBResource, EthernetInterface):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'net'
@@ -283,7 +283,7 @@ class USBEthernetInterface(USBResource, EthernetInterface):
         return value
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class AlteraUSBBlaster(USBResource):
     def filter_match(self, device):
         if device.properties.get('ID_VENDOR_ID') != "09fb":
@@ -293,7 +293,7 @@ class AlteraUSBBlaster(USBResource):
         return super().filter_match(device)
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class SigrokUSBDevice(USBResource):
     """The SigrokUSBDevice describes an attached sigrok device with driver and
     channel mapping, it is identified via usb using udev
@@ -309,7 +309,7 @@ class SigrokUSBDevice(USBResource):
         super().__attrs_post_init__()
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBSDMuxDevice(USBResource):
     """The USBSDMuxDevice describes an attached USBSDMux device,
     it is identified via USB using udev
@@ -353,7 +353,7 @@ class USBSDMuxDevice(USBResource):
         return self.disk_path
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBPowerPort(USBResource):
     """The USBPowerPort describes a single port on an USB hub which supports
     power control.
@@ -368,7 +368,7 @@ class USBPowerPort(USBResource):
         super().__attrs_post_init__()
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBVideo(USBResource):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'video4linux'
@@ -383,7 +383,7 @@ class USBVideo(USBResource):
         return None
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class USBTMC(USBResource):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'usbmisc'
@@ -399,7 +399,7 @@ class USBTMC(USBResource):
         return None
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DeditecRelais8(USBResource):
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
 

--- a/labgrid/resource/xenamanager.py
+++ b/labgrid/resource/xenamanager.py
@@ -4,7 +4,7 @@ from ..factory import target_factory
 from .common import Resource
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class XenaManager(Resource):
     """ Hostname/IP identifying the manageent address of the xena tester """
     hostname = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/resource/ykushpowerport.py
+++ b/labgrid/resource/ykushpowerport.py
@@ -5,7 +5,7 @@ from .common import Resource
 
 
 @target_factory.reg_resource
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class YKUSHPowerPort(Resource):
     """This resource describes a YEPKIT YKUSH switchable USB hub.
 

--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -17,7 +17,7 @@ class Status(enum.Enum):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class BareboxStrategy(Strategy):
     """BareboxStrategy - Strategy to switch to barebox or shell"""
     bindings = {

--- a/labgrid/strategy/common.py
+++ b/labgrid/strategy/common.py
@@ -4,12 +4,12 @@ from ..binding import BindingError
 from ..driver import Driver
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class StrategyError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Strategy(Driver):  # reuse driver handling
     """
     Represents a strategy which places a target into a requested state by

--- a/labgrid/strategy/dockerstrategy.py
+++ b/labgrid/strategy/dockerstrategy.py
@@ -15,7 +15,7 @@ class Status(enum.Enum):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class DockerStrategy(Strategy):
     """
     DockerStrategy enables the user to directly transition to a state

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -16,7 +16,7 @@ class Status(enum.Enum):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class ShellStrategy(Strategy):
     """ShellStrategy - Strategy to switch to shell"""
     bindings = {

--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -16,7 +16,7 @@ class Status(enum.Enum):
 
 
 @target_factory.reg_driver
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class UBootStrategy(Strategy):
     """UbootStrategy - Strategy to switch to uboot or shell"""
     bindings = {

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -13,7 +13,7 @@ from .strategy import Strategy
 from .util import Timeout
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Target:
     name = attr.ib(validator=attr.validators.instance_of(str))
     env = attr.ib(default=None)

--- a/labgrid/util/exceptions.py
+++ b/labgrid/util/exceptions.py
@@ -1,6 +1,6 @@
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class NoValidDriverError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/util/qmp.py
+++ b/labgrid/util/qmp.py
@@ -3,7 +3,7 @@ import logging
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class QMPMonitor:
     monitor_out = attr.ib()
     monitor_in = attr.ib()
@@ -45,6 +45,6 @@ class QMPMonitor:
             raise QMPError(answer['error'])
         return answer
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class QMPError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/util/timeout.py
+++ b/labgrid/util/timeout.py
@@ -3,7 +3,7 @@ import time
 import attr
 
 
-@attr.s(cmp=False)
+@attr.s(eq=False)
 class Timeout:
     """Reperents a timeout (as a deadline)"""
     timeout = attr.ib(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrs==19.1.0
+attrs==19.2.0
 jinja2==2.10.1
 pexpect==4.7
 https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     setup_requires=['pytest-runner', 'setuptools_scm'],
     tests_require=['pytest-mock', ],
     install_requires=[
-        'attrs>=17.4.0',
+        'attrs>=19.2.0',
         'ansicolors',
         'jinja2',
         'pexpect',


### PR DESCRIPTION
**Description**
With the release of attr.s 19.2.0 we use the deprecated `convert` instead of `converter`. This PR updates labgrid to attr.s 19.2.0 and adjusts it to the new deprecation notice.

**Checklist**
- [x] Documentation updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested

I did a short test with my local infrastructure, AFAICS everything still works.

Thanks to @Bastian-Krause for bringing this to my attention.

