### PR TITLE
target: allow driver bindings by class name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,9 @@ New Features in 0.3.0
 - The coordinator now updates the resource acquired state at the exporter.
   Accordingly, the exporter now starts ser2net only when a resources is
   aquired. Furthermore, resource conflicts between places are now detected.
+- The binding dictionary can now supports type name strings in addition to the
+  types themselves, avoiding the need to import a specific protocol or driver
+  in some cases.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -312,6 +312,9 @@ class Target:
             errors = []
             suppliers = []
             for requirement in requirements:
+                # convert class name string to classes
+                if isinstance(requirement, str):
+                    requirement = self._class_from_string(requirement)
                 try:
                     if issubclass(requirement, Resource):
                         suppliers.append(
@@ -456,4 +459,4 @@ class Target:
         try:
             return self._lookup_table[string]
         except KeyError:
-            raise KeyError("No such driver/resource/protocol in lookup table, perhaps not bound?")
+            raise KeyError("No driver/resource/protocol of type '{}' in lookup table, perhaps not bound?".format(string))


### PR DESCRIPTION
**Description**
We already allow class name strings in get_driver and similar, so we
should also allow it in the binding dict for consistency. In the longer
term, this should help to reduce the amount of required imports just for
binding to the correct types.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] CHANGES.rst has been updated
- [x] PR has been tested
