### PR TITLE
deditecrelaisdriver: add support for inverted signals

### DIFF
--- a/labgrid/driver/deditecrelaisdriver.py
+++ b/labgrid/driver/deditecrelaisdriver.py
@@ -38,9 +38,14 @@ class DeditecRelaisDriver(Driver, DigitalOutputProtocol):
     @Driver.check_active
     @step(args=['status'])
     def set(self, status):
+        if self.relais.invert:
+            status = not status
         self.proxy.set(self.relais.busnum, self.relais.devnum, self.relais.index, status)
 
     @Driver.check_active
     @step(result=True)
     def get(self):
-        return self.proxy.get(self.relais.busnum, self.relais.devnum, self.relais.index)
+        status = self.proxy.get(self.relais.busnum, self.relais.devnum, self.relais.index)
+        if self.relais.invert:
+            status = not status
+        return status

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -214,6 +214,7 @@ class NetworkUSBTMC(RemoteUSBResource):
 class NetworkDeditecRelais8(RemoteUSBResource):
     """The NetworkDeditecRelais8 describes a remotely accessible USB relais port"""
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
+    invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -402,6 +402,7 @@ class USBTMC(USBResource):
 @attr.s(eq=False)
 class DeditecRelais8(USBResource):
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
+    invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))
 
     def __attrs_post_init__(self):
         self.match['ID_VENDOR'] = 'DEDITEC'


### PR DESCRIPTION
**Description**
This add support for the invert attribute on deditec relais8 resources, similar to modbus and onewire.

**Checklist**
- [x] PR has been tested