### PR TITLE
setup: reenable fastentrypoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@
 
 from setuptools import setup
 
+import fastentrypoints  # noqa: F401 # pylint: disable=unused-import
+
+
 setup(
     name='labgrid',
     description='labgrid: lab hardware and software control layer',


### PR DESCRIPTION
This was lost in commit 7021d8db4308f6a75283ba6a2b267b50f700496f, and
significantly increased the startup time. Get some performance back by reenabling fastentrypoints.
    
Also add the linter hints to avoid losing it again.