### PR TITLE
driver/power: add PDUDaemon support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -111,6 +111,30 @@ The example describes port 0 on the remote power switch
 Used by:
   - `NetworkPowerDriver`_
 
+PDUDaemonPort
++++++++++++++
+A PDUDaemonPort describes a PDU port accessible via `PDUDaemon
+<https://github.com/pdudaemon/pdudaemon>`_.
+As one PDUDaemon instance can control many PDUs, the instance name from the
+PDUDaemon configuration file needs to be specified.
+
+.. code-block:: yaml
+
+   PDUDaemonPort:
+     host: pduserver
+     pdu: apc-snmpv3-noauth
+     index: 1
+
+The example describes port 1 on the PDU configured as `apc-snmpv3-noauth`, with
+PDUDaemon running on the host `pduserver`.
+
+- host (str): name of the host running the PDUDaemon
+- pdu (str): name of the PDU in the configuration file
+- index (int): index of the power port on the PDU
+
+Used by:
+  - `PDUDaemonDriver`_
+
 YKUSHPowerPort
 ++++++++++++++
 A YKUSHPowerPort describes a YEPKIT YKUSH USB (HID) switchable USB hub.
@@ -1059,6 +1083,30 @@ Implements:
 
 Arguments:
   - delay (float): optional delay in seconds between off and on
+
+PDUDaemonDriver
+~~~~~~~~~~~~~~~
+A PDUDaemonDriver controls a `PDUDaemonPort`, allowing control of the target
+power state without user interaction.
+
+.. note::
+  PDUDaemon processess commands in the background, so the actual state change
+  may happen several seconds after calls to PDUDaemonDriver return.
+
+Binds to:
+  port:
+    - `PDUDaemonPort`_
+
+Implements:
+  - :any:`PowerProtocol`
+
+.. code-block:: yaml
+
+   PDUDaemonDriver:
+     delay: 5
+
+Arguments:
+  - delay (int): optional delay in seconds between off and on
 
 YKUSHPowerDriver
 ~~~~~~~~~~~~~~~~

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -608,10 +608,3 @@ processes well.
 An implementation should start a new process,
 return a handle and forbid running other processes in the foreground.
 The handle can be used to retrieve output from a command.
-
-Support for PDU-Daemon
-~~~~~~~~~~~~~~~~~~~~~~
-
-The LAVA project developed their own daemon for power switching, the `PDU Daemon
-<https://https://staging.validation.linaro.org/static/docs/v2/pdudaemon.html>`_.
-Add support for the daemon in the NetworkPowerDriver.

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -18,3 +18,19 @@ class NetworkPowerPort(Resource):
     host = attr.ib(validator=attr.validators.instance_of(str))
     index = attr.ib(validator=attr.validators.instance_of(str),
                     converter=lambda x: str(int(x)))
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class PDUDaemonPort(Resource):
+    """The PDUDaemonPort describes a port on a PDU accessible via PDUDaemon
+
+    Args:
+        host (str): name of the host running the PDUDaemon
+        pdu (str): name of the PDU in the configuration file
+        index (int): index of the power port on the PDU
+    """
+    host = attr.ib(validator=attr.validators.instance_of(str))
+    pdu = attr.ib(validator=attr.validators.instance_of(str))
+    index = attr.ib(validator=attr.validators.instance_of(int),
+                    converter=lambda x: int(x))


### PR DESCRIPTION
**Description**
This addresses the long-standing request to add support for PDUDaemon
ports via the PowerProtocol.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested