### PR TITLE
Convert drivers from imports to strings

### DIFF
--- a/labgrid/driver/deditecrelaisdriver.py
+++ b/labgrid/driver/deditecrelaisdriver.py
@@ -3,7 +3,6 @@ import attr
 
 from .common import Driver
 from ..factory import target_factory
-from ..resource.udev import DeditecRelais8
 from ..resource.remote import NetworkDeditecRelais8
 from ..step import step
 from ..protocol import DigitalOutputProtocol
@@ -14,7 +13,7 @@ from ..util.agentwrapper import AgentWrapper
 @attr.s(eq=False)
 class DeditecRelaisDriver(Driver, DigitalOutputProtocol):
     bindings = {
-        "relais": {DeditecRelais8, NetworkDeditecRelais8},
+        "relais": {"DeditecRelais8", NetworkDeditecRelais8},
     }
 
     def __attrs_post_init__(self):

--- a/labgrid/driver/dockerdriver.py
+++ b/labgrid/driver/dockerdriver.py
@@ -8,7 +8,7 @@ import attr
 
 from labgrid.factory import target_factory
 from labgrid.driver.common import Driver
-from labgrid.resource.docker import DockerDaemon, DockerConstants
+from labgrid.resource.docker import DockerConstants
 from labgrid.protocol.powerprotocol import PowerProtocol
 
 
@@ -42,7 +42,7 @@ class DockerDriver(PowerProtocol, Driver):
                                  service that the docker container exposes.
 
     """
-    bindings = {"docker_daemon": {DockerDaemon}}
+    bindings = {"docker_daemon": {"DockerDaemon"}}
     image_uri = attr.ib(default=None, validator=attr.validators.optional(
         attr.validators.instance_of(str)))
     command = attr.ib(default=None, validator=attr.validators.optional(

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -2,8 +2,6 @@
 import attr
 
 from ..factory import target_factory
-from ..resource.remote import NetworkAndroidFastboot
-from ..resource.udev import AndroidFastboot
 from ..step import step
 from .common import Driver
 from ..util.managedfile import ManagedFile
@@ -14,7 +12,7 @@ from ..util.helper import processwrapper
 @attr.s(eq=False)
 class AndroidFastbootDriver(Driver):
     bindings = {
-        "fastboot": {AndroidFastboot, NetworkAndroidFastboot},
+        "fastboot": {"AndroidFastboot", "NetworkAndroidFastboot"},
     }
 
     image = attr.ib(default=None)

--- a/labgrid/driver/flashromdriver.py
+++ b/labgrid/driver/flashromdriver.py
@@ -3,7 +3,7 @@ import os.path
 import logging
 import attr
 
-from ..resource import Flashrom, NetworkFlashrom
+from ..resource import NetworkFlashrom
 from ..factory import target_factory
 from ..step import step
 from ..protocol import BootstrapProtocol
@@ -18,7 +18,7 @@ class FlashromDriver(Driver, BootstrapProtocol):
     """ The Flashrom driver used the flashrom utility to write an image to a raw rom.
     The driver is a pure wrapper of the flashrom utility"""
     bindings = {
-        'flashrom_resource': {Flashrom, NetworkFlashrom},
+        'flashrom_resource': {"Flashrom", NetworkFlashrom},
     }
 
     image = attr.ib(default=None)

--- a/labgrid/driver/gpiodriver.py
+++ b/labgrid/driver/gpiodriver.py
@@ -3,7 +3,6 @@ import attr
 
 from ..factory import target_factory
 from ..protocol import DigitalOutputProtocol
-from ..resource.base import SysfsGPIO
 from ..resource.remote import NetworkSysfsGPIO
 from ..step import step
 from .common import Driver
@@ -15,7 +14,7 @@ from ..util.agentwrapper import AgentWrapper
 class GpioDigitalOutputDriver(Driver, DigitalOutputProtocol):
 
     bindings = {
-        "gpio": {SysfsGPIO, NetworkSysfsGPIO},
+        "gpio": {"SysfsGPIO", "NetworkSysfsGPIO"},
     }
 
     def __attrs_post_init__(self):

--- a/labgrid/driver/modbusdriver.py
+++ b/labgrid/driver/modbusdriver.py
@@ -2,7 +2,6 @@ from importlib import import_module
 import attr
 
 from ..factory import target_factory
-from ..resource import ModbusTCPCoil
 from ..protocol import DigitalOutputProtocol
 from ..util.proxy import proxymanager
 from .common import Driver
@@ -11,7 +10,7 @@ from .exception import ExecutionError
 @target_factory.reg_driver
 @attr.s(eq=False)
 class ModbusCoilDriver(Driver, DigitalOutputProtocol):
-    bindings = {"coil": ModbusTCPCoil, }
+    bindings = {"coil": "ModbusTCPCoil", }
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -6,8 +6,6 @@ import time
 import attr
 
 from ..factory import target_factory
-from ..resource.udev import USBMassStorage, USBSDMuxDevice
-from ..resource.remote import NetworkUSBMassStorage, NetworkUSBSDMuxDevice
 from ..step import step
 from ..util.managedfile import ManagedFile
 from .common import Driver
@@ -27,10 +25,10 @@ class Mode(enum.Enum):
 class NetworkUSBStorageDriver(Driver):
     bindings = {
         "storage": {
-            USBMassStorage,
-            NetworkUSBMassStorage,
-            USBSDMuxDevice,
-            NetworkUSBSDMuxDevice
+            "USBMassStorage",
+            "NetworkUSBMassStorage",
+            "USBSDMuxDevice",
+            "NetworkUSBSDMuxDevice"
         },
     }
     image = attr.ib(

--- a/labgrid/driver/onewiredriver.py
+++ b/labgrid/driver/onewiredriver.py
@@ -3,7 +3,6 @@ import attr
 
 from ..exceptions import InvalidConfigError
 from ..factory import target_factory
-from ..resource import OneWirePIO
 from ..protocol import DigitalOutputProtocol
 from ..util.proxy import proxymanager
 from .common import Driver
@@ -14,7 +13,7 @@ from ..step import step
 @attr.s(eq=False)
 class OneWirePIODriver(Driver, DigitalOutputProtocol):
 
-    bindings = {"port": OneWirePIO, }
+    bindings = {"port": "OneWirePIO", }
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -5,8 +5,6 @@ import attr
 
 from ..factory import target_factory
 from ..protocol import BootstrapProtocol
-from ..resource.remote import NetworkAlteraUSBBlaster
-from ..resource.udev import AlteraUSBBlaster
 from ..step import step
 from ..util.managedfile import ManagedFile
 from ..util.helper import processwrapper
@@ -17,7 +15,7 @@ from .common import Driver
 @attr.s(eq=False)
 class OpenOCDDriver(Driver, BootstrapProtocol):
     bindings = {
-        "interface": {AlteraUSBBlaster, NetworkAlteraUSBBlaster},
+        "interface": {"AlteraUSBBlaster", "NetworkAlteraUSBBlaster"},
     }
 
     config = attr.ib(validator=attr.validators.instance_of((str, list)))

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -7,9 +7,6 @@ import attr
 from ..factory import target_factory
 from ..protocol import PowerProtocol, DigitalOutputProtocol, ResetProtocol
 from ..resource import NetworkPowerPort
-from ..resource import YKUSHPowerPort
-from ..resource.remote import NetworkUSBPowerPort
-from ..resource.udev import USBPowerPort
 from ..step import step
 from ..util.proxy import proxymanager
 from ..util.helper import processwrapper
@@ -185,7 +182,7 @@ class DigitalOutputPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 class YKUSHPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """YKUSHPowerDriver - Driver using a YEPKIT YKUSH switchable USB hub
         to control a target's power - https://www.yepkit.com/products/ykush"""
-    bindings = {"port": YKUSHPowerPort, }
+    bindings = {"port": "YKUSHPowerPort", }
     delay = attr.ib(default=2.0, validator=attr.validators.instance_of(float))
 
 
@@ -223,7 +220,7 @@ class USBPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """USBPowerDriver - Driver using a power switchable USB hub and the uhubctl
     tool (https://github.com/mvp/uhubctl) to control a target's power"""
 
-    bindings = {"hub": {USBPowerPort, NetworkUSBPowerPort}, }
+    bindings = {"hub": {"USBPowerPort", "NetworkUSBPowerPort"}, }
     delay = attr.ib(default=2.0, validator=attr.validators.instance_of(float))
 
     def __attrs_post_init__(self):

--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -4,8 +4,6 @@ import re
 import attr
 
 from ..factory import target_factory
-from ..resource.remote import NetworkAlteraUSBBlaster
-from ..resource.udev import AlteraUSBBlaster
 from ..step import step
 from .common import Driver
 from .exception import ExecutionError
@@ -17,7 +15,7 @@ from ..util.managedfile import ManagedFile
 @attr.s(eq=False)
 class QuartusHPSDriver(Driver):
     bindings = {
-        "interface": {AlteraUSBBlaster, NetworkAlteraUSBBlaster},
+        "interface": {"AlteraUSBBlaster", "NetworkAlteraUSBBlaster"},
     }
 
     image = attr.ib(

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -8,10 +8,10 @@ import serial.rfc2217
 
 from ..factory import target_factory
 from ..protocol import ConsoleProtocol
-from ..resource import SerialPort, NetworkSerialPort
 from .common import Driver
 from .consoleexpectmixin import ConsoleExpectMixin
 from ..util.proxy import proxymanager
+from ..resource import SerialPort
 
 
 @target_factory.reg_driver
@@ -23,9 +23,9 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     # pyserial 3.2.1 does not support RFC2217 under Python 3
     # https://github.com/pyserial/pyserial/pull/183
     if tuple(int(x) for x in serial.__version__.split('.')) <= (3, 2, 1):
-        bindings = {"port": SerialPort, }
+        bindings = {"port": "SerialPort", }
     else:
-        bindings = {"port": {SerialPort, NetworkSerialPort}, }
+        bindings = {"port": {"SerialPort", "NetworkSerialPort"}, }
     if tuple(int(x) for x in serial.__version__.split('.')) < (3, 4, 0, 1):
         message = ("The installed pyserial version does not contain important RFC2217 fixes.\n"
                    "You can install the labgrid fork via:\n"

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -10,7 +10,6 @@ import attr
 
 from ..factory import target_factory
 from ..protocol import CommandProtocol, FileTransferProtocol
-from ..resource import NetworkService
 from .commandmixin import CommandMixin
 from .common import Driver
 from ..step import step
@@ -21,7 +20,7 @@ from .exception import ExecutionError
 @attr.s(eq=False)
 class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     """SSHDriver - Driver to execute commands via SSH"""
-    bindings = {"networkservice": NetworkService, }
+    bindings = {"networkservice": "NetworkService", }
     priorities = {CommandProtocol: 10, FileTransferProtocol: 10}
     keyfile = attr.ib(default="", validator=attr.validators.instance_of(str))
     stderr_merge = attr.ib(default=False, validator=attr.validators.instance_of(bool))

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -4,8 +4,6 @@ import attr
 
 from ..factory import target_factory
 from ..protocol import BootstrapProtocol
-from ..resource.remote import NetworkMXSUSBLoader, NetworkIMXUSBLoader, NetworkRKUSBLoader
-from ..resource.udev import MXSUSBLoader, IMXUSBLoader, RKUSBLoader
 from ..step import step
 from .common import Driver
 from ..util.managedfile import ManagedFile
@@ -17,7 +15,7 @@ from ..util.helper import processwrapper
 @attr.s(eq=False)
 class MXSUSBDriver(Driver, BootstrapProtocol):
     bindings = {
-        "loader": {MXSUSBLoader, NetworkMXSUSBLoader},
+        "loader": {"MXSUSBLoader", "NetworkMXSUSBLoader"},
     }
 
     image = attr.ib(default=None)
@@ -53,7 +51,7 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
 @attr.s(eq=False)
 class IMXUSBDriver(Driver, BootstrapProtocol):
     bindings = {
-        "loader": {IMXUSBLoader, NetworkIMXUSBLoader, MXSUSBLoader, NetworkMXSUSBLoader},
+        "loader": {"IMXUSBLoader", "NetworkIMXUSBLoader", "MXSUSBLoader", "NetworkMXSUSBLoader"},
     }
 
     image = attr.ib(default=None)
@@ -90,7 +88,7 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
 @attr.s(eq=False)
 class RKUSBDriver(Driver, BootstrapProtocol):
     bindings = {
-        "loader": {RKUSBLoader, NetworkRKUSBLoader},
+        "loader": {"RKUSBLoader", "NetworkRKUSBLoader"},
     }
 
     image = attr.ib(default=None)

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -3,8 +3,6 @@ import attr
 
 from .common import Driver
 from ..factory import target_factory
-from ..resource.remote import NetworkUSBSDMuxDevice
-from ..resource.udev import USBSDMuxDevice
 from ..step import step
 from .exception import ExecutionError
 from ..util.helper import processwrapper
@@ -20,7 +18,7 @@ class USBSDMuxDriver(Driver):
         bindings (dict): driver to use with usbsdmux
     """
     bindings = {
-        "mux": {USBSDMuxDevice, NetworkUSBSDMuxDevice},
+        "mux": {"USBSDMuxDevice", "NetworkUSBSDMuxDevice"},
     }
 
     def __attrs_post_init__(self):

--- a/labgrid/driver/usbstorage.py
+++ b/labgrid/driver/usbstorage.py
@@ -5,7 +5,6 @@ from time import time
 import attr
 
 from ..factory import target_factory
-from ..resource.udev import USBMassStorage, USBSDMuxDevice
 from ..step import step
 from .common import Driver
 
@@ -13,7 +12,7 @@ from .common import Driver
 @target_factory.reg_driver
 @attr.s(eq=False)
 class USBStorageDriver(Driver):
-    bindings = {"storage": {USBMassStorage, USBSDMuxDevice}, }
+    bindings = {"storage": {"USBMassStorage", "USBSDMuxDevice"}, }
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/usbtmcdriver.py
+++ b/labgrid/driver/usbtmcdriver.py
@@ -5,8 +5,6 @@ import attr
 
 from .common import Driver
 from ..factory import target_factory
-from ..resource.remote import NetworkUSBTMC
-from ..resource.udev import USBTMC
 from ..exceptions import InvalidConfigError
 from ..util.agentwrapper import AgentWrapper, b2s, s2b
 
@@ -14,7 +12,7 @@ from ..util.agentwrapper import AgentWrapper, b2s, s2b
 @attr.s(eq=False)
 class USBTMCDriver(Driver):
     bindings = {
-        "tmc": {USBTMC, NetworkUSBTMC},
+        "tmc": {"USBTMC", "NetworkUSBTMC"},
     }
 
     def __attrs_post_init__(self):

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -4,15 +4,13 @@ import attr
 
 from .common import Driver
 from ..factory import target_factory
-from ..resource.remote import NetworkUSBVideo
-from ..resource.udev import USBVideo
 from ..exceptions import InvalidConfigError
 
 @target_factory.reg_driver
 @attr.s(eq=False)
 class USBVideoDriver(Driver):
     bindings = {
-        "video": {USBVideo, NetworkUSBVideo},
+        "video": {"USBVideo", "NetworkUSBVideo"},
     }
 
     def get_caps(self):

--- a/labgrid/driver/xenadriver.py
+++ b/labgrid/driver/xenadriver.py
@@ -4,7 +4,6 @@ import attr
 
 from ..factory import target_factory
 from .common import Driver
-from ..resource.xenamanager import XenaManager
 
 @target_factory.reg_driver
 @attr.s(eq=False)
@@ -12,7 +11,7 @@ class XenaDriver(Driver):
     """
     Xena Driver
     """
-    bindings = {"xena_manager": XenaManager}
+    bindings = {"xena_manager": "XenaManager"}
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -1,3 +1,5 @@
+import inspect
+
 from .exceptions import InvalidConfigError
 from .util.dict import filter_dict
 
@@ -5,12 +7,14 @@ class TargetFactory:
     def __init__(self):
         self.resources = {}
         self.drivers = {}
+        self.all_classes = {}
 
     def reg_resource(self, cls):
         """Register a resource with the factory.
 
         Returns the class to allow using it as a decorator."""
         self.resources[cls.__name__] = cls
+        self._insert_into_all(cls)
         return cls
 
     def reg_driver(self, cls):
@@ -18,6 +22,7 @@ class TargetFactory:
 
         Returns the class to allow using it as a decorator."""
         self.drivers[cls.__name__] = cls
+        self._insert_into_all(cls)
         return cls
 
     @staticmethod
@@ -147,6 +152,17 @@ class TargetFactory:
             self.make_driver(target, driver, name, args)
         return target
 
+    def class_from_string(self, string: str):
+        try:
+            return self.all_classes[string]
+        except KeyError:
+            raise KeyError("No driver/resource/protocol of type '{}' in factory, perhaps not registered?".format(string))
+
+    def _insert_into_all(self, cls):
+        classes = inspect.getmro(cls)
+        for cl in classes:
+            if not self.all_classes.get(cl.__name__):
+                self.all_classes[cl.__name__] = cl
 
 #: Global TargetFactory instance
 #:

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -11,6 +11,7 @@ from .exceptions import NoSupplierFoundError, NoDriverFoundError, NoResourceFoun
 from .resource import Resource
 from .strategy import Strategy
 from .util import Timeout
+from .factory import target_factory
 
 
 @attr.s(eq=False)
@@ -310,7 +311,7 @@ class Target:
             for requirement in requirements:
                 # convert class name string to classes
                 if isinstance(requirement, str):
-                    requirement = target_factory._reg_class_from_string(requirement)
+                    requirement = target_factory.class_from_string(requirement)
                 try:
                     if issubclass(requirement, Resource):
                         suppliers.append(

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -106,7 +106,7 @@ class Target:
         found = []
         other_names = []
         if isinstance(cls, str):
-            cls = self._class_from_string(cls)
+            cls = self._reg_class_from_string(cls)
 
         for res in self.resources:
             if not isinstance(res, cls):
@@ -139,7 +139,7 @@ class Target:
         found = []
         other_names = []
         if isinstance(cls, str):
-            cls = self._class_from_string(cls)
+            cls = self._reg_class_from_string(cls)
 
         for drv in self.drivers:
             if not isinstance(drv, cls):
@@ -228,7 +228,7 @@ class Target:
         elif len(key) == 2:
             cls, name = key
         if isinstance(cls, str):
-            cls = self._class_from_string(cls)
+            cls = self._reg_class_from_string(cls)
         if not issubclass(cls, (Driver, abc.ABC)): # all Protocols derive from ABC
             raise NoDriverFoundError(
                 "invalid driver class {}".format(cls)
@@ -310,7 +310,7 @@ class Target:
             for requirement in requirements:
                 # convert class name string to classes
                 if isinstance(requirement, str):
-                    requirement = self._class_from_string(requirement)
+                    requirement = target_factory._reg_class_from_string(requirement)
                 try:
                     if issubclass(requirement, Resource):
                         suppliers.append(
@@ -457,7 +457,7 @@ class Target:
         for res in reversed(self.resources):
             self.deactivate(res)
 
-    def _class_from_string(self, string: str):
+    def _reg_class_from_string(self, string: str):
         try:
             return self._lookup_table[string]
         except KeyError:


### PR DESCRIPTION
**Description**
This PR fixes the lookup by string during the driver binding by introducing a new dictionary in the TargetFactory and using this to look at all registered resources and drivers.
It then converts the imports used for the bindings to strings.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] PR has been tested

Tested by running tox, which also revealed the lookup problem.