### PR TITLE
add support for USB power supplies via sigrok

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1517,6 +1517,10 @@ Implements:
 Arguments:
   - delay (float): optional delay in seconds between off and on, defaults to
     3.0
+  - max_voltage (float): maximum allowed voltage for protection against
+    accidental damage (optional, in volts)
+  - max_current (float): maximum allowed current for protection against
+    accidental damage (optional, in ampere)
 
 USBSDMuxDriver
 ~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -279,7 +279,7 @@ from all connected supported devices use the `SigrokUSBDevice`_.
      channel: "D0=CLK,D1=DATA"
 
 - driver (str): name of the sigrok driver to use
-- channel (str): channel mapping as described in the sigrok-cli man page
+- channel (str): optional, channel mapping as described in the sigrok-cli man page
 
 Used by:
   - `SigrokDriver`_
@@ -411,7 +411,7 @@ A SigrokUSBDevice resource describes a sigrok USB device.
        'ID_PATH': 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 - driver (str): name of the sigrok driver to use
-- channel (str): channel mapping as described in the sigrok-cli man page
+- channel (str): optional, channel mapping as described in the sigrok-cli man page
 - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
@@ -432,7 +432,7 @@ host which is exported over the network. The SigrokDriver will access it via SSH
      host: remote.example.computer
 
 - driver (str): name of the sigrok driver to use
-- channel (str): channel mapping as described in the sigrok-cli man page
+- channel (str): optional, channel mapping as described in the sigrok-cli man page
 - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -438,6 +438,24 @@ host which is exported over the network. The SigrokDriver will access it via SSH
 Used by:
   - `SigrokDriver`_
 
+SigrokUSBSerialDevice
+~~~~~~~~~~~~~~~~~~~~~
+A SigrokUSBSerialDevice resource describes a sigrok device which communicates
+of a USB serial port instead of being a USB device itself (see
+`SigrokUSBDevice` for that case).
+
+.. code-block:: yaml
+
+   SigrokUSBSerialDevice:
+     driver: manson-hcs-3xxx
+     match:
+       '@ID_SERIAL_SHORT': P-00-02389
+
+- driver (str): name of the sigrok driver to use
+
+Used by:
+  - `SigrokPowerDriver`_
+
 USBSDMuxDevice
 ~~~~~~~~~~~~~~
 A :any:`USBSDMuxDevice` resource describes a Pengutronix
@@ -1477,6 +1495,28 @@ Implements:
 
 The driver can be used in test cases by calling the `capture`, `stop` and
 `analyze` functions.
+
+SigrokPowerDriver
+~~~~~~~~~~~~~~~~~
+The SigrokPowerDriver uses a `SigrokUSBSerialDevice`_ Resource to control a
+programmable power supply.
+
+Binds to:
+  sigrok:
+    - `SigrokUSBSerialDevice`_
+    - NetworkSigrokUSBSerialDevice
+
+Implements:
+  - :any:`PowerProtocol`
+
+.. code-block:: yaml
+
+   SigrokPowerDriver:
+     delay: 3.0
+
+Arguments:
+  - delay (float): optional delay in seconds between off and on, defaults to
+    3.0
 
 USBSDMuxDriver
 ~~~~~~~~~~~~~~

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -307,6 +307,7 @@ exports["MXSUSBLoader"] = USBGenericExport
 exports["RKUSBLoader"] = USBGenericExport
 exports["AlteraUSBBlaster"] = USBGenericExport
 exports["SigrokUSBDevice"] = USBSigrokExport
+exports["SigrokUSBSerialDevice"] = USBSigrokExport
 exports["USBSDMuxDevice"] = USBSDMuxExport
 
 exports["USBMassStorage"] = USBGenericExport

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -164,6 +164,17 @@ class NetworkSigrokUSBDevice(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkSigrokUSBSerialDevice(RemoteUSBResource):
+    """The NetworkSigrokUSBSerialDevice describes a remotely accessible sigrok USB device"""
+    driver = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    channels = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkUSBMassStorage(RemoteUSBResource):
     """The NetworkUSBMassStorage describes a remotely accessible USB storage device"""
     def __attrs_post_init__(self):

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -156,7 +156,7 @@ class NetworkAlteraUSBBlaster(RemoteUSBResource):
 class NetworkSigrokUSBDevice(RemoteUSBResource):
     """The NetworkSigrokUSBDevice describes a remotely accessible sigrok USB device"""
     driver = attr.ib(default=None, validator=attr.validators.instance_of(str))
-    channels = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    channels = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()

--- a/labgrid/resource/sigrok.py
+++ b/labgrid/resource/sigrok.py
@@ -14,4 +14,4 @@ class SigrokDevice(Resource):
         channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
     """
     driver = attr.ib(default="demo")
-    channels = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    channels = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -346,6 +346,8 @@ class SigrokUSBDevice(USBResource):
     """The SigrokUSBDevice describes an attached sigrok device with driver and
     optional channel mapping, it is identified via usb using udev.
 
+    This is used for devices which communicate over a custom USB protocol.
+
     Args:
         driver (str): driver to use with sigrok
         channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
@@ -356,6 +358,33 @@ class SigrokUSBDevice(USBResource):
     def __attrs_post_init__(self):
         self.match['@SUBSYSTEM'] = 'usb'
         super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class SigrokUSBSerialDevice(USBResource):
+    """The SigrokUSBSerialDevice describes an attached sigrok device with driver and
+    optional channel mapping, it is identified via usb using udev.
+
+    This is used for devices which communicate over an emulated serial device.
+
+    Args:
+        driver (str): driver to use with sigrok
+        channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
+    """
+    driver = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    channels = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
+
+    def __attrs_post_init__(self):
+        self.match['SUBSYSTEM'] = 'tty'
+        self.match['@SUBSYSTEM'] = 'usb'
+        super().__attrs_post_init__()
+
+    @property
+    def path(self):
+        if self.device is not None:
+            return self.device.device_node
+
+        return None
 
 @target_factory.reg_resource
 @attr.s(eq=False)

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -344,14 +344,15 @@ class AlteraUSBBlaster(USBResource):
 @attr.s(eq=False)
 class SigrokUSBDevice(USBResource):
     """The SigrokUSBDevice describes an attached sigrok device with driver and
-    channel mapping, it is identified via usb using udev
+    optional channel mapping, it is identified via usb using udev.
 
     Args:
         driver (str): driver to use with sigrok
         channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
     """
     driver = attr.ib(default=None, validator=attr.validators.instance_of(str))
-    channels = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    channels = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
+
     def __attrs_post_init__(self):
         self.match['@SUBSYSTEM'] = 'usb'
         super().__attrs_post_init__()

--- a/tests/test_sigrok.py
+++ b/tests/test_sigrok.py
@@ -3,9 +3,9 @@ import os.path
 from time import sleep
 from shutil import which
 
-from labgrid.resource.udev import SigrokUSBDevice
+from labgrid.resource.udev import SigrokUSBDevice, SigrokUSBSerialDevice
 from labgrid.resource.sigrok import SigrokDevice
-from labgrid.driver.sigrokdriver import SigrokDriver
+from labgrid.driver.sigrokdriver import SigrokDriver, SigrokPowerDriver
 
 
 pytestmark = pytest.mark.skipif(not which("sigrok-cli"),
@@ -35,3 +35,8 @@ def test_sigrok_usb_driver(target, tmpdir):
     assert samples != None
     assert list(samples[0].keys()) == ['time', 'D0', 'D1']
     assert list(samples[-1].keys()) == ['time', 'D0', 'D1']
+
+def test_sigrok_power_driver(target):
+    r = SigrokUSBSerialDevice(target, name=None, driver='manson-hcs-3xxx')
+    d = SigrokPowerDriver(target, name=None)
+    target.activate(d)


### PR DESCRIPTION
**Description**
This splits the capture support from common code in driver/sigrokdriver and then adds a new SigrokPowerDriver implementing PowerProtocol and get/set methods for voltage and current.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested