### PR TITLE
add udev match suggestion utility

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -214,14 +214,10 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         if ready:
             # Always read a page, regardless of size
             res = self._clientsocket.recv(4096)
-            self.logger.debug(
-                "Read %i bytes: %s, timeout %.2f, requested size %i",
-                len(res), res, timeout, size)
         else:
             raise TIMEOUT("Timeout of %.2f seconds exceeded" % timeout)
         return res
 
     @step(args=['data'])
     def _write(self, data):
-        self.logger.debug("Write %i bytes: %s", len(data), data)
         return self._clientsocket.send(data)

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -7,6 +7,7 @@ import shutil
 import socket
 import subprocess
 import tempfile
+import time
 
 import attr
 from pexpect import TIMEOUT
@@ -212,6 +213,8 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
     def _read(self, size=1, timeout=10):
         ready, _, _ = select.select([self._clientsocket], [], [], timeout)
         if ready:
+            # Collect some more data
+            time.sleep(0.01)
             # Always read a page, regardless of size
             res = self._clientsocket.recv(4096)
         else:

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -1,0 +1,109 @@
+import argparse
+import logging
+import sys
+import textwrap
+import time
+
+from .udev import (
+    USBSerialPort,
+    USBMassStorage,
+    USBTMC,
+    USBVideo,
+    IMXUSBLoader,
+    AndroidFastboot,
+    USBSDMuxDevice,
+    AlteraUSBBlaster,
+    RKUSBLoader,
+    USBEthernetInterface,
+)
+from ..util import dump
+
+
+class Suggester:
+    def __init__(self, args):
+        self.resources = []
+        self.log = logging.getLogger("suggester")
+
+        args = {
+            'target': None,
+            'name': None,
+            'suggest': self.suggest_callback,
+        }
+
+        self.resources.append(USBSerialPort(**args))
+        self.resources.append(USBTMC(**args))
+        self.resources.append(USBVideo(**args))
+        self.resources.append(IMXUSBLoader(**args))
+        self.resources.append(AndroidFastboot(**args))
+        self.resources.append(USBMassStorage(**args))
+        self.resources.append(USBSDMuxDevice(**args))
+        self.resources.append(AlteraUSBBlaster(**args))
+        self.resources.append(RKUSBLoader(**args))
+        self.resources.append(USBEthernetInterface(**args))
+
+    def suggest_callback(self, resource, meta, suggestions):
+        cls = type(resource).__name__
+        if resource.device.action == 'add':
+            print("=== added device ===")
+        else:
+            print("=== existing device ===")
+        print("  {} for {}".format(cls, resource.device.device_path))
+
+        if meta:
+            print("  === device properies ===")
+        for k, v in meta.items():
+            print("  {}: {}".format(k, v))
+        if not suggestions:
+            print("  === no suggested matches found ===")
+            print()
+            return
+
+        print("  === suggested matches ===")
+        for i, suggestion in enumerate(suggestions):
+            if i:
+                print("  ---")
+            print(textwrap.indent(
+                dump({cls: {"match": suggestion}}).strip(),
+                '  ',
+            ))
+        print("  ---")
+        print()
+
+    def run(self):
+        while True:
+            managers = {r.get_managed_parent().manager for r in self.resources}
+            for manager in managers:
+                manager.poll()
+            time.sleep(0.1)
+
+
+def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(levelname)7s %(name)-20s %(message)s',
+        stream=sys.stderr,
+    )
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        default=False,
+        help="enable debug mode"
+    )
+
+    args = parser.parse_args()
+
+    if args.debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+
+    suggester = Suggester(args)
+    try:
+        suggester.run()
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -180,6 +180,7 @@ class USBResource(ManagedResource):
 class USBSerialPort(USBResource, SerialPort):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'tty'
+        self.match['@SUBSYSTEM'] = 'usb'
         if self.port:
             warnings.warn(
                 "USBSerialPort: The port attribute will be overwritten by udev.\n"

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -4,6 +4,7 @@ import os
 import queue
 import time
 import warnings
+from collections import OrderedDict
 
 import attr
 import pyudev
@@ -56,6 +57,7 @@ class USBResource(ManagedResource):
 
     match = attr.ib(factory=dict, validator=attr.validators.instance_of(dict), hash=False)
     device = attr.ib(default=None, hash=False)
+    suggest = attr.ib(default=False, hash=False, repr=False)
 
     def __attrs_post_init__(self):
         self.timeout = 5.0
@@ -65,6 +67,42 @@ class USBResource(ManagedResource):
 
     def filter_match(self, device):  # pylint: disable=unused-argument,no-self-use
         return True
+
+    def suggest_match(self, device):
+        meta = OrderedDict()
+        suggestions = []
+
+        if self.device.device_node:
+            meta['device node'] = self.device.device_node
+        if list(self.device.tags):
+            meta['udev tags'] = ', '.join(self.device.tags)
+        if self.device.properties.get('ID_VENDOR'):
+            meta['vendor'] = self.device.properties.get('ID_VENDOR')
+        if self.device.properties.get('ID_VENDOR_FROM_DATABASE'):
+            meta['vendor (DB)'] = self.device.properties.get('ID_VENDOR_FROM_DATABASE')
+        if self.device.properties.get('ID_MODEL'):
+            meta['model'] = self.device.properties.get('ID_MODEL')
+        if self.device.properties.get('ID_MODEL_FROM_DATABASE'):
+            meta['model (DB)'] = self.device.properties.get('ID_MODEL_FROM_DATABASE')
+        if self.device.properties.get('ID_REVISION'):
+            meta['revision'] = self.device.properties.get('ID_REVISION')
+
+        if self.match.get('SUBSYSTEM', None) == 'usb':
+            path = self._get_usb_device().properties.get('ID_PATH')
+            if path:
+                suggestions.append({'ID_PATH': path})
+            serial = self._get_usb_device().properties.get('ID_SERIAL_SHORT')
+            if serial:
+                suggestions.append({'ID_SERIAL_SHORT': serial})
+        elif self.match.get('@SUBSYSTEM', None) == 'usb':
+            path = self._get_usb_device().properties.get('ID_PATH')
+            if path:
+                suggestions.append({'@ID_PATH': path})
+            serial = self._get_usb_device().properties.get('ID_SERIAL_SHORT')
+            if serial:
+                suggestions.append({'@ID_SERIAL_SHORT': serial})
+
+        return meta, suggestions
 
     def try_match(self, device):
         if self.device is None:  # new device
@@ -98,6 +136,13 @@ class USBResource(ManagedResource):
                 return False
 
         self.log.debug(" found match: %s", self)
+
+        if self.suggest and device.action in [None, 'add']:
+            self.device = device
+            self.suggest(self, *self.suggest_match(device))
+            self.device = None
+            return False
+
         if device.action in [None, 'add']:
             if self.avail:
                 warnings.warn("udev device {} is already available".format(device))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -54,7 +54,7 @@ class UdevManager(ResourceManager):
 class USBResource(ManagedResource):
     manager_cls = UdevManager
 
-    match = attr.ib(default={}, validator=attr.validators.instance_of(dict), hash=False)
+    match = attr.ib(factory=dict, validator=attr.validators.instance_of(dict), hash=False)
     device = attr.ib(default=None, hash=False)
 
     def __attrs_post_init__(self):

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
             'labgrid-client = labgrid.remote.client:main',
             'labgrid-exporter = labgrid.remote.exporter:main',
             'labgrid-autoinstall = labgrid.autoinstall.main:main',
+            'labgrid-suggest = labgrid.resource.suggest:main',
         ]
     },
     # custom PyPI classifiers


### PR DESCRIPTION
**Description**
This helps with finding the correct match attributes for USB devices.

The output looks like this:
```
=== existing device ===
  USBSerialPort for /devices/pci0000:00/0000:00:14.0/usb1/1-3/1-3.2/1-3.2:1.0/ttyUSB1/tty/ttyUSB1
  === device properies ===
  device node: /dev/ttyUSB1
  udev tags: seat, systemd, uaccess
  vendor: FTDI
  vendor (DB): Future Technology Devices International, Ltd
  model: USB_Serial_Converter
  model (DB): FT232 Serial (UART) IC
  revision: 0600
  === suggested matches ===
  USBSerialPort:
    match:
      '@ID_PATH': pci-0000:00:14.0-usb-0:3.2
  ---
  USBSerialPort:
    match:
      '@ID_SERIAL_SHORT': FT8WJPE3
  ---

=== added device ===
  USBSDMuxDevice for /devices/pci0000:00/0000:00:14.0/usb1/1-3/1-3.4/1-3.4.1
  === device properies ===
  device node: /dev/bus/usb/001/047
  vendor: Pengutronix
  vendor (DB): Standard Microsystems Corp.
  model: usb-sd-mux_rev2.0
  model (DB): Hub and media card controller
  revision: 0209
  === suggested matches ===
  USBSDMuxDevice:
    match:
      ID_PATH: pci-0000:00:14.0-usb-0:3.4.1
  ---
  USBSDMuxDevice:
    match:
      ID_SERIAL_SHORT: '000000000106'
  ---
```

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated

This PR is based on #515.