### PR TITLE
graphstrategy: fix error message about multiple root states

### DIFF
--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -81,7 +81,7 @@ class GraphStrategy(Strategy):
         if len(root_states) > 1:
             raise InvalidGraphStrategyError(
                 'Only one root state supported. Defined root states: {}'.format(  # NOQA
-                    ', '.join([i[0] for i in root_states]),
+                    ', '.join(root_states),
                 )
             )
 


### PR DESCRIPTION
**Description**
`root_states` already contains all states without dependencies as strings. Joining only the first element of each string results in the first character of each state being printed. Fix this by joining `root_states` directly without a list comprehension.

**Checklist**
- [x] PR has been tested