### PR TITLE
remote: missing optional for NetworkUSBSDMuxDevice

### DIFF
--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -186,7 +186,7 @@ class NetworkUSBMassStorage(RemoteUSBResource):
 @attr.s(eq=False)
 class NetworkUSBSDMuxDevice(RemoteUSBResource):
     """The NetworkUSBSDMuxDevice describes a remotely accessible USBSDMux device"""
-    control_path = attr.ib(default=None, validator=attr.validators.instance_of(str))
+    control_path = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()


### PR DESCRIPTION
**Description**
Without this optional the exporter might return None for the
control_path if no device is connected, which results in the following
error message when the client wants to create the target:
```
Traceback (most recent call last):
  File "/home/phoenix/work/ptx/labgrid/labgrid/factory.py", line 111, in make_resource
    r = cls(target, name, **args)
  File "<attrs generated init labgrid.resource.remote.NetworkUSBSDMuxDevice>", line 24, in __init__
    __attr_validator_control_path(self, __attr_control_path, self.control_path)
  File "/home/phoenix/.virtualenvs/labgrid/lib/python3.7/site-packages/attr/validators.py", line 45, in __call__
    value,
TypeError: ("'control_path' must be <class 'str'> (got None that is a <class 'NoneType'>).", Attribute(name='control_path', default=None, validator=<instance_of validator for type <class 'str'>>, repr=True, eq=True, order=True, hash=None, init=True, metadata=mappingproxy({}), type=None, converter=None, kw_only=False), <class 'str'>, None)

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/phoenix/work/ptx/labgrid/labgrid/remote/client.py", line 1531, in main
    args.func(session)
  File "/home/phoenix/work/ptx/labgrid/labgrid/remote/client.py", line 690, in power
    target = self._get_target(place)
  File "/home/phoenix/work/ptx/labgrid/labgrid/remote/client.py", line 683, in _get_target
    RemotePlace(target, name=place.name)
  File "<attrs generated init labgrid.resource.remote.RemotePlace>", line 11, in __init__
    self.__attrs_post_init__()
  File "/home/phoenix/work/ptx/labgrid/labgrid/resource/remote.py", line 101, in __attrs_post_init__
    super().__attrs_post_init__()
  File "/home/phoenix/work/ptx/labgrid/labgrid/resource/common.py", line 118, in __attrs_post_init__
    self.manager._add_resource(self)
  File "/home/phoenix/work/ptx/labgrid/labgrid/resource/common.py", line 94, in _add_resource
    self.on_resource_added(resource)
  File "/home/phoenix/work/ptx/labgrid/labgrid/resource/remote.py", line 56, in on_resource_added
    remote_place.target, resource_entry.cls, resource_name, resource_entry.args)
  File "/home/phoenix/work/ptx/labgrid/labgrid/factory.py", line 115, in make_resource
    resource, target, args)) from e
labgrid.exceptions.InvalidConfigError: failed to create NetworkUSBSDMuxDevice for target 'Target(name='nitrogen6x', env=None)' using {'host': 'dibooki', 'busnum': None, 'devnum': None, 'path': None, 'vendor_id': None, 'model_id': None, 'control_path': None}
This is likely caused by an error in the environment configuration or invalid
resource information provided by the coordinator.
```
Add the appropriate optional (which is also default) to allow usage of
places with disconnected USBSDMuxDevices.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

- [x] PR has been tested

