### PR TITLE
client: exit gracefully when microcom is missing

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -785,7 +785,10 @@ class ClientSession(ApplicationSession):
             "{}:{}".format(host, port)
         ]
         print("connecting to {} calling {}".format(resource, " ".join(call)))
-        p = await asyncio.create_subprocess_exec(*call)
+        try:
+            p = await asyncio.create_subprocess_exec(*call)
+        except FileNotFoundError as e:
+            raise ServerError("failed to execute microcom: {}".format(e))
         while p.returncode is None:
             try:
                 await asyncio.wait_for(p.wait(), 1.0)


### PR DESCRIPTION
When 'microcom' is not installed on the host running labgrid exporter,
client calling 'labgrid-client console' will receive FileNotFoundError.
This patch adds graceful exit in this situation.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>