### PR TITLE
docker: refactor Dockerfiles to reduce their size

### DIFF
--- a/docker/base/Dockerfile
+++ b/docker/base/Dockerfile
@@ -1,0 +1,13 @@
+FROM debian:buster-slim
+
+LABEL maintainer="eha@deif.com"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY ./ /opt/labgrid/
+
+RUN set -e ;\
+    apt update -q=2 ;\
+    apt install -q=2 --yes --no-install-recommends python3 python3-dev python3-pip python3-setuptools python3-wheel git build-essential libsnappy-dev ;\
+    apt clean ;\
+    rm -rf /var/lib/apt/lists/*

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,7 @@
-#!/bin/sh -ex
-docker build -t labgrid-client -f docker/client/Dockerfile .
-docker build -t labgrid-exporter -f docker/exporter/Dockerfile .
-docker build -t labgrid-coordinator -f docker/coordinator/Dockerfile .
+#!/bin/sh
+
+set -ex
+
+for dir in base client exporter coordinator; do
+    docker build -t labgrid-${dir} -f docker/${dir}/Dockerfile .
+done

--- a/docker/client/Dockerfile
+++ b/docker/client/Dockerfile
@@ -1,15 +1,12 @@
-FROM python:3.7
-MAINTAINER eha@deif.com
+FROM labgrid-base
 
-RUN mkdir -p /opt/labgrid
-COPY ./ /opt/labgrid/
-RUN cd /opt/labgrid \
- && pip install -r requirements.txt \
- && python setup.py install
-
-RUN apt-get update -q \
- && apt-get install -q -y microcom \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+RUN set -e ;\
+    cd /opt/labgrid ;\
+    pip3 install --no-cache-dir -r requirements.txt ;\
+    python3 setup.py install ;\
+    apt update -q=2 ;\
+    apt install -q=2 --yes --no-install-recommends microcom ;\
+    apt clean ;\
+    rm -rf /var/lib/apt/lists/*
 
 CMD ["/bin/bash"]

--- a/docker/coordinator/Dockerfile
+++ b/docker/coordinator/Dockerfile
@@ -1,14 +1,14 @@
-FROM python:3.7
-MAINTAINER eha@deif.com
-
-RUN mkdir -p /opt/labgrid
-COPY ./ /opt/labgrid/
-RUN cd /opt/labgrid \
- && pip install -r crossbar-requirements.txt \
- && python setup.py install
-
-VOLUME /opt/crossbar
-EXPOSE 20408
+FROM labgrid-base
 
 ENV CROSSBAR_DIR=/opt/crossbar
+
+RUN set -e ;\
+    cd /opt/labgrid ;\
+    pip3 install --no-cache-dir -r crossbar-requirements.txt ;\
+    python3 setup.py install
+
+VOLUME /opt/crossbar
+
+EXPOSE 20408
+
 CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]

--- a/docker/exporter/Dockerfile
+++ b/docker/exporter/Dockerfile
@@ -1,18 +1,16 @@
-FROM python:3.7
-MAINTAINER eha@deif.com
+FROM labgrid-base
 
-RUN mkdir -p /opt/labgrid
-COPY ./ /opt/labgrid/
-RUN cd /opt/labgrid \
- && pip install -r requirements.txt \
- && python setup.py install
+COPY docker/exporter/entrypoint.sh /entrypoint.sh
 
-RUN apt-get update -q \
- && apt-get install -q -y ser2net \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+RUN set -e ;\
+    cd /opt/labgrid ;\
+    pip3 install --no-cache-dir -r requirements.txt ;\
+    python3 setup.py install ;\
+    apt update -q=2 ;\
+    apt install -q=2 --yes --no-install-recommends ser2net ;\
+    apt clean ;\
+    rm -rf /var/lib/apt/lists/*
 
 VOLUME /opt/conf
 
-COPY docker/exporter/entrypoint.sh /entrypoint.sh
 CMD ["/entrypoint.sh"]

--- a/docker/exporter/entrypoint.sh
+++ b/docker/exporter/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
-if [ -f /opt/conf/ser2net.conf ] ; then
+
+set -e
+
+if [ -f /opt/conf/ser2net.conf ]; then
     ser2net -c /opt/conf/ser2net.conf
 fi
 labgrid-exporter "$@" /opt/conf/exporter.yaml


### PR DESCRIPTION
* Base image switched to debian:buster-slim to reduce the size of the
images (python:3 base images is fat). Each image is now ~500M instead of
~1G.
* Introduce a labgrid-base image since the build-dependencies are common
to all images.
* Use buildkit backend to slightly speed up the docker build time.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>
