### PR TITLE
driver/commandmixin: add step args for run_check

### DIFF
--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -82,7 +82,7 @@ class CommandMixin:
         return stdout
 
     @Driver.check_active
-    @step(args=['cmd'], result=True)
+    @step(args=['cmd', 'timeout', 'codec', 'decodeerrors'], result=True)
     def run_check(self, cmd: str, *, timeout=30, codec="utf-8", decodeerrors="strict"):
         """
         External run_check function, only available if the driver is active.


### PR DESCRIPTION
Add the missing step arguments for run_check.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

- [ ] PR has been tested