### PR TITLE
driver: shelldriver: combine marker/prompt expects and increase timeout in _check_prompt()

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -183,8 +183,10 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         # hide marker from expect
         self.console.sendline("echo '{}''{}'".format(marker[:4], marker[4:]))
         try:
-            self.console.expect("{}".format(marker), timeout=2)
-            self.console.expect(self.prompt, timeout=1)
+            self.console.expect(
+                r"{marker}\s+{prompt}".format(marker=marker, prompt=self.prompt),
+                timeout=3
+            )
             self._status = 1
         except TIMEOUT:
             self._status = 0

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -185,7 +185,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         try:
             self.console.expect(
                 r"{marker}\s+{prompt}".format(marker=marker, prompt=self.prompt),
-                timeout=3
+                timeout=5
             )
             self._status = 1
         except TIMEOUT:


### PR DESCRIPTION
**Description**
Use only a single expect call. This allows using a combined timeout for the marker and the prompt.

Due to heavy load on the target echoing the marker and displaying the prompt might take a while. This is no error, so increase the timeout (3 seconds -> 5 seconds).

**Checklist**
- [x] PR has been tested