### PR TITLE
doc: Add python-dev to required development dependency

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -22,7 +22,7 @@ Install required dependencies:
 
 .. code-block:: bash
 
-   sudo apt install libow-dev
+   sudo apt install python3-dev libow-dev
 
 Install the development requirements:
 


### PR DESCRIPTION
**Description**
Fixup: Add python3-dev to dependencies for development-environment
