### PR TITLE
Implement poll for all resources

### DIFF
--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -43,7 +43,7 @@ def pytest_addoption(parser):
         help='colored step reporter')
 
 
-@pytest.fixture('session')
+@pytest.fixture(scope="session")
 def env(request):
     """Return the environment configured in the supplied configuration file.
     It contains the targets contained in the configuration file.
@@ -103,7 +103,7 @@ def env(request):
     sshmanager.close_all()
 
 
-@pytest.fixture('session')
+@pytest.fixture(scope="session")
 def target(env):
     """Return the default target `main` configured in the supplied
     configuration file."""

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -46,6 +46,11 @@ class Resource(BindingMixin):
         """
         return self._parent.get_managed_parent() if self._parent else None
 
+    def poll(self):
+        managed_parent = self.get_managed_parent()
+        if managed_parent:
+            managed_parent.poll()
+
 
 @attr.s(eq=False)
 class NetworkResource(Resource):

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -44,10 +44,8 @@ class Target:
         if (monotonic() - self.last_update) < 0.1:
             return
         self.last_update = monotonic()
-        resources = [r for r in self.resources if isinstance(r, ManagedResource)]
-        for resource in resources:
+        for resource in self.resources:
             resource.poll()
-        for resource in resources:
             if not resource.avail and resource.state is BindingState.active:
                 self.log.info("deactivating unavailable resource %s", resource.display_name)  # pylint: disable=line-too-long
                 self.deactivate(resource)

--- a/tests/test_sigrok.py
+++ b/tests/test_sigrok.py
@@ -38,5 +38,6 @@ def test_sigrok_usb_driver(target, tmpdir):
 
 def test_sigrok_power_driver(target):
     r = SigrokUSBSerialDevice(target, name=None, driver='manson-hcs-3xxx')
+    r.avail = True
     d = SigrokPowerDriver(target, name=None)
     target.activate(d)


### PR DESCRIPTION
**Description**
Implement `poll` for all resources.

This should fix the bug in #530 and now poll all resources either directly or using their respective manager. Needs more testing before being merged.
**Checklist**
- [x] PR has been tested


Fixes #530 