### PR TITLE
remote/client: add PDUDaemon driver support

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -688,8 +688,8 @@ class ClientSession(ApplicationSession):
         action = self.args.action
         delay = self.args.delay
         target = self._get_target(place)
-        from ..driver.powerdriver import NetworkPowerDriver, USBPowerDriver
-        from ..resource.power import NetworkPowerPort
+        from ..driver.powerdriver import NetworkPowerDriver, PDUDaemonDriver, USBPowerDriver
+        from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort
         drv = None
         for resource in target.resources:
@@ -704,6 +704,12 @@ class ClientSession(ApplicationSession):
                     drv = target.get_driver(USBPowerDriver)
                 except NoDriverFoundError:
                     drv = USBPowerDriver(target, name=None, delay=delay)
+                break
+            elif isinstance(resource, PDUDaemonPort):
+                try:
+                    drv = target.get_driver(PDUDaemonDriver)
+                except NoDriverFoundError:
+                    drv = PDUDaemonDriver(target, name=None, delay=int(delay))
                 break
         if not drv:
             raise UserError("target has no compatible resource available")


### PR DESCRIPTION
**Description**
Add PDUDaemon driver support to the client.

Tested with [PDUDaemon in revision 941f14c](https://github.com/pdudaemon/pdudaemon/commit/941f14cdb0a5a36777c1bfc6fed87cd9c1ca8362). Older versions of PDUDaemon will still work, but since the HTTP listener falsely always responds with an error (see commit message in above link), the Labgrid client will raise an exception as well.

- [x] PR has been tested