### PR TITLE
coordinator and client robustness fixes

### DIFF
--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 setuptools>=38.0.0
-crossbar==19.3.5
+crossbar==19.11.1
 # For crossbar
 idna==2.5
 msgpack==0.6.2
+urllib3==1.24.3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ pytest-mock==1.12.1
 pytest-pylint==0.14.1
 pytest-dependency==0.4.0
 yapf==0.28.0
+psutil==5.6.3
 -r doc-requirements.txt
 -r crossbar-requirements.txt
 -r onewire-requirements.txt

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -587,10 +587,6 @@ class CoordinatorComponent(ApplicationSession):
 
         return True
 
-    @locked
-    async def acquire_resources(self, place, resources):
-        return await self._acquire_resources(place, resources)
-
     async def _release_resources(self, place, resources):
         resources = resources.copy() # we may modify the list
 
@@ -613,10 +609,6 @@ class CoordinatorComponent(ApplicationSession):
                     self._publish_resource(resource)
                 except:
                     pass
-
-    @locked
-    async def release_resources(self, place, resources):
-        return await self._release_resources(place, resources)
 
     @locked
     async def acquire_place(self, name, details=None):

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -333,7 +333,7 @@ class CoordinatorComponent(ApplicationSession):
         place.matches.append(ResourceMatch(exporter="*", group=name, cls="*"))
         self.places[name] = place
 
-    async def _update_acquired_places(self, action, resource):
+    async def _update_acquired_places(self, action, resource, callback=True):
         """Update acquired places when resources are added or removed."""
         if action not in [Action.ADD, Action.DEL]:
             return  # currently nothing needed for Action.UPD
@@ -356,7 +356,7 @@ class CoordinatorComponent(ApplicationSession):
             self._publish_place(place)
         else:
             for place in places:
-                await self._release_resources(place, [resource])
+                await self._release_resources(place, [resource], callback=callback)
                 self._publish_place(place)
 
     def _publish_place(self, place):
@@ -398,7 +398,7 @@ class CoordinatorComponent(ApplicationSession):
             for groupname, group in session.groups.items():
                 for resourcename in group.copy():
                     action, resource = session.set_resource(groupname, resourcename, {})
-                    await self._update_acquired_places(action, resource)  # pylint: disable=not-an-iterable
+                    await self._update_acquired_places(action, resource, callback=False)  # pylint: disable=not-an-iterable
         self.save_later()
 
     @locked
@@ -592,7 +592,7 @@ class CoordinatorComponent(ApplicationSession):
 
         return True
 
-    async def _release_resources(self, place, resources):
+    async def _release_resources(self, place, resources, callback=True):
         resources = resources.copy() # we may modify the list
 
         for resource in resources:
@@ -605,8 +605,9 @@ class CoordinatorComponent(ApplicationSession):
             try:
                 # this triggers an update from the exporter which is published
                 # to the clients
-                await self.call('org.labgrid.exporter.{}.release'.format(resource.path[0]),
-                                resource.path[1], resource.path[3])
+                if callback:
+                    await self.call('org.labgrid.exporter.{}.release'.format(resource.path[0]),
+                                    resource.path[1], resource.path[3])
             except:
                 print("failed to release {}".format(resource))
                 # at leaset try to notify the clients

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -255,7 +255,10 @@ class CoordinatorComponent(ApplicationSession):
                 done, _ = await asyncio.wait([fut], timeout=5)
                 if not done:
                     print('kicking exporter ({}/{})'.format(session.key, session.name))
+                    await self.call('wamp.session.kill', session.key, message="timeout detected by coordinator")
+                    print('cleaning up exporter ({}/{})'.format(session.key, session.name))
                     await self.on_session_leave(session.key)
+                    print('removed exporter ({}/{})'.format(session.key, session.name))
                     continue
                 try:
                     session.version = done.pop().result()
@@ -264,6 +267,8 @@ class CoordinatorComponent(ApplicationSession):
                         pass # old client
                     elif e.error == "wamp.error.canceled":
                         pass # disconnected
+                    elif e.error == "wamp.error.no_such_session":
+                        pass # client has already disconnected
                     else:
                         raise
         # update reservations

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ pytest==5.3.1
 pyudev==0.21.0
 requests==2.22.0
 xmodem==0.4.5
-autobahn==19.3.3
+autobahn==19.11.1
 PyYAML==5.1.2
 ansicolors==1.1.8
 pyusb==1.0.2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -111,7 +111,7 @@ def crossbar(tmpdir, pytestconfig):
     reader.join()
 
 @pytest.fixture(scope='function')
-def exporter(tmpdir):
+def exporter(tmpdir, crossbar):
     p = tmpdir.join("exports.yaml")
     p.write(
         """

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -17,118 +17,118 @@ def place(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client -p test create') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test set-tags board=bar') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     yield
 
     with pexpect.spawn('python -m labgrid.remote.client -p test delete') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 @pytest.fixture(scope='function')
 def place_acquire(place, exporter):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/*/*"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     yield
 
     with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_place_show(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test show') as spawn:
         spawn.expect("Place 'test':")
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_place_alias(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-alias foo') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p foo del-alias foo') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_place_comment(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test set-comment my comment') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test show') as spawn:
         spawn.expect("Place 'test':")
         spawn.expect(" comment: my comment")
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_place_match(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match "e1/g1/r1" "e2/g2/*"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test del-match "e1/g1/r1"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test show') as spawn:
         spawn.expect(" matches:")
         spawn.expect(" e2/g2/*")
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_place_aquire(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client who') as spawn:
         spawn.expect(".*test.*")
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_place_add_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client create') as spawn:
         spawn.expect("missing place name")
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus != 0
+        assert spawn.exitstatus != 0, spawn.before.strip()
 
 def test_place_del_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client delete') as spawn:
         spawn.expect("deletes require an exact place name")
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus != 0
+        assert spawn.exitstatus != 0, spawn.before.strip()
 
 def test_remoteplace_target(place_acquire, tmpdir):
     from labgrid.environment import Environment
@@ -151,30 +151,30 @@ def test_resource_conflict(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test2 create') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test2 add-match "*/*/*"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test2 acquire') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus != 0
+        assert spawn.exitstatus != 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test2 delete') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
 def test_reservation(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client reserve --shell board=bar name=test') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
         m = re.search(rb"^export LG_TOKEN=(\S+)$", spawn.before.replace(b'\r\n', b'\n'), re.MULTILINE)
-        assert m is not None
+        assert m is not None, spawn.before.strip()
         token = m.group(1)
 
     env = os.environ.copy()
@@ -183,64 +183,64 @@ def test_reservation(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
-        assert b'waiting' in spawn.before
-        assert token in spawn.before
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        assert b'waiting' in spawn.before, spawn.before.strip()
+        assert token in spawn.before, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
-        assert b'allocated' in spawn.before
-        assert token in spawn.before
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        assert b'allocated' in spawn.before, spawn.before.strip()
+        assert token in spawn.before, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
-        assert b'allocated' in spawn.before
-        assert token in spawn.before
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        assert b'allocated' in spawn.before, spawn.before.strip()
+        assert token in spawn.before, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p + acquire', env=env) as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p + show', env=env) as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert token in spawn.before
-        assert spawn.exitstatus == 0
+        assert token in spawn.before, spawn.before.strip()
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p + release', env=env) as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
-        assert b'allocated' in spawn.before
-        assert token in spawn.before
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        assert b'allocated' in spawn.before, spawn.before.strip()
+        assert token in spawn.before, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client cancel-reservation', env=env) as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client reservations') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
-        assert token not in spawn.before
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        assert token not in spawn.before, spawn.before.strip()
 
     with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
-        assert spawn.exitstatus == 0
+        assert spawn.exitstatus == 0, spawn.before.strip()


### PR DESCRIPTION
**Description**
This fixes a locking issue in the coordinator, which was triggered when exporters stopped responding without closing their TCP connection to crossbar.
It also adds some more robustness fixes to the client and improves testing in these areas.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested