### PR TITLE
Add copy-files client command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Features in 0.4.0
 - Network controlled relay providing GET/PUT based REST API
 - Improved LG_PROXY documentation in docs/usage.rst.
 - Exporter now checks /usr/sbin/ser2net for SerialPortExport
+- labgrid-client now has a ``copy-files`` subcommand to copy files onto mass
+  storage devices.
 
 Bug fixes in 0.4.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -426,7 +426,7 @@ Used by:
   - `USBStorageDriver`_
 
 The NetworkUSBMassStorage can be used in test cases by calling the
-`write_image()`, and `get_size()` functions.
+`copy_files()`, `write_image()`, and `get_size()` functions.
 
 SigrokDevice
 ~~~~~~~~~~~~

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -184,6 +184,8 @@ matches anything.
 .sp
 \fBtmc\fP command                 Control a USB TMC device
 .sp
+\fBcopy\-files\fP filename(s)      Copy files onto mass storage device
+.sp
 \fBwrite\-image\fP                 Write images onto block devices (USBSDMux, USB Sticks, …)
 .sp
 \fBreserve\fP filter              Create a reservation

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -178,6 +178,8 @@ LABGRID-CLIENT COMMANDS
 
 ``tmc`` command                 Control a USB TMC device
 
+``copy-files`` filename(s)      Copy files onto mass storage device
+
 ``write-image``                 Write images onto block devices (USBSDMux, USB Sticks, …)
 
 ``reserve`` filter              Create a reservation


### PR DESCRIPTION
**Description**

Adds a copy-files client command to copy files onto mass storage. In our workflow, we often need to update individual boot files (i.e. ``BOOT.BIN`` and `image.ub` on Xilinx SoC devices), but not the whole partition or device image. The user interface tries to reproduce the semantics of the UNIX ``cp`` command as much as possible.

As of now, we can only copy individual files, but not recursively on directories; in the future we might want to extend the ``ManagedFile`` class to support this use case as well.

Tested with an USB-SD-Mux on Ubuntu 18.04 LTS with pmount installed.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated