### PR TITLE
driver/power: Add power driver to support GEMBIRD SiS-PM Control

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,6 +37,7 @@ New Features in 0.3.0
 - UBootDriver now allows overriding of default boot command (``run bootcmd``)
   via new ``boot_command`` argument.
 - The config file supports per-target options, in addition to global options.
+- Add power driver to support GEMBIRD SiS-PM implementing SiSPMPowerDriver.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -183,6 +183,25 @@ Used by:
    looking for, paths without the interface will fail to match since they use
    the ``usb`` driver.
 
+SiSPMPowerPort
++++++++++++++++++
+A SiSPMPowerPort describes a GEMBIRD SiS-PM as supported by
+`sispmctl <https://sourceforge.net/projects/sispmctl/>`_.
+
+.. code-block:: yaml
+
+   SiSPMPowerPort:
+     match:
+       ID_PATH: platform-1c1a400.usb-usb-0:2
+     index: 1
+
+The example describes port 1 on the hub with the ID_PATH
+"platform-1c1a400.usb-usb-0:2".
+
+- index (int): number of the port to switch
+
+Used by:
+  - `SiSPMPowerDriver`_
 
 ModbusTCPCoil
 ~~~~~~~~~~~~~
@@ -1248,6 +1267,25 @@ Implements:
 .. code-block:: yaml
 
    USBPowerPort:
+     delay: 5.0
+
+Arguments:
+  - delay (float): optional delay in seconds between off and on
+
+SiSPMPowerDriver
+~~~~~~~~~~~~~~~~~~~
+A SiSPMPowerDriver controls a `SiSPMPowerPort`, allowing control of the target
+power state without user interaction.
+
+Binds to:
+  - `SiSPMPowerPort`_
+
+Implements:
+  - :any:`PowerProtocol`
+
+.. code-block:: yaml
+
+   SiSPMPowerPort:
      delay: 5.0
 
 Arguments:

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -13,7 +13,7 @@ from .flashromdriver import FlashromDriver
 from .onewiredriver import OneWirePIODriver
 from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
                          DigitalOutputPowerDriver, YKUSHPowerDriver, \
-                         USBPowerDriver
+                         USBPowerDriver, SiSPMPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver, RKUSBDriver, UUUDriver
 from .usbsdmuxdriver import USBSDMuxDriver
 from .usbsdwiredriver import USBSDWireDriver

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -693,9 +693,10 @@ class ClientSession(ApplicationSession):
         action = self.args.action
         delay = self.args.delay
         target = self._get_target(place)
-        from ..driver.powerdriver import NetworkPowerDriver, PDUDaemonDriver, USBPowerDriver
+        from ..driver.powerdriver import (NetworkPowerDriver, PDUDaemonDriver,
+                                          USBPowerDriver, SiSPMPowerDriver)
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
-        from ..resource.remote import NetworkUSBPowerPort
+        from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort
 
         drv = None
         try:
@@ -714,6 +715,12 @@ class ClientSession(ApplicationSession):
                     except NoDriverFoundError:
                         drv = USBPowerDriver(target, name=None, delay=delay)
                         break
+                elif isinstance(resource, NetworkSiSPMPowerPort):
+                    try:
+                        drv = target.get_driver(SiSPMPowerDriver)
+                    except NoDriverFoundError:
+                        drv = SiSPMPowerDriver(target, name=None, delay=delay)
+                    break
                 elif isinstance(resource, PDUDaemonPort):
                     try:
                         drv = target.get_driver(PDUDaemonDriver)

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -376,6 +376,25 @@ class USBSDWireExport(USBGenericExport):
         }
 
 @attr.s(eq=False)
+class SiSPMPowerPortExport(USBGenericExport):
+    """ResourceExport for ports on GEMBRID switches"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': self.host,
+            'busnum': self.local.busnum,
+            'devnum': self.local.devnum,
+            'path': self.local.path,
+            'vendor_id': self.local.vendor_id,
+            'model_id': self.local.model_id,
+            'index': self.local.index,
+        }
+
+@attr.s(eq=False)
 class USBPowerPortExport(USBGenericExport):
     """ResourceExport for ports on switchable USB hubs"""
 
@@ -427,6 +446,7 @@ exports["USBSDWireDevice"] = USBSDWireExport
 exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport
 exports["USBTMC"] = USBGenericExport
+exports["SiSPMPowerPort"] = SiSPMPowerPortExport
 exports["USBPowerPort"] = USBPowerPortExport
 exports["DeditecRelais8"] = USBDeditecRelaisExport
 

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -10,6 +10,7 @@ from .udev import USBSerialPort
 from .udev import USBSDMuxDevice
 from .udev import USBSDWireDevice
 from .udev import USBPowerPort
+from .udev import SiSPMPowerPort
 from .common import Resource, ResourceManager, ManagedResource
 from .ykushpowerport import YKUSHPowerPort
 from .xenamanager import XenaManager

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -219,6 +219,15 @@ class NetworkUSBSDWireDevice(RemoteUSBResource):
         self.timeout = 10.0
         super().__attrs_post_init__()
 
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkSiSPMPowerPort(RemoteUSBResource):
+    """The NetworkSiSPMPowerPort describes a remotely accessible SiS-PM power port"""
+    index = attr.ib(default=None, validator=attr.validators.instance_of(int))
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
 
 @target_factory.reg_resource
 @attr.s(eq=False)

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -16,6 +16,7 @@ from .udev import (
     AlteraUSBBlaster,
     RKUSBLoader,
     USBEthernetInterface,
+    SiSPMPowerPort,
 )
 from ..util import dump
 
@@ -42,6 +43,7 @@ class Suggester:
         self.resources.append(AlteraUSBBlaster(**args))
         self.resources.append(RKUSBLoader(**args))
         self.resources.append(USBEthernetInterface(**args))
+        self.resources.append(SiSPMPowerPort(**args))
 
     def suggest_callback(self, resource, meta, suggestions):
         cls = type(resource).__name__

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -519,6 +519,27 @@ class USBPowerPort(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class SiSPMPowerPort(USBResource):
+    """This resource describes a SiS-PM (Silver Shield PM) power port.
+
+    Args:
+        index (int): port index
+    """
+    index = attr.ib(default=0, validator=attr.validators.instance_of(int))
+
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [
+                ("04b4", "fd10"), ("04b4", "fd11"),
+                ("04b4", "fd12"), ("04b4", "fd13"),
+                ("04b4", "fd15")]:
+            return False
+
+        return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class USBVideo(USBResource):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'video4linux'

--- a/tests/test_sispm.py
+++ b/tests/test_sispm.py
@@ -1,0 +1,17 @@
+from labgrid.resource.remote import NetworkSiSPMPowerPort
+from labgrid.driver.powerdriver import SiSPMPowerDriver
+
+
+def test_sispm_create(target):
+    r = NetworkSiSPMPowerPort(target,
+            name=None,
+            host="localhost",
+            busnum=0,
+            devnum=1,
+            path='0:1',
+            vendor_id=0x0,
+            model_id=0x0,
+            index=1,
+    )
+    d = SiSPMPowerDriver(target, name=None)
+    assert (isinstance(d, SiSPMPowerDriver))


### PR DESCRIPTION
This patch adds support for SiS-PM (Silver Shield PM) Control
for Linux, aka sismpctl.

Signed-off-by: Matthias Brugger <matthias.bgg@kernel.org>


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
