### PR TITLE
doc: Link 'Overview' Chapters From 'Getting Started' Chapter

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -162,11 +162,12 @@ The HTML documentation is written to ``doc/.build/html/``.
 Setting Up the Distributed Infrastructure
 -----------------------------------------
 
-The labgrid distributed infrastructure consists of three components:
+The labgrid :ref:`distributed infrastructure <remote-resources-and-places>`
+consists of three components:
 
-#. Coordinator
-#. Exporter
-#. Client
+#. :ref:`overview-coordinator`
+#. :ref:`overview-exporter`
+#. :ref:`overview-client`
 
 The system needs at least one coordinator and exporter, these can run on the
 same machine. The client is used to access functionality provided by an

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -3,6 +3,8 @@ Getting Started
 
 This section of the manual contains introductory tutorials for installing
 labgrid, running your first test and setting up the distributed infrastructure.
+For an overview about the basic design and components of `labgrid`, read the
+:ref:`overview` first.
 
 Installation
 ------------

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -1,3 +1,5 @@
+.. _overview:
+
 Overview
 ========
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -220,6 +220,8 @@ implementation `Autobahn <http://autobahn.ws/>`_ and the `Crossbar
 The following sections describe the resposibilities of each component. See
 :ref:`remote-usage` for usage information.
 
+.. _overview-coordinator:
+
 Coordinator
 ~~~~~~~~~~~
 
@@ -281,6 +283,8 @@ client host has currently acquired the place.
 The resource matches are only evaluated while a place is being acquired and cannot be
 changed until it is `released` again.
 
+.. _overview-exporter:
+
 Exporter
 ~~~~~~~~
 An exporters registers all its configured resources when it connects to the
@@ -299,6 +303,8 @@ Resources which do not need explicit support in the exporter, are just
 published as declared in the configuration file.
 This is useful to register externally configured resources such as network
 power switches or serial port servers with a labgrid coordinator.
+
+.. _overview-client:
 
 Client
 ~~~~~~


### PR DESCRIPTION
**Description**

Adds some links from the "Getting Started" chapter to the "Overview" chapter to ease finding informtaion about the general concept of things in labgrid.

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested

