### PR TITLE
RFC: Add BackgroundProcessProtocol, let SSHDriver/ShellDriver implement it 

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -838,6 +838,7 @@ Binds to:
 
 Implements:
   - :any:`CommandProtocol`
+  - :any:`BackgroundProcessProtocol`
   - :any:`FileTransferProtocol`
 
 .. code-block:: yaml

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -797,6 +797,7 @@ Binds to:
 
 Implements:
   - :any:`CommandProtocol`
+  - :any:`BackgroundProcessProtocol`
 
 .. code-block:: yaml
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -599,12 +599,3 @@ By writing these events to a file (or sqlite database) as a trace, we can
 collect data over multiple runs for later analysis.
 This would become more useful by passing recognized events (stack traces,
 crashes, ...) and benchmark results via the Step infrastructure.
-
-CommandProtocol Support for Background Processes
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Currently the CommandProtocol does not support long running
-processes well.
-An implementation should start a new process,
-return a handle and forbid running other processes in the foreground.
-The handle can be used to retrieve output from a command.

--- a/labgrid/protocol/__init__.py
+++ b/labgrid/protocol/__init__.py
@@ -9,3 +9,4 @@ from .digitaloutputprotocol import DigitalOutputProtocol
 from .mmioprotocol import MMIOProtocol
 from .filesystemprotocol import FileSystemProtocol
 from .resetprotocol import ResetProtocol
+from .backgroundprocessprotocol import BackgroundProcessProtocol

--- a/labgrid/protocol/backgroundprocessprotocol.py
+++ b/labgrid/protocol/backgroundprocessprotocol.py
@@ -1,0 +1,67 @@
+import abc
+
+
+class BackgroundProcessProtocol(abc.ABC):
+    """
+    Abstract class providing the BackgroundProcessProtocol interface. It allows running commands
+    as background processes. Running multiple commands concurrently may work depending on the
+    driver.
+
+    Example usage:
+
+    >>> from labgrid.util.timeout import Timeout
+    >>> with Timeout(300.0) as timeout:
+    >>>     process = driver.run_as_background_process('dd if=/dev/random bs=1M count=100')
+    >>>     while driver.poll_background_process(process) is None and not timeout.expired:
+    >>>         time.sleep(min(timeout.remaining, 1.0))
+    >>>         stdout, stderr = driver.read_from_background_process(process, timeout=timeout.remaining)
+    >>>         # do something else
+    >>> exitcode = driver.poll_background_process(process)
+    """
+
+    @abc.abstractmethod
+    def run_as_background_process(self, command):
+        """
+        Runs the given `command` as a background process and immediately return a process handle.
+        Raises ExecutionError if the maximum number of allowed concurrent processes is exceeded.
+
+        Args:
+            command (str): the command to run in background
+
+        Returns:
+            process handle, type implementation defined
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def read_from_background_process(self, process, *, timeout=0):
+        """
+        Read stdout/stderr of background process until timeout. For timeout=0 (default) the call
+        won't block and will return stdout/stderr until current EOF. For timeout=None the call
+        will block until the process has terminated. Returns a tuple (stdout, stderr).
+        Raises ExecutionError if process is not known.
+
+        Args:
+            process: process handle, type implementation defined
+            timeout (int or None): will block until timeout is exceeded or process terminates,
+                                   timeout=0 returns immediately (default), timeout=None blocks
+                                   until process terminates
+
+        Returns:
+            (stdout (str), stderr (str))
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def poll_background_process(self, process):
+        """
+        Check if background process has terminated. Returns exitcode if process has terminated
+        otherwise None. Raises ExecutionError if process is not known.
+
+        Args:
+            process: process handle, type implementation defined
+
+        Returns:
+            exit code if process terminated otherwise None
+        """
+        raise NotImplementedError

--- a/labgrid/util/expect.py
+++ b/labgrid/util/expect.py
@@ -1,3 +1,5 @@
+import string
+
 import pexpect
 
 
@@ -33,3 +35,12 @@ class PtxExpect(pexpect.spawn):
         if timeout == -1:
             timeout = self.timeout
         return self.driver.read(size=size, timeout=timeout)
+
+    def sendcontrol(self, char):
+        char = char.lower()
+        try:
+            ord_ = string.ascii_lowercase.index(char) + 1
+            self.send(bytes([ord_]))
+        except ValueError:
+            raise NotImplementedError("Sending control character {} is not supported yet".format(char))
+

--- a/labgrid/util/timeout.py
+++ b/labgrid/util/timeout.py
@@ -5,7 +5,7 @@ import attr
 
 @attr.s(eq=False)
 class Timeout:
-    """Reperents a timeout (as a deadline)"""
+    """Represents a timeout (as a deadline)"""
     timeout = attr.ib(
         default=120.0, validator=attr.validators.instance_of(float)
     )

--- a/labgrid/util/timeout.py
+++ b/labgrid/util/timeout.py
@@ -1,6 +1,7 @@
 import time
 
 import attr
+from pexpect import TIMEOUT
 
 
 @attr.s(eq=False)
@@ -23,3 +24,10 @@ class Timeout:
     @property
     def expired(self):
         return self._deadline <= time.monotonic()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        if self.expired:
+            raise TIMEOUT("Timeout of {} seconds exceeded".format(self.timeout))


### PR DESCRIPTION
**Description**
The _CommandProtocol_ allows executing commands on the target. `CommandProtocol.run()` blocks until the process terminated and stdout/stderr/exit code are returned. Some use cases require non-blocking communication with the process because something else needs to be done concurrently (think of a listening _netcat_ on the target and another _netcat_ on the testing host connecting to it). Maybe even multiple commands need to be run concurrently (if the underlying communication mechanism allows that).

The _BackgroundProcessProtocol_ allows exactly that. It defines a method to start a command in background, a method to read stdout/stderr from that background process and a method to check if the background process terminated (and if so with which exit code). The abstract _BackgroundProcessProtocol_ provides an example how to use it. Users of this protocol have to implement the timeout handling themselves. In order to simplify it `labgrid.util.timeout` can now be used as a context manager (see example).

This PR implements this protocol for the _SSHDriver_ and the _ShellDriver_. These driver probably benefit most from this feature.

**Checklist**
- [x] Documentation for the feature (in the BackgroundProcessProtocol)
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested