### PR TITLE
pytestplugin: reporter: report event source

### DIFF
--- a/labgrid/pytestplugin/reporter.py
+++ b/labgrid/pytestplugin/reporter.py
@@ -75,7 +75,8 @@ class StepReporter:
 
     def _line_format(self, event):
         indent = '  '*event.step.level
-        line = [indent, colors.color(event.step.title, style='bold')]
+        title = '{}.{}'.format(event.step.source.__class__.__name__, event.step.title)
+        line = [indent, colors.color(title, style='bold')]
         if event.resource:
             line.append(event.resource)
         line.extend(self.__format_elements())
@@ -143,7 +144,8 @@ class ColoredStepReporter(StepReporter):
     def _line_format(self, event):
         indent = '  '*event.step.level
         color = self.__event_color(event)
-        line = [indent, colors.color(event.step.title, fg=color, style='bold')]
+        title = '{}.{}'.format(event.step.source.__class__.__name__, event.step.title)
+        line = [indent, colors.color(title, fg=color, style='bold')]
         if event.resource:
             line.append(event.resource)
         line.extend(self.__format_elements(color))


### PR DESCRIPTION
**Description**
Due to an increasing number of drivers implementing protocols the method names logged in the step reporter become more and more ambiguous. Therefore prepend the event source (the name of the driver) to the report.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested