### PR TITLE
exporter broken tracking

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -445,13 +445,17 @@ class ExporterSession(ApplicationSession):
 
     async def acquire(self, group_name, resource_name, place_name):
         resource = self.groups[group_name][resource_name]
-        resource.acquire(place_name)
-        await self.update_resource(group_name, resource_name)
+        try:
+            resource.acquire(place_name)
+        finally:
+            await self.update_resource(group_name, resource_name)
 
     async def release(self, group_name, resource_name):
         resource = self.groups[group_name][resource_name]
-        resource.release()
-        await self.update_resource(group_name, resource_name)
+        try:
+            resource.release()
+        finally:
+            await self.update_resource(group_name, resource_name)
 
     async def version(self):
         self.checkpoint = time.monotonic()

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -211,6 +211,12 @@ class SerialPortExport(ResourceExport):
                 self.port, start_params['path']
             ),
         ])
+        try:
+            self.child.wait(timeout=0.5)
+            raise ExporterError("ser2net for {} exited immediately".format(start_params['path']))
+        except subprocess.TimeoutExpired:
+            # good, ser2net didn't exit immediately
+            pass
         self.logger.info("started ser2net for %s on port %d", start_params['path'], self.port)
 
     def _stop(self, start_params):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -117,7 +117,8 @@ def exporter(tmpdir, crossbar):
         """
     Testport:
         NetworkSerialPort:
-          {host: 'localhost', port: 4000}
+          host: 'localhost'
+          port: 4000
     """
     )
     spawn = pexpect.spawn(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -119,6 +119,9 @@ def exporter(tmpdir, crossbar):
         NetworkSerialPort:
           host: 'localhost'
           port: 4000
+    Broken:
+        RawSerialPort:
+          port: 'none'
     """
     )
     spawn = pexpect.spawn(

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -47,7 +47,7 @@ def place(crossbar):
 
 @pytest.fixture(scope='function')
 def place_acquire(place, exporter):
-    with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/*/*"') as spawn:
+    with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/Testport/*"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
@@ -186,7 +186,7 @@ def test_resource_conflict(place_acquire, tmpdir):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
-    with pexpect.spawn('python -m labgrid.remote.client -p test2 add-match "*/*/*"') as spawn:
+    with pexpect.spawn('python -m labgrid.remote.client -p test2 add-match "*/Testport/*"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -149,6 +149,25 @@ def test_place_aquire(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+def test_place_aquire_broken(place, exporter):
+    with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/Broken/*"') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
+        spawn.expect('failed to acquire place test')
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 1, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test show') as spawn:
+        spawn.expect("'broken': 'start failed'")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        print(spawn.before.decode())
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
 def test_place_add_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client create') as spawn:
         spawn.expect("missing place name")


### PR DESCRIPTION
**Description**
When the exporter is unable to start or stop subprocesses for resources, it's better to handle that explicitly rather than wait for errors when using them.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested