### PR TITLE
step: set event source for bound methods

### DIFF
--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -207,7 +207,7 @@ def step(*, title=None, args=[], result=False, tag=None):  # pylint: disable=unu
         def wrapper(*_args, **_kwargs):
             bound = signature.bind_partial(*_args, **_kwargs)
             bound.apply_defaults()
-            source = bound.arguments.get('self')
+            source = func.__self__ if inspect.ismethod(func) else bound.arguments.get('self')
             step = steps.get_new(title, tag, source)
             # optionally pass the step object
             if 'step' in signature.parameters:


### PR DESCRIPTION
**Description**
It is possible to call the step function not via the `@step` decorator but directly. In case `getattr()` is used to retrieve an object's method it will be a bound method object (instead of a function object when used via the decorator). The signature of a bound method does not contain self as a parameter, so the event source will always be None.

Currently only the _GraphStrategy_ calls the step function directly. Fix the event source in these cases by using `func.__self__` for bound methods.

Note: This allows #555 to print steps for GraphStrategy states with the correct event source (the class name of the individual strategy).

**Checklist**
- [ ] Tests for the feature 
- [ ] CHANGES.rst has been updated
- [x] PR has been tested