### PR TITLE
improve async scheduling

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -541,6 +541,9 @@ class ExporterSession(ApplicationSession):
                     continue
                 if changed:
                     await self.update_resource(group_name, resource_name)
+                else:
+                    # let other tasks run, see https://github.com/python/asyncio/issues/284
+                    await asyncio.sleep(0)
 
     async def poll(self):
         while True:


### PR DESCRIPTION
**Description**
We found two cases where the exporter and coordinator could block for some time, leading to ping timeouts and forced restarts. This PR allows scheduling other async tasks more often.

**Checklist**
- [x] PR has been tested