### PR TITLE
crossbar-requirements: Add explicit zlmdb version

### DIFF
--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -5,3 +5,4 @@ crossbar==19.11.1
 idna==2.5
 msgpack==0.6.2
 urllib3==1.24.3
+zlmdb==19.11.1


### PR DESCRIPTION
**Description**
The most resent update of zlmdb (20.1.1) is not compatible with crossbar 19.11.1. Hence this explicit version pin to zlmdb 19.11.1 in the crossbar requirements file

- [x] PR has been tested: In the docker based environment where a full labgrid environment is spun off.

