### PR TITLE
crossbar: move labgrid specific files to general workdir

### DIFF
--- a/.crossbar/config.yaml
+++ b/.crossbar/config.yaml
@@ -56,7 +56,7 @@ workers:
   arguments:
   - -mlabgrid.remote.coordinator
   options:
-    workdir: ..
+    workdir: .
     env:
       vars:
         WS: ws://localhost:20408/ws

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,6 +45,10 @@ Breaking changes in 0.3.0
   setup the cleanup job.
 - ``@attr.s(cmp=False)`` is deprecated and all classes have been moved to
   ``@attr.s(eq=False)``, this release requires attrs version 19.2.0
+- Coordinator work dir is now set to the same dir as the crossbar configuration
+  dir. Hence coordinator specific files like ``places.yaml`` and
+  ``resources.yaml`` are now also stored in the crossbar configuration folder.
+  Previously it would use ``..``.
 
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------

--- a/docker/staging/docker-compose.yml
+++ b/docker/staging/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "./crossbar:/home/root/crossbar"
     tty: true
     network_mode: "host"
-    command: bash -c "cp /home/root/crossbar/places_example.yaml /opt/places.yaml &&
+    command: bash -c "cp /home/root/crossbar/places_example.yaml /opt/crossbar/places.yaml &&
       crossbar start --config /opt/labgrid/.crossbar/config.yaml"
   client:
     image: "labgrid-client"


### PR DESCRIPTION
**Description**
Change the crossbar workdir configuration, for labgrid, from being
the parent dir to the actual workdir of crossbar. This implies
that all files related to crossbar are in the same dir.

- [x] CHANGES.rst has been updated
- [x] PR has been tested
