### PR TITLE
Improve process output logging, adjust client log levels

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -58,7 +58,10 @@ class AndroidFastbootDriver(Driver):
     @Driver.check_active
     @step(title='call', args=['args'])
     def __call__(self, *args):
-        processwrapper.check_output(self._get_fastboot_prefix() + list(args))
+        processwrapper.check_output(
+            self._get_fastboot_prefix() + list(args),
+            print_on_silent_log=True
+        )
 
     @Driver.check_active
     @step(args=['filename'])

--- a/labgrid/driver/flashromdriver.py
+++ b/labgrid/driver/flashromdriver.py
@@ -49,7 +49,6 @@ class FlashromDriver(Driver, BootstrapProtocol):
         arg_list = list(args)
         arg_list.append('-p')
         arg_list.append('{}'.format(self.flashrom_resource.programmer))
-        self.logger.debug('Call: %s with args: %s', self.tool, arg_list)
         processwrapper.check_output(self._get_flashrom_prefix() + arg_list)
 
     @Driver.check_active

--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -115,7 +115,8 @@ class USBStorageDriver(Driver):
             raise ValueError
 
         processwrapper.check_output(
-            self.storage.command_prefix + args
+            self.storage.command_prefix + args,
+            print_on_silent_log=True
         )
 
     @Driver.check_active

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1249,7 +1249,7 @@ def find_any_role_with_place(config):
 def main():
     processwrapper.enable_print()
     logging.basicConfig(
-        level=logging.INFO,
+        level=logging.WARNING,
         format='%(levelname)7s: %(message)s',
         stream=sys.stderr,
     )
@@ -1556,7 +1556,9 @@ def main():
         args.leftover = leftover
 
 
-    if args.debug:
+    if args.verbose:
+        logging.getLogger().setLevel(logging.INFO)
+    if args.debug or args.verbose > 1:
         logging.getLogger().setLevel(logging.DEBUG)
 
     if not args.config and args.state:

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1247,7 +1247,7 @@ def find_any_role_with_place(config):
     return None, None
 
 def main():
-    processwrapper.enable_print()
+    processwrapper.enable_logging()
     logging.basicConfig(
         level=logging.WARNING,
         format='%(levelname)7s: %(message)s',

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -60,7 +60,7 @@ class ProcessWrapper:
                 res.extend(parts)
                 for part in parts:
                     for callback in self.callbacks:
-                        callback(part)
+                        callback(part, process)
             process.poll()
             if process.returncode is not None:
                 break
@@ -73,7 +73,7 @@ class ProcessWrapper:
             if buf[-1] != b'\n':
                 buf += b'\n'
             for callback in self.callbacks:
-                callback(buf)
+                callback(buf, process)
         if process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode,
                                                 command,
@@ -93,7 +93,7 @@ class ProcessWrapper:
         self.callbacks.remove(callback)
 
     @staticmethod
-    def log_callback(message):
+    def log_callback(message, process):
         """Logs process output message along with its pid."""
         import logging
         logger = logging.getLogger("Process")
@@ -102,7 +102,7 @@ class ProcessWrapper:
             logger.info(message)
 
     @staticmethod
-    def print_callback(message):
+    def print_callback(message, _):
         """Prints process output message."""
         message = message.decode(encoding="utf-8", errors="replace")
         print("\r{}".format(message), end='')

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -107,9 +107,17 @@ class ProcessWrapper:
         Loglevel is logging.INFO."""
         self.register(ProcessWrapper.log_callback)
 
+    def disable_logging(self):
+        """Disables process output logging."""
+        self.unregister(ProcessWrapper.log_callback)
+
     def enable_print(self):
         """Enables process output to print."""
         self.register(ProcessWrapper.print_callback)
+
+    def disable_print(self):
+        """Disables process output printing."""
+        self.unregister(ProcessWrapper.print_callback)
 
 
 processwrapper = ProcessWrapper()

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -90,20 +90,26 @@ class ProcessWrapper:
         assert callback in self.callbacks
         self.callbacks.remove(callback)
 
+    @staticmethod
+    def log_callback(message):
+        """Logs process output message along with its pid."""
+        import logging
+        logger = logging.getLogger("Process")
+        logger.info(message.decode(encoding="utf-8", errors="replace"))
+
+    @staticmethod
+    def print_callback(message):
+        """Prints process output message."""
+        print(message.decode(encoding="utf-8", errors="replace"))
+
     def enable_logging(self):
         """Enables process output to the logging interface.
         Loglevel is logging.INFO."""
-        def log_callback(message):
-            import logging
-            logger = logging.getLogger("Process")
-            logger.info(message.decode(encoding="utf-8", errors="replace"))
-        self.register(log_callback)
+        self.register(ProcessWrapper.log_callback)
 
     def enable_print(self):
         """Enables process output to print."""
-        def print_callback(message):
-            print(message.decode(encoding="utf-8", errors="replace"))
-        self.register(print_callback)
+        self.register(ProcessWrapper.print_callback)
 
 
 processwrapper = ProcessWrapper()

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -42,6 +42,8 @@ class ProcessWrapper:
         process = subprocess.Popen(command, stderr=sfd,
                                    stdout=sfd, bufsize=0)
 
+        logger.log(ProcessWrapper.loglevel, "[%d] command: %s", process.pid, " ".join(command))
+
         # do not register/unregister already registered print_callback
         if ProcessWrapper.print_callback in self.callbacks:
             print_on_silent_log = False
@@ -113,7 +115,7 @@ class ProcessWrapper:
         logger = logging.getLogger("Process")
         message = message.decode(encoding="utf-8", errors="replace").strip("\n")
         if message:
-            logger.log(ProcessWrapper.loglevel, message)
+            logger.log(ProcessWrapper.loglevel, "[%d] %s", process.pid, message)
 
     @staticmethod
     def print_callback(message, _):


### PR DESCRIPTION
**Description**
#469 introduced ProcessWrapper, acting "like `subprocess.check_output`, but takes callbacks to send the output of the command to". This PR aims to improve the user experience of process output:

Output is now split on "\r" instead of "\r\n". This allows processing output of commands rewriting lines. It is currently used for "labgrid-client write-image" which again uses "dd status=progress".

Command output is in many cases not recognizable by the user without knowing the actual command. This gets even worse when multiple processes emit output. This is addressed by printing the command as well as its PID when started and prepend the PID to every log line of output.

To make use of this ProcessWrapper's logging callback is enabled for labgrid-client. Command output that is understandable without further context can now be printed with `ProcessWrapper.check_output(command, print_on_silent_log=True)`. This is enabled examplarily for NetworkUSBStorageDriver.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested