### PR TITLE
Add write-image features

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -32,6 +32,8 @@ New Features in 0.3.0
 - The binding dictionary can now supports type name strings in addition to the
   types themselves, avoiding the need to import a specific protocol or driver
   in some cases.
+- ``labgrid-client write-image`` gained new arguments: ``--partition``,
+  ``--skip``, ``--seek``.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -49,6 +49,14 @@ class NetworkUSBStorageDriver(Driver):
     @Driver.check_active
     @step(args=['filename'])
     def write_image(self, filename=None, mode=Mode.DD):
+        """
+        Writes the file specified by filename or if not specified by config image subkey to the
+        bound USB storage.
+
+        Args:
+            filename (str): optional, path to the image to write to bound USB storage
+            mode (Mode): optional, Mode.DD or Mode.BMAPTOOL (defaults to Mode.DD)
+        """
         if filename is None and self.image is not None:
             filename = self.target.env.config.get_image_path(self.image)
         assert filename, "write_image requires a filename"

--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -48,7 +48,7 @@ class NetworkUSBStorageDriver(Driver):
 
     @Driver.check_active
     @step(args=['filename'])
-    def write_image(self, filename=None, mode=Mode.DD, partition=None):
+    def write_image(self, filename=None, mode=Mode.DD, partition=None, skip=0, seek=0):
         """
         Writes the file specified by filename or if not specified by config image subkey to the
         bound USB storage root device or partition.
@@ -58,6 +58,8 @@ class NetworkUSBStorageDriver(Driver):
             mode (Mode): optional, Mode.DD or Mode.BMAPTOOL (defaults to Mode.DD)
             partition (int or None): optional, write to the specified partition or None for writing
                 to root device (defaults to None)
+            skip (int): optional, skip n 512-sized blocks at start of input file (defaults to 0)
+            seek (int): optional, skip n 512-sized blocks at start of output (defaults to 0)
         """
         if filename is None and self.image is not None:
             filename = self.target.env.config.get_image_path(self.image)
@@ -82,15 +84,20 @@ class NetworkUSBStorageDriver(Driver):
         partition = "" if partition is None else partition
 
         if mode == Mode.DD:
+            block_size = '512' if skip or seek else '4M'
             args = [
                 "dd",
                 "if={}".format(mf.get_remote_path()),
                 "of={}{}".format(self.storage.path, partition),
                 "status=progress",
-                "bs=4M",
+                "bs={}".format(block_size),
+                "skip={}".format(skip),
+                "seek={}".format(seek),
                 "conv=fdatasync"
             ]
         elif mode == Mode.BMAPTOOL:
+            if skip or seek:
+                raise ExecutionError("bmaptool does not support skip or seek")
             args = [
                 "bmaptool",
                 "copy",

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1098,7 +1098,8 @@ class ClientSession(ApplicationSession):
             raise UserError("target has no compatible resource available")
         target.activate(drv)
         try:
-            drv.write_image(self.args.filename)
+            drv.write_image(self.args.filename, partition=self.args.partition, skip=self.args.skip,
+                            seek=self.args.seek)
         except subprocess.CalledProcessError as e:
             raise UserError("could not write image to network usb storage: {}".format(e))
         except FileNotFoundError as e:
@@ -1469,6 +1470,11 @@ def main():
 
     subparser = subparsers.add_parser('write-image', help="write an image onto mass storage")
     subparser.add_argument('-w', '--wait', type=float, default=10.0)
+    subparser.add_argument('-p', '--partition', type=int, help="partition number to write to")
+    subparser.add_argument('--skip', type=int, default=0,
+                           help="skip n 512-sized blocks at start of input")
+    subparser.add_argument('--seek', type=int, default=0,
+                           help="skip n 512-sized blocks at start of output")
     subparser.add_argument('filename', help='filename to boot on the target')
     subparser.set_defaults(func=ClientSession.write_image)
 


### PR DESCRIPTION
**Description**
This PR enables writing to USB storage partitions and enables skip and seek for `Mode.DD`. Corresponding options were added to the client's `write-image` action.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [x] CHANGES.rst has been updated
- [x] PR has been tested