### PR TITLE
config: move resolve_path_str_or_list() from OpenOCDDriver to Config

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -67,6 +67,27 @@ class Config:
 
         return os.path.join(self.base, path)
 
+    def resolve_path_str_or_list(self, path):
+        """
+        Resolves a single path or multiple paths. Always returns a list (containing a single or
+        multiple resolved paths).
+
+        Args:
+            path (str, list): path(s) to resolve
+
+        Returns:
+            list: absolute path(s
+
+        Raises:
+            TypeError: if input is neither str nor list
+        """
+        if isinstance(path, str):
+            return [self.resolve_path(path)]
+        elif isinstance(path, list):
+            return [self.resolve_path(p) for p in path]
+
+        raise TypeError("path must be str or list")
+
     def get_tool(self, tool):
         """Retrieve an entry from the tools subkey
 

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -31,27 +31,18 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         self.logger = logging.getLogger("{}:{}".format(self, self.target))
-        self.config = self.resolve_path_str_or_list(self.config)
-        self.search = self.resolve_path_str_or_list(self.search)
 
         # FIXME make sure we always have an environment or config
         if self.target.env:
             self.tool = self.target.env.config.get_tool('openocd') or 'openocd'
+            self.config = self.target.env.config.resolve_path_str_or_list(self.config)
+            self.search = self.target.env.config.resolve_path_str_or_list(self.search)
         else:
             self.tool = 'openocd'
-
-    def resolve_path_str_or_list(self, path):
-        if isinstance(path, str):
-            if self.target.env:
-                return [self.target.env.config.resolve_path(path)]
-            return [path]
-
-        if isinstance(path, list):
-            if self.target.env:
-                return [self.target.env.config.resolve_path(p) for p in path]
-            # fall-through
-
-        return path
+            if isinstance(self.config, str):
+                self.config = [self.config]
+            if isinstance(self.search, str):
+                self.search = [self.search]
 
     def _get_usb_path_cmd(self):
         # OpenOCD supports "adapter usb location" since a1b308ab, if the command is not known


### PR DESCRIPTION
I am not sure if moving the reusable part of `resolve_path_str_or_list()` from the OpenOCDDriver to Config is beneficial . Either way, it was [requested back in summer 2018](https://github.com/labgrid-project/labgrid/pull/270#pullrequestreview-133655151), so here we go.

Feedback (as always) welcome.

**Checklist**
- [x] PR has been tested
