### PR TITLE
target: improve exception messages

### DIFF
--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -119,17 +119,16 @@ class Target:
         if not found:
             if other_names:
                 raise NoResourceFoundError(
-                    "all resources matching {cls} found in target {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
+                    "all resources matching {cls} found in {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
                         cls=cls, target=self, other_names=other_names)
                 )
 
             raise NoResourceFoundError(
-                "no resource matching {cls} found in target {target}".format(cls=cls, target=self)
+                "no resource matching {cls} found in {target}".format(cls=cls, target=self)
             )
         elif len(found) > 1:
             raise NoResourceFoundError(
-                "multiple resources matching {cls} found in target {target}".format(
-                    cls=cls, target=self)
+                "multiple resources matching {cls} found in {target}".format(cls=cls, target=self)
             )
         if wait_avail:
             self.await_resources(found)
@@ -155,12 +154,12 @@ class Target:
         if not found:
             if other_names:
                 raise NoDriverFoundError(
-                    "all {active}drivers matching {cls} found in target {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
+                    "all {active}drivers matching {cls} found in {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
                         active="active " if active else "", cls=cls, target=self, other_names=other_names)
                 )
 
             raise NoDriverFoundError(
-                "no {active}driver matching {cls} found in target {target}".format(
+                "no {active}driver matching {cls} found in {target}".format(
                     active="active " if active else "", cls=cls, target=self
                 )
             )
@@ -180,7 +179,7 @@ class Target:
                 found = prio_found
             else:
                 raise NoDriverFoundError(
-                    "multiple {active}drivers matching {cls} found in target {target} with the same priorities".format(  # pylint: disable=line-too-long
+                    "multiple {active}drivers matching {cls} found in {target} with the same priorities".format(  # pylint: disable=line-too-long
                         active="active " if active else "", cls=cls, target=self)
                 )
         if activate:
@@ -294,7 +293,7 @@ class Target:
             supplier_name = mapping.pop(name, None)
             if explicit and supplier_name is None:
                 raise BindingError(
-                    "supplier for {name} ({requirements}) of {driver} in target {target} requires an explicit name".format(  # pylint: disable=line-too-long
+                    "supplier for {name} ({requirements}) of {driver} in {target} requires an explicit name".format(  # pylint: disable=line-too-long
                         name=name, requirements=requirements, driver=client, target=self)
                 )
             # use sets even for a single requirement and make a local copy
@@ -332,7 +331,7 @@ class Target:
                     raise errors[0]
                 else:
                     raise NoSupplierFoundError(
-                        "no supplier matching {requirements} found in target {target} (errors: {errors})".format(  # pylint: disable=line-too-long
+                        "no supplier matching {requirements} found in {target} (errors: {errors})".format(  # pylint: disable=line-too-long
                             requirements=requirements, target=self, errors=errors)
                     )
             elif len(suppliers) > 1:

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -119,16 +119,17 @@ class Target:
         if not found:
             if other_names:
                 raise NoResourceFoundError(
-                    "all resources matching {} found in target {} have other names: {}".format(
-                        cls, self, other_names)
+                    "all resources matching {cls} found in target {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
+                        cls=cls, target=self, other_names=other_names)
                 )
 
             raise NoResourceFoundError(
-                "no resource matching {} found in target {}".format(cls, self)
+                "no resource matching {cls} found in target {target}".format(cls=cls, target=self)
             )
         elif len(found) > 1:
             raise NoResourceFoundError(
-                "multiple resources matching {} found in target {}".format(cls, self)
+                "multiple resources matching {cls} found in target {target}".format(
+                    cls=cls, target=self)
             )
         if wait_avail:
             self.await_resources(found)
@@ -154,14 +155,13 @@ class Target:
         if not found:
             if other_names:
                 raise NoDriverFoundError(
-                    "all {}drivers matching {} found in target {} have other names: {}".format(
-                        "active " if active else "",
-                        cls, self, other_names)
+                    "all {active}drivers matching {cls} found in target {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
+                        active="active " if active else "", cls=cls, target=self, other_names=other_names)
                 )
 
             raise NoDriverFoundError(
-                "no {}driver matching {} found in target {}".format(
-                    "active " if active else "", cls, self
+                "no {active}driver matching {cls} found in target {target}".format(
+                    active="active " if active else "", cls=cls, target=self
                 )
             )
         elif len(found) > 1:
@@ -180,8 +180,8 @@ class Target:
                 found = prio_found
             else:
                 raise NoDriverFoundError(
-                    "multiple {}drivers matching {} found in target {} with the same priorities".
-                    format("active " if active else "", cls, self)
+                    "multiple {active}drivers matching {cls} found in target {target} with the same priorities".format(  # pylint: disable=line-too-long
+                        active="active " if active else "", cls=cls, target=self)
                 )
         if activate:
             self.activate(found[0])
@@ -294,8 +294,8 @@ class Target:
             supplier_name = mapping.pop(name, None)
             if explicit and supplier_name is None:
                 raise BindingError(
-                    "supplier for {} ({}) of {} in target {} requires an explicit name".format(
-                        name, requirements, client, self)
+                    "supplier for {name} ({requirements}) of {driver} in target {target} requires an explicit name".format(  # pylint: disable=line-too-long
+                        name=name, requirements=requirements, driver=client, target=self)
                 )
             # use sets even for a single requirement and make a local copy
             if not isinstance(requirements, set):
@@ -332,8 +332,8 @@ class Target:
                     raise errors[0]
                 else:
                     raise NoSupplierFoundError(
-                        "no supplier matching {} found in target {} (errors: {})".format(
-                            requirements, self, errors)
+                        "no supplier matching {requirements} found in target {target} (errors: {errors})".format(  # pylint: disable=line-too-long
+                            requirements=requirements, target=self, errors=errors)
                     )
             elif len(suppliers) > 1:
                 raise NoSupplierFoundError("conflicting suppliers matching {} found in target {}".format(requirements, self))  # pylint: disable=line-too-long

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -117,14 +117,16 @@ class Target:
                 continue
             found.append(res)
         if not found:
+            name_msg = " named '{}'".format(name) if name else ""
             if other_names:
                 raise NoResourceFoundError(
-                    "all resources matching {cls} found in {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
-                        cls=cls, target=self, other_names=other_names)
+                    "no {cls} resource{name} found in {target}, matching resources with other names: {other_names}".format(  # pylint: disable=line-too-long
+                        cls=cls, name=name_msg, target=self, other_names=other_names)
                 )
 
             raise NoResourceFoundError(
-                "no resource matching {cls} found in {target}".format(cls=cls, target=self)
+                "no {cls} resource{name} found in {target}".format(
+                    cls=cls, name=name_msg, target=self)
             )
         elif len(found) > 1:
             raise NoResourceFoundError(
@@ -152,15 +154,17 @@ class Target:
                 continue
             found.append(drv)
         if not found:
+            name_msg = " named '{}'".format(name) if name else ""
             if other_names:
                 raise NoDriverFoundError(
-                    "all {active}drivers matching {cls} found in {target} have other names: {other_names}".format(  # pylint: disable=line-too-long
-                        active="active " if active else "", cls=cls, target=self, other_names=other_names)
+                    "no {active}{cls} driver{name} found in {target}, matching resources with other names: {other_names}".format(  # pylint: disable=line-too-long
+                        active="active " if active else "", cls=cls, name=name_msg, target=self,
+                        other_names=other_names)
                 )
 
             raise NoDriverFoundError(
-                "no {active}driver matching {cls} found in {target}".format(
-                    active="active " if active else "", cls=cls, target=self
+                "no {active}{cls} driver{name} found in {target}".format(
+                    active="active " if active else "", cls=cls, name=name_msg, target=self
                 )
             )
         elif len(found) > 1:

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,4 +1,5 @@
 import abc
+import re
 
 import attr
 import pytest
@@ -55,10 +56,11 @@ def test_getitem(target):
     assert target[AProtocol, "adriver"] is a
     with pytest.raises(NoDriverFoundError) as excinfo:
         target[A, "bdriver"]
-    assert "have other names" in excinfo.value.msg
+    assert "matching resources with other names" in excinfo.value.msg
     with pytest.raises(NoDriverFoundError) as excinfo:
         target[B, "adriver"]
-    assert "no active driver" in excinfo.value.msg
+    assert re.match("no active .*? driver named '{}' found in Target".format(a.name),
+                    excinfo.value.msg)
 
     a2 = A(target, None)
     target.activate(a2)


### PR DESCRIPTION
**Description**
When getting named resources and drivers fails because the requested name is unavailable the error messages do not say which name was not found. Add the name in these cases. While at it use named args for extensive format strings and remove redundancies in exception messages.

**Checklist**
- [ ] PR has been tested (parts of it)