### PR TITLE
driver: networkusbstorage: make decorator check that resources are bound

### DIFF
--- a/labgrid/driver/networkusbstoragedriver.py
+++ b/labgrid/driver/networkusbstoragedriver.py
@@ -46,12 +46,9 @@ class NetworkUSBStorageDriver(Driver):
     def on_deactivate(self):
         pass
 
+    @Driver.check_active
     @step(args=['filename'])
     def write_image(self, filename=None, mode=Mode.DD):
-        if not self.storage.path:
-            raise ExecutionError(
-                "{} is not available".format(self.storage_path)
-            )
         if filename is None and self.image is not None:
             filename = self.target.env.config.get_image_path(self.image)
         assert filename, "write_image requires a filename"
@@ -95,12 +92,9 @@ class NetworkUSBStorageDriver(Driver):
             self.storage.command_prefix + args
         )
 
+    @Driver.check_active
     @step(result=True)
     def get_size(self):
-        if not self.storage.path:
-            raise ExecutionError(
-                "{} is not available".format(self.storage_path)
-            )
         args = ["cat", "/sys/class/block/{}/size".format(self.storage.path[5:])]
         size = processwrapper.check_output(self.storage.command_prefix + args)
         return int(size)

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -250,6 +250,16 @@ class USBMassStorage(USBResource):
         self.match['@SUBSYSTEM'] = 'usb'
         super().__attrs_post_init__()
 
+    # Overwrite the avail attribute with our internal property
+    @property
+    def avail(self):
+        return self.path is not None
+
+    # Forbid the USBResource super class to set the avail property
+    @avail.setter
+    def avail(self, prop):
+        pass
+
     @property
     def path(self):
         if self.device is not None:


### PR DESCRIPTION
**Description**
Instead of explicitly checking if self.storage.path is set use the `@Driver.check_active` decorator. In order to make this work for USBMassStorage resources overwrite its avail attribute.

**Checklist**
- [x] PR has been tested

Fixes #363
Replaces #556