### PR TITLE
Update protocols, make drivers follow protocols

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,9 @@ Breaking changes in 0.3.0
   renamed to `USBStorageDriver`.
   A deprecated `NetworkUSBStorageDriver` exists temporarily for compatibility
   reasons.
+- ``codec`` and ``decodeerrors`` are no longer ``run()``/``run_check()``
+  kwargs, but driver (``codec``) and `CommandMixin` (``decodeerrors``)
+  attributes.
 
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -817,6 +817,7 @@ Arguments:
     to pass before sending a newline to device.
   - console_ready (regex): optional, pattern used by the kernel to inform
     the user that a console can be activated by pressing enter.
+  - codec (str, default="utf-8"): optional, encoding used to decode output bytes
 
 .. _conf-sshdriver:
 
@@ -849,6 +850,7 @@ Arguments:
     (only used if password is not set)
   - stderr_merge (bool): set to True to make `run()` return stderr merged with
       stdout, and an empty list as second element.
+  - codec (str, default="utf-8"): optional, encoding used to decode output bytes
 
 UBootDriver
 ~~~~~~~~~~~
@@ -880,6 +882,7 @@ Arguments:
   - bootstring (str): optional, regex to match on Linux Kernel boot
   - login_timeout (int): optional, timeout for login prompt detection in
     seconds (default 60)
+  - codec (str, default="utf-8"): optional, encoding used to decode output bytes
 
 SmallUBootDriver
 ~~~~~~~~~~~~~~~~
@@ -932,6 +935,7 @@ Arguments:
   - boot_expression (str): optional, regex to match the U-Boot start string
     defaults to "U-Boot 20\d+"
   - login_timeout (str): optional, timeout for the password/login detection
+  - codec (str, default="utf-8"): optional, encoding used to decode output bytes
 
 BareboxDriver
 ~~~~~~~~~~~~~
@@ -957,6 +961,7 @@ Arguments:
   - bootstring (regex, default="Linux version \d"): succesfully jumped into the kernel
   - password (str): optional, password to use for access to the shell
   - login_timeout (int): optional, timeout for access to the shell
+  - codec (str, default="utf-8"): optional, encoding used to decode output bytes
 
 ExternalConsoleDriver
 ~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -59,16 +59,16 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         self._status = 0
 
     @Driver.check_active
-    @step(args=['cmd'])
-    def run(self, cmd: str, *, timeout: int = 30):
-        return self._run(cmd, timeout=timeout)
+    @step(args=['command'])
+    def run(self, command: str, *, timeout: int = 30):
+        return self._run(command, timeout=timeout)
 
-    def _run(self, cmd: str, *, timeout: int = 30):
+    def _run(self, command: str, *, timeout: int = 30):
         """
         Runs the specified command on the shell and returns the output.
 
         Args:
-            cmd (str): command to run on the shell
+            command (str): command to run on the shell
             timeout (int): optional, timeout in seconds
 
         Returns:
@@ -79,7 +79,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         # hide marker from expect
         hidden_marker = '"{}""{}"'.format(marker[:4], marker[4:])
         cmp_command = '''echo -o /cmd {cmd}; echo {marker}; sh /cmd; echo {marker} $?;'''.format(
-            cmd=shlex.quote(cmd), marker=hidden_marker)
+            cmd=shlex.quote(command), marker=hidden_marker)
         if self._status == 1:
             self.console.sendline(cmp_command)
             _, _, match, _ = self.console.expect(

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -33,6 +33,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     bootstring = attr.ib(default=r"Linux version \d", validator=attr.validators.instance_of(str))
     password = attr.ib(default="", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=60, validator=attr.validators.instance_of(int))
+    codec = attr.ib(default="utf-8", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -59,10 +60,10 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
     @Driver.check_active
     @step(args=['cmd'])
-    def run(self, cmd: str, *, timeout: int = 30):  # pylint: disable=unused-argument
+    def run(self, cmd: str, *, timeout: int = 30):
         return self._run(cmd, timeout=timeout)
 
-    def _run(self, cmd: str, *, timeout: int = 30, codec: str = "utf-8", decodeerrors: str = "strict"):  # pylint: disable=unused-argument,line-too-long
+    def _run(self, cmd: str, *, timeout: int = 30):
         """
         Runs the specified command on the shell and returns the output.
 
@@ -73,7 +74,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         Returns:
             Tuple[List[str],List[str], int]: if successful, None otherwise
         """
-        # FIXME: use codec, decodeerrors
+        # FIXME: use self.codec, self.decodeerrors
         marker = gen_marker()
         # hide marker from expect
         hidden_marker = '"{}""{}"'.format(marker[:4], marker[4:])

--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -16,45 +16,46 @@ class CommandMixin:
         self.decodeerrors = 'strict'
 
     @Driver.check_active
-    @step(args=['cmd', 'pattern'])
-    def wait_for(self, cmd, pattern, timeout=30.0, sleepduration=1):
+    @step(args=['command', 'pattern'])
+    def wait_for(self, command: str, pattern: str, *, timeout: int = 30, sleepduration: int = 1):
         """
-        Wait until the pattern is detected in the output of cmd. Raises
+        Wait until the pattern is detected in the output of command. Raises
         ExecutionError when the timeout expires.
 
         Args:
-            cmd (str): command to run on the shell
+            command (str): command to run on the shell
             pattern (str): pattern as a string to look for in the output
-            timeout (float): timeout for the pattern detection
-            sleepduration (int): sleep time between the runs of the cmd
+            timeout (int): timeout for the pattern detection
+            sleepduration (int): sleep time between the runs of the commands
         """
-        timeout = Timeout(timeout)
-        while not any(pattern in s for s in self.run_check(cmd)) and not timeout.expired:
+        timeout = Timeout(float(timeout))
+        while not any(pattern in s for s in self.run_check(command)) and not timeout.expired:
             sleep(sleepduration)
         if timeout.expired:
             raise ExecutionError("Wait timeout expired")
 
     @Driver.check_active
-    @step(args=['cmd', 'expected', 'tries', 'timeout', 'sleepduration'])
-    def poll_until_success(self, cmd, *, expected=0, tries=None, timeout=30.0, sleepduration=1):
+    @step(args=['command', 'expected', 'tries', 'timeout', 'sleepduration'])
+    def poll_until_success(self, command: str, *, expected: int = 0, tries: int = None,
+                           timeout: int = 30, sleepduration: int = 1):
         """
         Poll a command until a specific exit code is detected.
-        Takes a timeout and the number of tries to run the cmd.
-        The sleepduration argument sets the duration between runs of the cmd.
+        Takes a timeout and the number of tries to run the command.
+        The sleepduration argument sets the duration between runs of the commands.
 
         Args:
-            cmd (str): command to run on the shell
+            command (str): command to run on the shell
             expected (int): exitcode to detect
             tries (int): number of tries, can be None for infinite tries
             timeout (float): timeout for the exitcode detection
-            sleepduration (int): sleep time between the runs of the cmd
+            sleepduration (int): sleep time between the runs of the commands
 
         Returns:
             bool: whether the command finally executed sucessfully
         """
-        timeout = Timeout(timeout)
+        timeout = Timeout(float(timeout))
         while not timeout.expired:
-            _, _, exitcode = self.run(cmd, timeout=timeout.remaining)
+            _, _, exitcode = self.run(command, timeout=timeout.remaining)
             if exitcode == expected:
                 return True
             sleep(sleepduration)

--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -65,34 +65,34 @@ class CommandMixin:
                     break
         return False
 
-    def _run_check(self, cmd: str, *, timeout=30):
+    def _run_check(self, command: str, *, timeout: int = 30):
         """
         Internal function which runs the specified command on the shell and
         returns the output if successful, raises ExecutionError otherwise.
 
         Args:
-            cmd (str): command to run on the shell
+            command (str): command to run on the shell
 
         Returns:
             List[str]: stdout of the executed command
         """
-        stdout, stderr, exitcode = self._run(cmd, timeout=timeout)
+        stdout, stderr, exitcode = self._run(command, timeout=timeout)
         if exitcode != 0:
-            raise ExecutionError(cmd, stdout, stderr)
+            raise ExecutionError(command, stdout, stderr)
         return stdout
 
     @Driver.check_active
-    @step(args=['cmd'], result=True)
-    def run_check(self, cmd: str, *, timeout=30):
+    @step(args=['command'], result=True)
+    def run_check(self, command: str, *, timeout: int = 30):
         """
         External run_check function, only available if the driver is active.
         Runs the supplied command and returns the stdout, raises an
         ExecutionError otherwise.
 
         Args:
-            cmd (str): command to run on the shell
+            command (str): command to run on the shell
 
         Returns:
             List[str]: stdout of the executed command
         """
-        return self._run_check(cmd, timeout=timeout)
+        return self._run_check(command, timeout=timeout)

--- a/labgrid/driver/commandmixin.py
+++ b/labgrid/driver/commandmixin.py
@@ -13,6 +13,7 @@ class CommandMixin:
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        self.decodeerrors = 'strict'
 
     @Driver.check_active
     @step(args=['cmd', 'pattern'])
@@ -63,8 +64,7 @@ class CommandMixin:
                     break
         return False
 
-    def _run_check(self, cmd: str, *, timeout=30, codec: str = "utf-8",
-                   decodeerrors: str = "strict"):
+    def _run_check(self, cmd: str, *, timeout=30):
         """
         Internal function which runs the specified command on the shell and
         returns the output if successful, raises ExecutionError otherwise.
@@ -75,15 +75,14 @@ class CommandMixin:
         Returns:
             List[str]: stdout of the executed command
         """
-        stdout, stderr, exitcode = self._run(cmd, timeout=timeout, codec=codec,
-                                             decodeerrors=decodeerrors)
+        stdout, stderr, exitcode = self._run(cmd, timeout=timeout)
         if exitcode != 0:
             raise ExecutionError(cmd, stdout, stderr)
         return stdout
 
     @Driver.check_active
     @step(args=['cmd'], result=True)
-    def run_check(self, cmd: str, *, timeout=30, codec="utf-8", decodeerrors="strict"):
+    def run_check(self, cmd: str, *, timeout=30):
         """
         External run_check function, only available if the driver is active.
         Runs the supplied command and returns the stdout, raises an
@@ -95,4 +94,4 @@ class CommandMixin:
         Returns:
             List[str]: stdout of the executed command
         """
-        return self._run_check(cmd, timeout=timeout, codec=codec, decodeerrors=decodeerrors)
+        return self._run_check(cmd, timeout=timeout)

--- a/labgrid/driver/serialdigitaloutput.py
+++ b/labgrid/driver/serialdigitaloutput.py
@@ -47,8 +47,8 @@ class SerialPortDigitalOutputDriver(Driver, DigitalOutputProtocol):
 
     @Driver.check_active
     @step()
-    def set(self, value):
+    def set(self, status):
         if self.signal == "dtr":
-            self._p.dtr = value
+            self._p.dtr = status
         elif self.signal == "rts":
-            self._p.rts = value
+            self._p.rts = status

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -73,19 +73,19 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def on_deactivate(self):
         self._status = 0
 
-    def _run(self, cmd, *, timeout=30.0):
+    def _run(self, command: str, *, timeout: int = 30):
         """
-        Runs the specified cmd on the shell and returns the output.
+        Runs the specified command on the shell and returns the output.
 
         Arguments:
-        cmd - cmd to run on the shell
+        command - command to run on the shell
         """
         # FIXME: Handle pexpect Timeout
         self._check_prompt()
         marker = gen_marker()
         # hide marker from expect
         cmp_command = '''MARKER='{}''{}' run {}'''.format(
-            marker[:4], marker[4:], shlex.quote(cmd)
+            marker[:4], marker[4:], shlex.quote(command)
         )
         self.console.sendline(cmp_command)
         _, _, match, _ = self.console.expect(r'{marker}(.*){marker}\s+(\d+)\s+{prompt}'.format(
@@ -102,9 +102,9 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return (data, [], exitcode)
 
     @Driver.check_active
-    @step(args=['cmd'], result=True)
-    def run(self, cmd, timeout=30.0):
-        return self._run(cmd, timeout=timeout)
+    @step(args=['command'], result=True)
+    def run(self, command: str, *, timeout: int = 30):
+        return self._run(command, timeout=timeout)
 
     @step()
     def _await_login(self):

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -384,7 +384,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         Args:
             buf (bytes): file contents
-            remotefile (str): destination filename on the target
+            remote_file (str): destination filename on the target
 
         Raises:
             ExecutionError: if something went wrong
@@ -395,22 +395,22 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def _put(self, localfile: str, remotefile: str):
         with open(localfile, 'rb') as fh:
             buf = fh.read(None)
-            self._put_bytes(buf, remotefile)
+            self._put_bytes(buf, remote_file)
 
     @Driver.check_active
-    def put(self, localfile: str, remotefile: str):
+    def put(self, local_file: str, remote_file: str):
         """ Upload a file to the target.
         Will silently overwrite the remote file if it already exists.
 
         Args:
-            localfile (str): source filename on the local machine
-            remotefile (str): destination filename on the target
+            local_file (str): source filename on the local machine
+            remote_file (str): destination filename on the target
 
         Raises:
-            IOError: if the provided localfile could not be found
+            IOError: if the provided local_file could not be found
             ExecutionError: if something else went wrong
         """
-        self._put(localfile, remotefile)
+        self._put(local_file, remote_file)
 
     @step(title='get_bytes', args=['remotefile'])
     def _get_bytes(self, remotefile: str):
@@ -470,19 +470,19 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             fh.write(buf)
 
     @Driver.check_active
-    def get(self, remotefile: str, localfile: str):
+    def get(self, remote_file: str, local_file: str):
         """ Download a file from the target.
         Will silently overwrite the local file if it already exists.
 
         Args:
-            remotefile (str): source filename on the target
-            localfile (str): destination filename on the local machine (can be relative)
+            remote_file (str): source filename on the target
+            local_file (str): destination filename on the local machine (can be relative)
 
         Raises:
-            IOError: if localfile could not be written
+            IOError: if local_file could not be written
             ExecutionError: if something went wrong
         """
-        self._get(remotefile, localfile)
+        self._get(remote_file, local_file)
 
     @step(title='run_script', args=['data', 'timeout'])
     def _run_script(self, data: bytes, timeout: int = 60):

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -59,13 +59,13 @@ class SmallUBootDriver(UBootDriver):
         # wait until UBoot has reached it's prompt
         self.console.expect(self.prompt)
 
-    def _run(self, cmd: str, *, timeout: int = 30):
+    def _run(self, command: str, *, timeout: int = 30):
         """
-        If Uboot is in Command-Line mode: Run command cmd and return it's
+        If Uboot is in Command-Line mode: Run command and return its
         output.
 
         Arguments:
-        cmd - Command to run
+        command - Command to run
         """
         # TODO: use self.codec, self.decodeerrors
 
@@ -80,7 +80,7 @@ class SmallUBootDriver(UBootDriver):
         # handle it's error message as an echo-output.
         # additionally we are not able to get the command's return code and
         # will always return 0.
-        cmp_command = "echo{marker}; {cmd}; echo{marker}".format(marker=marker, cmd=cmd)
+        cmp_command = "echo{marker}; {cmd}; echo{marker}".format(marker=marker, cmd=command)
 
         self.console.sendline(cmp_command)
         _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -59,7 +59,7 @@ class SmallUBootDriver(UBootDriver):
         # wait until UBoot has reached it's prompt
         self.console.expect(self.prompt)
 
-    def _run(self, cmd: str, *, timeout: int = 30, codec: str = "utf-8", decodeerrors: str = "strict"):  # pylint: disable=unused-argument,line-too-long
+    def _run(self, cmd: str, *, timeout: int = 30):
         """
         If Uboot is in Command-Line mode: Run command cmd and return it's
         output.
@@ -67,7 +67,7 @@ class SmallUBootDriver(UBootDriver):
         Arguments:
         cmd - Command to run
         """
-        # TODO: use codec, decodeerrors
+        # TODO: use self.codec, self.decodeerrors
 
         # Check if Uboot is in command line mode
         if self._status != 1:

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -114,16 +114,16 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return self._start_own_master()
 
     @Driver.check_active
-    @step(args=['cmd'], result=True)
-    def run(self, cmd, timeout=None): # pylint: disable=unused-argument
-        return self._run(cmd)
+    @step(args=['command'], result=True)
+    def run(self, command: str, *, timeout: int = None):
+        return self._run(command, timeout=timeout)
 
-    def _run(self, cmd, timeout=None): # pylint: disable=unused-argument
-        """Execute `cmd` on the target.
+    def _run(self, command: str, *, timeout: int = None):
+        """Execute `command` on the target.
 
-        This method runs the specified `cmd` as a command on its target.
+        This method runs the specified `command` on its target.
         It uses the ssh shell command to run the command and parses the exitcode.
-        cmd - command to be run on the target
+        command - command to be run on the target
 
         returns:
         (stdout, stderr, returncode)
@@ -134,7 +134,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         complete_cmd = ["ssh", "-x", *self.ssh_prefix,
                         "-p", str(self.networkservice.port), "{}@{}".format(
                             self.networkservice.username, self.networkservice.address
-                        )] + cmd.split(" ")
+                        )] + command.split(" ")
         self.logger.debug("Sending command: %s", complete_cmd)
         if self.stderr_merge:
             stderr_pipe = subprocess.STDOUT

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -164,17 +164,17 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         return 1
 
     @Driver.check_active
-    @step(args=['filename', 'remotepath'])
-    def put(self, filename, remotepath=''):
+    @step(args=['local_file', 'remote_file'])
+    def put(self, local_file: str, remote_file: str = ''):
         transfer_cmd = [
             "scp",
             *self.ssh_prefix,
             "-P", str(self.networkservice.port),
-            filename,
+            local_file,
             "{user}@{host}:{remotepath}".format(
                 user=self.networkservice.username,
                 host=self.networkservice.address,
-                remotepath=remotepath)
+                remotepath=remote_file)
             ]
 
         try:
@@ -191,8 +191,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             )
 
     @Driver.check_active
-    @step(args=['filename', 'destination'])
-    def get(self, filename, destination="."):
+    @step(args=['remote_file', 'local_file'])
+    def get(self, remote_file: str, local_file: str = "."):
         transfer_cmd = [
             "scp",
             *self.ssh_prefix,
@@ -200,8 +200,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             "{user}@{host}:{filename}".format(
                 user=self.networkservice.username,
                 host=self.networkservice.address,
-                filename=filename),
-            destination
+                filename=remote_file),
+            local_file
             ]
 
         try:

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -24,6 +24,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     priorities = {CommandProtocol: 10, FileTransferProtocol: 10}
     keyfile = attr.ib(default="", validator=attr.validators.instance_of(str))
     stderr_merge = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    codec = attr.ib(default="utf-8", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -114,10 +115,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     @Driver.check_active
     @step(args=['cmd'], result=True)
-    def run(self, cmd, codec="utf-8", decodeerrors="strict", timeout=None): # pylint: disable=unused-argument
-        return self._run(cmd, codec=codec, decodeerrors=decodeerrors)
+    def run(self, cmd, timeout=None): # pylint: disable=unused-argument
+        return self._run(cmd)
 
-    def _run(self, cmd, codec="utf-8", decodeerrors="strict", timeout=None): # pylint: disable=unused-argument
+    def _run(self, cmd, timeout=None): # pylint: disable=unused-argument
         """Execute `cmd` on the target.
 
         This method runs the specified `cmd` as a command on its target.
@@ -149,12 +150,12 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             )
 
         stdout, stderr = sub.communicate(timeout=timeout)
-        stdout = stdout.decode(codec, decodeerrors).split('\n')
+        stdout = stdout.decode(self.codec, self.decodeerrors).split('\n')
         stdout.pop()
         if stderr is None:
             stderr = []
         else:
-            stderr = stderr.decode(codec, decodeerrors).split('\n')
+            stderr = stderr.decode(self.codec, self.decodeerrors).split('\n')
             stderr.pop()
         return (stdout, stderr, sub.returncode)
 

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -66,14 +66,14 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """
         self._status = 0
 
-    def _run(self, cmd: str, *, timeout: int = 30):
+    def _run(self, command: str, *, timeout: int = 30):
         # TODO: use self.codec, self.decodeerrors
         # TODO: Shell Escaping for the U-Boot Shell
         marker = gen_marker()
         cmp_command = """echo '{}''{}'; {}; echo "$?"; echo '{}''{}';""".format(
             marker[:4],
             marker[4:],
-            cmd,
+            command,
             marker[:4],
             marker[4:],
         )
@@ -85,7 +85,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
                 '', before.decode('utf-8'), count=1000000
             ).replace("\r", "").split("\n")
             self.logger.debug("Received Data: %s", data)
-            # Remove first element, the invoked cmd
+            # Remove first element, the invoked command
             data = data[data.index(marker) + 1:]
             data = data[:data.index(marker)]
             exitcode = int(data[-1])
@@ -95,19 +95,19 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         return None
 
     @Driver.check_active
-    @step(args=['cmd'], result=True)
-    def run(self, cmd, timeout=30):
+    @step(args=['command'], result=True)
+    def run(self, command: str, *, timeout: int = 30):
         """
         Runs the specified command on the shell and returns the output.
 
         Args:
-            cmd (str): command to run on the shell
+            command (str): command to run on the shell
             timeout (int): optional, how long to wait for completion
 
         Returns:
             Tuple[List[str],List[str], int]: if successful, None otherwise
         """
-        return self._run(cmd, timeout=timeout)
+        return self._run(command, timeout=timeout)
 
     def get_status(self):
         """Retrieve status of the UBootDriver.

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -41,6 +41,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     boot_expression = attr.ib(default=r"U-Boot 20\d+", validator=attr.validators.instance_of(str))
     bootstring = attr.ib(default=r"Linux version \d", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
+    codec = attr.ib(default="utf-8", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -65,8 +66,8 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """
         self._status = 0
 
-    def _run(self, cmd: str, *, timeout: int = 30, codec: str = "utf-8", decodeerrors: str = "strict"):  # pylint: disable=unused-argument,line-too-long
-        # TODO: use codec, decodeerrors
+    def _run(self, cmd: str, *, timeout: int = 30):
+        # TODO: use self.codec, self.decodeerrors
         # TODO: Shell Escaping for the U-Boot Shell
         marker = gen_marker()
         cmp_command = """echo '{}''{}'; {}; echo "$?"; echo '{}''{}';""".format(

--- a/labgrid/protocol/commandprotocol.py
+++ b/labgrid/protocol/commandprotocol.py
@@ -26,15 +26,16 @@ class CommandProtocol(abc.ABC):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def wait_for(self):
+    def wait_for(self, command: str, pattern: str, *, timeout: int = 30, sleepduration: int = 1):
         """
         Wait for a shell command to return with the specified output
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def poll_until_success(self):
+    def poll_until_success(self, command: str, *, expected: int = 0, tries: int = None,
+                           timeout: int = 30, sleepduration: int = 1):
         """
-        Repeatedly call a shell command until it succeeds
+        Poll a command until a specific exit code is detected.
         """
         raise NotImplementedError

--- a/labgrid/protocol/commandprotocol.py
+++ b/labgrid/protocol/commandprotocol.py
@@ -5,14 +5,14 @@ class CommandProtocol(abc.ABC):
     """Abstract class for the CommandProtocol"""
 
     @abc.abstractmethod
-    def run(self, command: str):
+    def run(self, command: str, *, timeout: int):
         """
         Run a command
         """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def run_check(self, command: str):
+    def run_check(self, command: str, *, timeout: int):
         """
         Run a command, return str if succesful, ExecutionError otherwise
         """

--- a/labgrid/protocol/filetransferprotocol.py
+++ b/labgrid/protocol/filetransferprotocol.py
@@ -3,9 +3,9 @@ import abc
 
 class FileTransferProtocol(abc.ABC):
     @abc.abstractmethod
-    def put(self, filename: str, remotepath: str):
+    def put(self, local_file: str, remote_file: str):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get(self, filename: str, destination: str):
+    def get(self, remote_file: str, local_file: str):
         raise NotImplementedError

--- a/tests/test_ubootdriver.py
+++ b/tests/test_ubootdriver.py
@@ -24,7 +24,7 @@ class TestUBootDriver:
         d._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = d.run_check("test")
         assert res == ['success']
-        d._run.assert_called_once_with("test", timeout=30, codec='utf-8', decodeerrors='strict')
+        d._run.assert_called_once_with("test", timeout=30)
         d._run.reset_mock()
         res = d.run("test")
         assert res == (['success'], [], 0)
@@ -38,7 +38,7 @@ class TestUBootDriver:
         d._run = mocker.MagicMock(return_value=(['error'], [], 1))
         with pytest.raises(ExecutionError):
             res = d.run_check("test")
-        d._run.assert_called_once_with("test", timeout=30, codec='utf-8', decodeerrors='strict')
+        d._run.assert_called_once_with("test", timeout=30)
         d._run.reset_mock()
         res = d.run("test")
         assert res == (['error'], [], 1)


### PR DESCRIPTION
**Description**
Make method args of `CommandProtocol`, `FileTransferProtocol` consistent/reflect driver reality. Now let drivers implementing protocols follow them strictly.

This PR includes converting `run()`'s/`run_check()`'s `codec`/`decodeerrors` kwargs to driver attributes.

**Checklist**
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] PR has been tested (parts of it)