### PR TITLE
driver: add invert to SerialDigitalOutputDriver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1334,6 +1334,7 @@ Arguments:
     bind against. This is only needed if you have multiple
     SerialDriver in your environment (what is likely to be the case
     if you are using this driver).
+  - invert (bool): whether to invert the signal
 
 FileDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/serialdigitaloutput.py
+++ b/labgrid/driver/serialdigitaloutput.py
@@ -24,6 +24,7 @@ class SerialPortDigitalOutputDriver(Driver, DigitalOutputProtocol):
 
     bindings = {'serial': SerialDriver}
     signal = attr.ib(validator=attr.validators.instance_of(str))
+    invert = attr.ib(validator=attr.validators.instance_of(bool))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -39,15 +40,22 @@ class SerialPortDigitalOutputDriver(Driver, DigitalOutputProtocol):
     @step()
     def get(self):
         if self.signal == "dtr":
-            return self._p.dtr
+            val =  self._p.dtr
         if self.signal == "rts":
-            return self._p.rts
+            val = self._p.rts
+        else:
+            raise ValueError("Expected signal to be dtr or rts")
 
-        raise ValueError("Expected signal to be dtr or rts")
+        if self.invert:
+            val = not val
+
+        return val
 
     @Driver.check_active
     @step()
     def set(self, value):
+        if self.invert:
+            value = not value
         if self.signal == "dtr":
             self._p.dtr = value
         elif self.signal == "rts":


### PR DESCRIPTION
**Description**
This allows the inversion of serial lines lines which are used as
digital outputs. This is done on the driver level to not clutter the
SerialPort resource, which is usually used for communication and not as
a digital output.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested
