### PR TITLE
binding: improve StateError message

### DIFF
--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -94,8 +94,8 @@ class BindingMixin:
         def wrapper(self, *_args, **_kwargs):
             if self.state is not BindingState.active:
                 raise StateError(
-                    "{} can not be called ({} is in state {})".format(
-                        func.__qualname__, self, self.state.name)
+                    '{} has not been activated, {} cannot be called in state "{}"'.format(
+                        self, func.__qualname__, self.state.name)
                 )
             return func(self, *_args, **_kwargs)
 


### PR DESCRIPTION
**Description**
Currently the error message does not tell a user (without detailed knowledge of driver binding states) why the method called cannot be called at this time:

```
Driver.method can not be called (Driver(target=Target(name='name', env=Environment(config_file='conf.yaml')), name=None, state=<BindingState.bound: 1>) is in state bound)
```
The exception is raised only if the state is not active, so make the error message say this:
```
Driver(target=Target(name='name', env=Environment(config_file='x86-esr.yaml')), name=None, state=<BindingState.bound: 1>) has not been activated, Driver.method cannot be called in state "bound"
```


**Checklist**
- [x] PR has been tested
