### PR TITLE
man/remote: client: document 'labgrid-client -x' default

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1238,7 +1238,7 @@ def main():
         metavar='URL',
         type=str,
         default=os.environ.get("LG_CROSSBAR", "ws://127.0.0.1:20408/ws"),
-        help="crossbar websocket URL"
+        help="crossbar websocket URL (default: %(default)s)"
     )
     parser.add_argument(
         '-c',

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -52,7 +52,7 @@ display command line help
 specify the place to operate on
 .TP
 .B \-x\fP,\fB  \-\-crossbar\-url
-the crossbar url of the coordinator
+the crossbar url of the coordinator, defaults to \fBws://127.0.0.1:20408/ws\fP
 .TP
 .BI \-c \ CONFIG\fP,\fB \ \-\-config \ CONFIG
 set the configuration file

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -39,7 +39,7 @@ OPTIONS
 -p PLACE, --place PLACE
     specify the place to operate on
 -x, --crossbar-url
-    the crossbar url of the coordinator
+    the crossbar url of the coordinator, defaults to ``ws://127.0.0.1:20408/ws``
 -c CONFIG, --config CONFIG
     set the configuration file
 -s STATE, --state STATE


### PR DESCRIPTION
**Description**
This also helps setting the correct URL form for a coordinator URL.

**Checklist**
- [x] Man pages have been regenerated
