### PR TITLE
driver/power/gude24.py: Raise execution error if device is blocked

### DIFF
--- a/labgrid/driver/power/gude24.py
+++ b/labgrid/driver/power/gude24.py
@@ -8,6 +8,8 @@ Driver has been tested with:
 * Gude Expert Power Control 8080
 """
 
+import re
+
 import requests
 
 from ..exception import ExecutionError
@@ -67,6 +69,10 @@ def get_state(request, index):
                 return True
 
             raise ExecutionError("failed to parse the port status")
+
+    m = re.search("Device is blocked by another user with IP ([^\s<]+)", request.text)
+    if m:
+        raise ExecutionError("device is blocked by another user with IP {}".format(m.group(1)))
 
     # if we got this far, something is wrong with the website
     raise ExecutionError("failed to determine status of power port {}".format(index))

--- a/labgrid/driver/power/gude24.py
+++ b/labgrid/driver/power/gude24.py
@@ -1,43 +1,65 @@
+"""
+This driver implements a power port for Gude Power Switches with up to
+24 ports.
+These switches differ in their API to the previous 8-port switches for set-
+and get-commands.
+
+Driver has been tested with:
+* Gude Expert Power Control 8080
+"""
+
 import requests
 
 from ..exception import ExecutionError
 
 
-# This driver implements a power port for Gude Power Switches with up to
-# 24 ports.
-# These switches differ in their API to the previous 8-port switches for set-
-# and get-commands.
-#
-# Driver has been tested with:
-# * Gude Expert Power Control 8080
-
 PORT = 80
 
 def power_set(host, port, index, value):
-    # The gude web-interface uses different pages for the three groups of
-    # switches. The web-interface always uses the 'correct' page to set a
-    # value. But commands for all pages are accepted on all pages.
+    """
+    The gude web-interface uses different pages for the three groups of
+    switches. The web-interface always uses the 'correct' page to set a
+    value. But commands for all pages are accepted on all pages.
+    """
     index = int(index)
     assert 1 <= index <= 24
     # access the web interface...
     value = 1 if value else 0
-    r = requests.get(
+    response = requests.get(
         "http://{}:{}/ov.html?cmd=1&p={}&s={}".format(host, port, index, value)
     )
-    r.raise_for_status()
+
+    # Check, that the port is in the desired state
+    state = get_state(response, index)
+    if state != value:
+        raise ExecutionError("failed to set port {} to status {}".format(index, value))
 
 
 def power_get(host, port, index):
-    # The status of the ports is made available via a html <meta>-tag using the
-    # following format:
-    # <meta http-equiv="powerstate" content="Power Port 1,0">
-    # Again the status of all ports is made available on all pages.
+    """
+    Get the status of a port.
+    """
     index = int(index)
     assert 1 <= index <= 24
     # get the contents of the main page
-    r = requests.get("http://{}:{}/ov.html".format(host, port))
-    r.raise_for_status()
-    for line in r.text.splitlines():
+    response = requests.get("http://{}:{}/ov.html".format(host, port))
+    state = get_state(response, index)
+    return state
+
+
+def get_state(request, index):
+    """
+    The status of the ports is made available via a html <meta>-tag using the
+    following format:
+    <meta http-equiv="powerstate" content="Power Port 1,0">
+    Again the status of all ports is made available on all pages.
+    """
+    request.raise_for_status()
+
+    # Get the power state of a specified index
+    # raise an exception if the state cannot be determined.
+
+    for line in request.text.splitlines():
         if line.find("content=\"Power Port {}".format(index)) > 0:
             if line.find(",0") > 0:
                 return False
@@ -45,5 +67,6 @@ def power_get(host, port, index):
                 return True
 
             raise ExecutionError("failed to parse the port status")
+
     # if we got this far, something is wrong with the website
-    raise ExecutionError("failed to find the port")
+    raise ExecutionError("failed to determine status of power port {}".format(index))


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
When the Gude Expert Power Control 8080 receives a request it blocks requests from other IP addresses for 120 seconds. Therefor when user A creates a request to the web interface user B with a different IP can not make a request for two minutes. The return message user B will get is:
```html
<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
<html><head>
<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
<meta http-equiv="cache-control" content="no-cache">
<link rel="stylesheet" type="text/css" href="style.css">
<title>Device blocked</title>
</head><body><h2 align="center"><font color="red">Device is blocked by another user with IP xyz</font></h2>
<hr size=1 noshade><p align="center">[<a href="/">back</A>]
</body></html> 
```
The previous implementation of power_set would return ok, even if the device is blocked and the command has not been executed. This change raises an execution error to show that the device is locked and the command has not been executed.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
