### PR TITLE
driver/sshdriver: Allow whitespaces in filenames

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -164,14 +164,17 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     @Driver.check_active
     @step(args=['filename', 'remotepath'])
     def put(self, filename, remotepath=''):
-        transfer_cmd = "scp {prefix} -P {port} {filename} {user}@{host}:{remotepath}".format(
-            filename=filename,
-            user=self.networkservice.username,
-            host=self.networkservice.address,
-            remotepath=remotepath,
-            prefix=self.ssh_prefix,
-            port=self.networkservice.port
-        ).split(' ')
+        transfer_cmd = [
+            "scp",
+            self.ssh_prefix,
+            "-P", str(self.networkservice.port),
+            filename,
+            "{user}@{host}:{remotepath}".format(
+                user=self.networkservice.username,
+                host=self.networkservice.address,
+                remotepath=remotepath)
+            ]
+
         try:
             sub = subprocess.call(
                 transfer_cmd
@@ -188,14 +191,17 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     @Driver.check_active
     @step(args=['filename', 'destination'])
     def get(self, filename, destination="."):
-        transfer_cmd = "scp {prefix} -P {port} {user}@{host}:{filename} {destination}".format(
-            filename=filename,
-            user=self.networkservice.username,
-            host=self.networkservice.address,
-            prefix=self.ssh_prefix,
-            port=self.networkservice.port,
-            destination=destination
-        ).split(' ')
+        transfer_cmd = [
+            "scp",
+            self.ssh_prefix,
+            "-P", str(self.networkservice.port),
+            "{user}@{host}:{filename}".format(
+                user=self.networkservice.username,
+                host=self.networkservice.address,
+                filename=filename),
+            destination
+            ]
+
         try:
             sub = subprocess.call(
                 transfer_cmd


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
This fixes a bug in the sshdriver. If the filename contains whitespaces they get split and passed as arguments to the subprocess command. The new implementation fixes this by creating the list needed for the subprocess.call function directly and removing the split()
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
