### PR TITLE
sshdriver: ssh_prefix to list and adjust users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - sudo mkdir /var/cache/labgrid && sudo chmod 1775 /var/cache/labgrid && sudo chown root:travis /var/cache/labgrid
 script:
   - pip install -e .
-  - pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager
+  - pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username travis
   - python setup.py build_sphinx
   - make -C man all
   - git --no-pager diff --exit-code

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -146,6 +146,8 @@ def pytest_addoption(parser):
                      help="Run sigrok usb tests with fx2lafw device (0925:3881)")
     parser.addoption("--local-sshmanager", action="store_true",
                      help="Run SSHManager tests against localhost")
+    parser.addoption("--ssh-username", default=None,
+                     help="SSH username to use for SSHDriver testing")
 
 def pytest_configure(config):
     # register an additional marker
@@ -153,6 +155,8 @@ def pytest_configure(config):
                             "sigrokusb: enable fx2lafw USB tests (0925:3881)")
     config.addinivalue_line("markers",
                             "localsshmanager: test SSHManager against Localhost")
+    config.addinivalue_line("markers",
+                            "sshusername: test SSHDriver against Localhost")
 
 def pytest_runtest_setup(item):
     envmarker = item.get_closest_marker("sigrokusb")
@@ -163,3 +167,7 @@ def pytest_runtest_setup(item):
     if envmarker is not None:
         if item.config.getoption("--local-sshmanager") is False:
             pytest.skip("SSHManager tests against localhost not enabled (enable with --local-sshmanager)")
+    envmarker = item.get_closest_marker("sshusername")
+    if envmarker is not None:
+        if item.config.getoption("--ssh-username") is None:
+            pytest.skip("SSHDriver tests against localhost not enabled (enable with --ssh-username <username>)")

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -6,49 +6,88 @@ from labgrid.resource import NetworkService
 
 @pytest.fixture(scope='function')
 def ssh_driver_mocked_and_activated(target, mocker):
-        NetworkService(target, "service", "1.2.3.4", "root")
-        call = mocker.patch('subprocess.call')
-        call.return_value = 0
-        popen = mocker.patch('subprocess.Popen', autospec=True)
-        path = mocker.patch('os.path.exists')
-        path.return_value = True
-        instance_mock = mocker.MagicMock()
-        popen.return_value = instance_mock
-        instance_mock.wait = mocker.MagicMock(return_value=0)
+    NetworkService(target, "service", "1.2.3.4", "root")
+    call = mocker.patch('subprocess.call')
+    call.return_value = 0
+    popen = mocker.patch('subprocess.Popen', autospec=True)
+    path = mocker.patch('os.path.exists')
+    path.return_value = True
+    instance_mock = mocker.MagicMock()
+    popen.return_value = instance_mock
+    instance_mock.wait = mocker.MagicMock(return_value=0)
+    SSHDriver(target, "ssh")
+    s = target.get_driver("SSHDriver")
+    return s
+
+def test_create_fail_missing_resource(target):
+    with pytest.raises(NoResourceFoundError):
         SSHDriver(target, "ssh")
-        s = target.get_driver("SSHDriver")
-        return s
 
-class TestSSHDriver:
-    def test_create_fail_missing_resource(self, target):
-        with pytest.raises(NoResourceFoundError):
-            SSHDriver(target, "ssh")
+def test_create(target, mocker):
+    NetworkService(target, "service", "1.2.3.4", "root")
+    call = mocker.patch('subprocess.call')
+    call.return_value = 0
+    popen = mocker.patch('subprocess.Popen', autospec=True)
+    path = mocker.patch('os.path.exists')
+    path.return_value = True
+    instance_mock = mocker.MagicMock()
+    popen.return_value = instance_mock
+    instance_mock.wait = mocker.MagicMock(return_value=0)
+    s = SSHDriver(target, "ssh")
+    assert isinstance(s, SSHDriver)
 
-    def test_create(self, target, mocker):
-        NetworkService(target, "service", "1.2.3.4", "root")
-        call = mocker.patch('subprocess.call')
-        call.return_value = 0
-        popen = mocker.patch('subprocess.Popen', autospec=True)
-        path = mocker.patch('os.path.exists')
-        path.return_value = True
-        instance_mock = mocker.MagicMock()
-        popen.return_value = instance_mock
-        instance_mock.wait = mocker.MagicMock(return_value=0)
-        s = SSHDriver(target, "ssh")
-        assert (isinstance(s, SSHDriver))
+def test_run_check(ssh_driver_mocked_and_activated, mocker):
+    s = ssh_driver_mocked_and_activated
+    s._run = mocker.MagicMock(return_value=(['success'], [], 0))
+    res = s.run_check("test")
+    assert res == ['success']
+    res = s.run("test")
+    assert res == (['success'], [], 0)
 
-    def test_run_check(self, ssh_driver_mocked_and_activated, mocker):
-        s = ssh_driver_mocked_and_activated
-        s._run = mocker.MagicMock(return_value=(['success'], [], 0))
+def test_run_check_raise(ssh_driver_mocked_and_activated, mocker):
+    s = ssh_driver_mocked_and_activated
+    s._run = mocker.MagicMock(return_value=(['error'], [], 1))
+    with pytest.raises(ExecutionError):
         res = s.run_check("test")
-        assert res == ['success']
-        res = s.run("test")
-        assert res == (['success'], [], 0)
+    res = s.run("test")
+    assert res == (['error'], [], 1)
 
-    def test_run_check_raise(self, ssh_driver_mocked_and_activated, mocker):
-        s = ssh_driver_mocked_and_activated
-        s._run = mocker.MagicMock(return_value=(['error'], [], 1))
-        with pytest.raises(ExecutionError):
-            res = s.run_check("test")
-        res = s.run("test")
-        assert res == (['error'], [], 1)
+@pytest.fixture(scope='function')
+def ssh_localhost(target, pytestconfig):
+    name = pytestconfig.getoption("--ssh-username")
+    NetworkService(target, "service", "localhost", name)
+    SSHDriver(target, "ssh")
+    s = target.get_driver("SSHDriver")
+    return s
+
+@pytest.mark.sshusername
+def test_local_put(ssh_localhost, tmpdir):
+    p = tmpdir.join("config.yaml")
+    p.write(
+        """PUT Teststring"""
+    )
+
+    ssh_localhost.put(str(p), "/tmp/test_put_yaml")
+    assert open('/tmp/test_put_yaml', 'r').readlines() == [ "PUT Teststring" ]
+
+@pytest.mark.sshusername
+def test_local_get(ssh_localhost, tmpdir):
+    p = tmpdir.join("config.yaml")
+    p.write(
+        """GET Teststring"""
+    )
+
+    ssh_localhost.get(str(p), "/tmp/test_get_yaml")
+    assert open('/tmp/test_get_yaml', 'r').readlines() == [ "GET Teststring" ]
+
+@pytest.mark.sshusername
+def test_local_run(ssh_localhost, tmpdir):
+
+    res = ssh_localhost.run("echo Hello")
+    assert res == (["Hello"], [], 0)
+
+@pytest.mark.sshusername
+def test_local_run_check(ssh_localhost, tmpdir):
+
+    res = ssh_localhost.run_check("echo Hello")
+    assert res == (["Hello"])


### PR DESCRIPTION
**Description**
Convert ssh_prefix to a list and adjust all users. This was a string
previously, which led to get() and put() being broken on master, since
the string contained spaces. Convert it to a list, adjust the callers
and add new tests to test the SSHDriver against localhost. We also add a
new pytest option to supply the username, to make this work on travis.

Fixes: 1d7b97b838f7 (driver/sshdriver: Allow whitespaces in filenames Prevent filenames with whitespaces from beeing split.)

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested

Thanks @krevsbech for the report on IRC.