### PR TITLE
doc/getting_started: instructions are also valid for buster

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -10,7 +10,7 @@ Installation
 ------------
 
 Depending on your distribution you need some dependencies. On Debian stretch
-these usually are:
+and buster these usually are:
 
 .. code-block:: bash
 


### PR DESCRIPTION
The instructions outlined here are not only valid for stretch, but also for buster.