### PR TITLE
USBSerialPorts: Add baudrate

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -202,6 +202,7 @@ class SerialPortExport(ResourceExport):
         return {
             'host': self.host,
             'port': self.port,
+            'speed': self.local.speed,
             'extra': {
                 'path': self.local.port,
             }
@@ -218,8 +219,8 @@ class SerialPortExport(ResourceExport):
             '-d',
             '-n',
             '-C',
-            '{}:telnet:0:{}:115200 8DATABITS NONE 1STOPBIT LOCAL'.format(
-                self.port, start_params['path']
+            '{}:telnet:0:{}:{} 8DATABITS NONE 1STOPBIT LOCAL'.format(
+                self.port, start_params['path'], self.local.speed
             ),
         ])
         try:


### PR DESCRIPTION
Up to now we only support 115200 baud for the serial console.
Add a new option to allow a different baud rate to be used.

Signed-off-by: Matthias Brugger <matthias.bgg@gmail.com>

Documentation for the feature already exists but it wasn't actually implemented.
I tested this with a MediaTek board that has a baudrate of 921600 on it's serial console.

**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
