### PR TITLE
labgrid/remote: remove explicit path from ser2net

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -8,7 +8,9 @@ import sys
 import os
 import time
 import traceback
+import shutil
 import subprocess
+import warnings
 from socket import gethostname, getfqdn
 import attr
 from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
@@ -187,6 +189,10 @@ class SerialPortExport(ResourceExport):
         self.data['cls'] = "NetworkSerialPort"
         self.child = None
         self.port = None
+        self.ser2net_bin = shutil.which("ser2net")
+        if self.ser2net_bin is None:
+            warnings.warn("ser2net binary not found, falling back to /usr/bin/ser2net")
+            self.ser2net_bin = "/usr/bin/ser2net"
 
     def __del__(self):
         if self.child is not None:
@@ -214,7 +220,7 @@ class SerialPortExport(ResourceExport):
         assert start_params['path'].startswith('/dev/')
         self.port = get_free_port()
         self.child = subprocess.Popen([
-            '/usr/sbin/ser2net',
+            self.ser2net_bin,
             '-d',
             '-n',
             '-C',


### PR DESCRIPTION
**Description**
Remove the explicit path from ser2net. Setting PATH correctly is for the
user to decide, and this allows overriding it externally with a locally
compiled version by modifying PATH.

Reasonably sure this breaks debian packages which run labgrid as a non-root user. We could modify the service units for this.
On the other hand this will be useful to have to test newer ser2net versions locally without updating the system.
@jluebbe what do you think?
**Checklist**
- [x] Feature has been tested.
