### PR TITLE
util/yaml: avoid customization on the default Loader/Dumper classes

### DIFF
--- a/labgrid/util/yaml.py
+++ b/labgrid/util/yaml.py
@@ -7,12 +7,16 @@ from string import Template
 
 import yaml
 
+class Loader(yaml.SafeLoader):
+    pass
+class Dumper(yaml.SafeDumper):
+    pass
 
 def _dict_constructor(loader, node):
     return OrderedDict(loader.construct_pairs(node))
 
 
-yaml.SafeLoader.add_constructor(
+Loader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor
 )
 
@@ -21,7 +25,7 @@ def _dict_representer(dumper, data):
     return dumper.represent_dict(data.items())
 
 
-yaml.SafeDumper.add_representer(OrderedDict, _dict_representer)
+Dumper.add_representer(OrderedDict, _dict_representer)
 
 
 def _str_constructor(loader, node):
@@ -34,7 +38,7 @@ def _str_constructor(loader, node):
     return obj
 
 
-yaml.SafeLoader.add_constructor(
+Loader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_SCALAR_TAG, _str_constructor
 )
 
@@ -43,14 +47,9 @@ def _template_constructor(loader, node):
     return Template(loader.construct_scalar(node))
 
 
-yaml.SafeLoader.add_constructor(
+Loader.add_constructor(
     '!template', _template_constructor
 )
-
-
-# use SafeLoader
-Loader = yaml.SafeLoader
-Dumper = yaml.SafeDumper
 
 
 def load(stream):

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,0 +1,56 @@
+from collections import OrderedDict, UserString
+
+import pytest
+import yaml
+
+from labgrid.util.yaml import *
+
+
+def test_default_loader():
+    """Importing labgrid should not modify the default loaders"""
+    doc = """
+    foo: |
+      multi
+      line
+    bar: False
+    """
+
+    data = yaml.load(doc, Loader=yaml.SafeLoader)
+    assert type(data) == dict
+    assert type(data["foo"]) == str
+
+    data = yaml.load(doc, Loader=yaml.FullLoader)
+    assert type(data) == dict
+    assert type(data["foo"]) == str
+
+    data = yaml.load(doc, Loader=yaml.Loader)
+    assert type(data) == dict
+    assert type(data["foo"]) == str
+
+
+def test_labgrid_loader():
+    doc = """
+    foo: |
+      multi
+      line
+    bar: False
+    """
+    data = load(doc)
+    assert type(data) == OrderedDict
+    assert type(data["foo"]) == UserString
+    assert data["foo"].start_mark.line == 1
+    assert data["foo"].end_mark.line == 4
+
+
+def test_default_dumper():
+    """Importing labgrid should not modify the default dumpers"""
+    data = OrderedDict([])
+    assert "!!python/object/apply:collections.OrderedDict\n- []\n" == yaml.dump(data, Dumper=yaml.Dumper)
+    with pytest.raises(yaml.representer.RepresenterError):
+        yaml.dump(data, Dumper=yaml.SafeDumper)
+
+
+def test_labgrid_dumper():
+    data = OrderedDict([])
+    doc = dump(data)
+    assert "{}\n" == doc


### PR DESCRIPTION
**Description**
This could otherwise cause problems with other users of the yaml module
in the same python process.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested