### PR TITLE
support binding outbound SSH connections to specific interfaces, add support for scp, rsync and sshfs to labgrid-client

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,6 +10,7 @@ Package: labgrid
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python3, ${misc:Pre-Depends}
 Depends: ${python3:Depends}, ${misc:Depends}, ${shlibs:Depends}
+Recommends: openssh-client, microcom, socat, sshfs, rsync
 Description: embedded board control python library
  Labgrid is a embedded board control python library with a focus on testing,
  development and general automation. It includes a remote control layer to

--- a/debian/labgrid.install
+++ b/debian/labgrid.install
@@ -2,3 +2,4 @@ debian/labgrid.yaml /etc
 debian/labgrid-client /usr/bin
 debian/labgrid-exporter /usr/bin
 debian/labgrid-pytest /usr/bin
+helpers/labgrid-bound-connect /usr/sbin

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -211,6 +211,13 @@ with the username `root`.
 Set the optional password password property to make SSH login with a password
 instead of the key file (needs sshpass to be installed)
 
+When used with ``labgrid-exporter``, the address can contain a device scope
+suffix (such as ``%eth1``), which is especially useful with overlapping address
+ranges or link-local IPv6 addresses.
+In that case, the SSH connection will be proxied via the exporter, using
+``socat`` and the ``labgrid-bound-connect`` sudo helper.
+These and the sudo configuration needs to be prepared by the administrator.
+
 - address (str): hostname of the remote system
 - username (str): username used by SSH
 - password (str): password used by SSH

--- a/helpers/labgrid-bound-connect
+++ b/helpers/labgrid-bound-connect
@@ -1,0 +1,74 @@
+#!/usr/bin/python3 
+
+# This is intended to be used via sudo. For example, add via visudo:
+# %developers ALL = NOPASSWD: /usr/local/sbin/labgrid-bound-connect
+
+import argparse
+import os
+import sys
+import ipaddress
+
+
+def main(ifname, address, port):
+    if not ifname:
+        raise ValueError("Empty interface name.")
+    if any((c == "/" or c.isspace()) for c in ifname):
+        raise ValueError("Interface name '{}' contains invalid characters.".format(ifname))
+    if len(ifname) > 16:
+        raise ValueError("Interface name '{}' is too long.".format(ifname))
+
+    address = ipaddress.ip_address(address)
+
+    if not 0 < port < 0xFFFF:
+        raise ValueError("Invalid port '{}'.".format(port))
+
+    args = [
+        "socat",
+        "STDIO",
+    ]
+
+    if address.version == 4:
+        prefix = "TCP4:{}:{}".format(address, port)
+    elif address.version == 6:
+        prefix = "TCP6:[{}]:{}".format(address, port)
+    else:
+        raise RuntimeError("Invalid IP version '{}'".format(address.version))
+
+    args.append(','.join([
+        prefix,
+        'so-bindtodevice={}'.format(ifname),
+        'connect-timeout=15',
+        'keepalive',
+        'keepcnt=3',
+        'keepidle=15',
+        'keepintvl=15',
+        'nodelay',
+    ]))
+
+    try:
+        os.execvp(args[0], args)
+    except FileNotFoundError as e:
+        raise RuntimeError("Missing socat binary") from e
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-d',
+        '--debug',
+        action='store_true',
+        default=False,
+        help="enable debug mode"
+    )
+    parser.add_argument('interface', type=str, help='interface name')
+    parser.add_argument('address', type=str, help='destination IP address')
+    parser.add_argument('port', type=int, help='destination TCP port')
+    args = parser.parse_args()
+    try:
+        main(args.interface, args.address, args.port)
+    except Exception as e:  # pylint: disable=broad-except
+        if args.debug:
+            import traceback
+            traceback.print_exc()
+        print("ERROR: {}".format(e), file=sys.stderr)
+

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -69,8 +69,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                  "-o", "ControlPersist=300", "-o",
                  "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no",
                  "-o", "ServerAliveInterval=15", "-MN", "-S", control, "-p",
-                 str(self.networkservice.port), "{}@{}".format(
-                     self.networkservice.username, self.networkservice.address)]
+                 str(self.networkservice.port), "-l", self.networkservice.username,
+                 self.networkservice.address]
 
         env = os.environ.copy()
         if self.networkservice.password:
@@ -109,9 +109,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def _check_master(self):
         args = [
-            "ssh", "-O", "check", "{}@{}".format(
-                self.networkservice.username, self.networkservice.address
-            )
+            "ssh", "-O", "check", "-l", self.networkservice.username, self.networkservice.address
         ]
         check = subprocess.call(
             args,
@@ -143,9 +141,9 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             raise ExecutionError("Keepalive no longer running")
 
         complete_cmd = ["ssh", "-x", *self.ssh_prefix,
-                        "-p", str(self.networkservice.port), "{}@{}".format(
-                            self.networkservice.username, self.networkservice.address
-                        )] + cmd.split(" ")
+                        "-p", str(self.networkservice.port), "-l", self.networkservice.username,
+                        self.networkservice.address
+                        ] + cmd.split(" ")
         self.logger.debug("Sending command: %s", complete_cmd)
         if self.stderr_merge:
             stderr_pipe = subprocess.STDOUT
@@ -230,7 +228,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def _cleanup_own_master(self):
         """Exit the controlmaster and delete the tmpdir"""
-        complete_cmd = "ssh -x -o ControlPath={cpath} -O exit -p {port} {user}@{host}".format(
+        complete_cmd = "ssh -x -o ControlPath={cpath} -O exit -p {port} -l {user} {host}".format(
             cpath=self.control,
             port=self.networkservice.port,
             user=self.networkservice.username,

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -168,6 +168,24 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             stderr.pop()
         return (stdout, stderr, sub.returncode)
 
+    def interact(self, cmd=None):
+        assert cmd is None or isinstance(cmd, list)
+
+        if not self._check_keepalive():
+            raise ExecutionError("Keepalive no longer running")
+
+        complete_cmd = ["ssh", "-x", *self.ssh_prefix,
+                        "-t",
+                        self.networkservice.address
+                        ]
+        if cmd:
+            complete_cmd += ["--", *cmd]
+        self.logger.debug("Running command: %s", complete_cmd)
+        sub = subprocess.Popen(
+            complete_cmd,
+        )
+        return sub.wait()
+
     def get_status(self):
         """The SSHDriver is always connected, return 1"""
         return 1

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -988,6 +988,16 @@ class ClientSession(ApplicationSession):
         elif res:
             print("connection lost (remote exit code {})".format(res))
 
+    def scp(self):
+        drv = self._get_ssh()
+
+        res = drv.scp(src=self.args.src, dst=self.args.dst)
+
+    def rsync(self):
+        drv = self._get_ssh()
+
+        res = drv.rsync(src=self.args.src, dst=self.args.dst, extra=self.args.leftover)
+
     def sshfs(self):
         drv = self._get_ssh()
 
@@ -1433,6 +1443,18 @@ def main():
                                       help="connect via ssh (with optional arguments)")
     subparser.set_defaults(func=ClientSession.ssh)
 
+    subparser = subparsers.add_parser('scp',
+                                      help="transfer file via scp")
+    subparser.add_argument('src', help='source path (use :dir/file for remote side)')
+    subparser.add_argument('dst', help='destination path (use :dir/file for remote side)')
+    subparser.set_defaults(func=ClientSession.scp)
+
+    subparser = subparsers.add_parser('rsync',
+                                      help="transfer files via rsync")
+    subparser.add_argument('src', help='source path (use :dir/file for remote side)')
+    subparser.add_argument('dst', help='destination path (use :dir/file for remote side)')
+    subparser.set_defaults(func=ClientSession.rsync)
+
     subparser = subparsers.add_parser('sshfs',
                                       help="mount via sshfs (blocking)")
     subparser.add_argument('path', help='remote path on the target')
@@ -1512,7 +1534,7 @@ def main():
 
     # make any leftover arguments available for some commands
     args, leftover = parser.parse_known_args()
-    if args.command not in ['ssh']:
+    if args.command not in ['ssh', 'rsync']:
         args = parser.parse_args()
     else:
         args.leftover = leftover

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -439,6 +439,31 @@ class GPIOGenericExport(ResourceExport):
 exports["SysfsGPIO"] = GPIOGenericExport
 
 
+@attr.s
+class NetworkServiceExport(ResourceExport):
+    """ResourceExport for a NetworkService
+
+    This checks if the address has a interface suffix and then provides the
+    neccessary proxy information.
+    """
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        from ..resource.networkservice import NetworkService
+        self.data['cls'] = "NetworkService"
+        self.local = NetworkService(target=None, name=None, **self.local_params)
+        if '%' in self.local_params['address']:
+            self.proxy_required = True
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            **self.local_params,
+        }
+
+exports["NetworkService"] = NetworkServiceExport
+
+
 class ExporterSession(ApplicationSession):
     def onConnect(self):
         """Set up internal datastructures on successful connection:

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -17,7 +17,7 @@ __all__ = ['sshmanager', 'SSHConnection', 'ForwardError']
 @attr.s
 class SSHConnectionManager:
     """The SSHConnectionManager manages multiple SSH connections. This class
-    should not be directly instanciated, use the exported sshmanager from this
+    should not be directly instantiated, use the exported sshmanager from this
     module instead.
     """
     _connections = attr.ib(

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -164,6 +164,12 @@ matches anything.
 .sp
 \fBssh\fP                         Connect via SSH
 .sp
+\fBscp\fP                         Transfer file via scp (use \(aq:dir/file\(aq for the remote side)
+.sp
+\fBrsync\fP                       Transfer files via rsync (use \(aq:dir/file\(aq for the remote side)
+.sp
+\fBsshfs\fP                       Mount a remote path via sshfs
+.sp
 \fBtelnet\fP                      Connect via telnet
 .sp
 \fBvideo\fP                       Start a video stream

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -156,6 +156,12 @@ LABGRID-CLIENT COMMANDS
 
 ``ssh``                         Connect via SSH
 
+``scp``                         Transfer file via scp (use ':dir/file' for the remote side)
+
+``rsync``                       Transfer files via rsync (use ':dir/file' for the remote side)
+
+``sshfs``                       Mount a remote path via sshfs
+
 ``telnet``                      Connect via telnet
 
 ``video``                       Start a video stream


### PR DESCRIPTION
**Description**
When the target is only reachable via link-local addresses or overlapping network ranges, we need to make sure to connect from a specific interface on the exporter. This is possible using the SO_BINDTODEVICE socket option (which requires root privileges, so we need a sudo helper script) and some additional SSH tunneling.

As SSH is now more widely usable, also implement the low-hanging fruits in labgrid-client and SSHDriver (scp, rsync and sshfs).

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested
- [x] Man pages have been regenerated