### PR TITLE
driver: sshdriver: avoid password authentication fallback

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -105,6 +105,9 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         self.logger.debug('Connected to %s', self.networkservice.address)
 
+        # We don't want to silently fall back to password authentication from now
+        if self.networkservice.password:
+            self.ssh_prefix += ["-o", "PasswordAuthentication=no"]
         return control
 
     def _check_master(self):


### PR DESCRIPTION
I saw issues with the control socket dropping me to interactive shell to
enter password:

INFO: Socket already closed
Control socket connect(/tmp/labgrid-ssh-tmp-ik7fhcku/control-192.168.0.10): Connection refused

To avoid this fallback don't allow password authentication after the
control socket runs.

Signed-off-by: Jan Remmet <j.remmet@phytec.de>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project

- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
