### PR TITLE
ubootdriver: allow overriding of boot command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ New Features in 0.3.0
   in some cases.
 - ``labgrid-client write-image`` gained new arguments: ``--partition``,
   ``--skip``, ``--seek``.
+- UBootDriver now allows overriding of default boot command (``run bootcmd``)
+  via new ``boot_command`` argument.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -878,6 +878,7 @@ Arguments:
   - boot_expression (str): optional, regex to match the U-Boot start string
     defaults to "U-Boot 20\d+"
   - bootstring (str): optional, regex to match on Linux Kernel boot
+  - boot_command (str): optional, boot command for booting target (default 'run bootcmd')
   - login_timeout (int): optional, timeout for login prompt detection in
     seconds (default 60)
 

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -28,6 +28,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         password_prompt (str): string to detect the password prompt
         boot_expression (str): string to search for on UBoot start
         bootstring (str): string that indicates that the Kernel is booting
+        boot_command (str): optional boot command to boot target
         login_timeout (int): optional, timeout for login prompt detection
 
     """
@@ -40,6 +41,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     password_prompt = attr.ib(default="enter Password:", validator=attr.validators.instance_of(str))
     boot_expression = attr.ib(default=r"U-Boot 20\d+", validator=attr.validators.instance_of(str))
     bootstring = attr.ib(default=r"Linux version \d", validator=attr.validators.instance_of(str))
+    boot_command = attr.ib(default="run bootcmd", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
 
     def __attrs_post_init__(self):
@@ -183,4 +185,4 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         if name:
             self.console.sendline("boot -v {}".format(name))
         else:
-            self.console.sendline("run bootcmd")
+            self.console.sendline(self.boot_command)


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->

Currently it's not possible to boot into shell on Linksys WRT3200ACM
device as the U-Boot there doesn't have standard bootcmd:

```
 Marvell>> run bootcmd
 Unknown command 'run nandboot' - try 'help'
```

So lets introduce new `boot_command` argument which defaults to current
`run bootcmd`, but can be overriden on such exotic targets.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested