### PR TITLE
strategy improvements

### DIFF
--- a/labgrid/pytestplugin/__init__.py
+++ b/labgrid/pytestplugin/__init__.py
@@ -1,2 +1,2 @@
-from .fixtures import pytest_addoption, env, target
+from .fixtures import pytest_addoption, env, target, strategy
 from .hooks import pytest_configure, pytest_collection_modifyitems

--- a/labgrid/strategy/common.py
+++ b/labgrid/strategy/common.py
@@ -42,3 +42,9 @@ class Strategy(Driver):  # reuse driver handling
 
     def resolve_conflicts(self, client):
         raise NotImplementedError("Strategies do not support clients")
+
+    def transition(self, status):
+        raise NotImplementedError("Strategy.transition() is not implemented for {}".format(self.__class__.__name__))
+
+    def force(self, status):
+        raise NotImplementedError("Strategy.force() is not implemented for {}".format(self.__class__.__name__))

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -52,3 +52,20 @@ class ShellStrategy(Strategy):
                 format(self.status, status)
             )
         self.status = status
+
+    @step(args=['status'])
+    def force(self, status, *, step):
+        if not isinstance(status, Status):
+            status = Status[status]
+        if status == Status.unknown:
+            raise StrategyError("can not force state {}".format(status))
+        elif status == Status.off:
+            self.target.deactivate(self.shell)
+            self.target.activate(self.power)
+        elif status == Status.shell:
+            self.target.activate(self.power)
+            self.target.activate(self.shell)
+        else:
+            raise StrategyError("not setup found for {}".format(status))
+        self.status = status
+

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -29,7 +29,9 @@ class Target:
         # argument at the BindingMixin level.
         # https://github.com/python-attrs/attrs/issues/106
         self._binding_map = {}
-        self._lookup_table = {}
+        self._lookup_table = {
+            Strategy.__name__: Strategy,
+        }
 
     def interact(self, msg):
         if self.env:


### PR DESCRIPTION
**Description**
This adds support for the Stategy state forcing approach we've been using internally in some test suites to labgrid itself. It's exposed as a `--lg-initial-state=` on the pytest plugin.

Also, it makes it possible to use `target.get_driver("Strategy")` to get the registered Strategy without knowing the actual class.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated