### PR TITLE
smallubootdriver and getting_started fixes

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -14,7 +14,7 @@ and buster these usually are:
 
 .. code-block:: bash
 
-   $ apt-get install python3 python3-virtualenv python3-pip virtualenv
+   $ apt-get install python3 python3-virtualenv python3-pip python3-setuptools virtualenv
 
 
 In many cases, the easiest way is to install labgrid into a virtualenv:

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -58,6 +58,8 @@ class SmallUBootDriver(UBootDriver):
 
         # wait until UBoot has reached it's prompt
         self.console.expect(self.prompt)
+        for command in self.init_commands:  #pylint: disable=not-an-iterable
+            self._run(command)
 
     def _run(self, cmd: str, *, timeout: int = 30, codec: str = "utf-8", decodeerrors: str = "strict"):  # pylint: disable=unused-argument,line-too-long
         """


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->

* smallubootdriver: fix missing init_commands argument support
* doc/getting_started: fix missing python3-setuptools package

- [x] PR has been tested on TP-Link Archer C7v5 device