### PR TITLE
remote/exporter: Use YAML syntax for ser2net if version > 4.0.0

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -230,7 +230,7 @@ class SerialPortExport(ResourceExport):
                 '-d',
                 '-n',
                 '-Y', 'connection: &con01#  accepter: telnet(rfc2217,mode=server),{}'.format(self.port),
-                '-Y', '  connector: serialdev,{},115200n81,local'.format(start_params['path']
+                '-Y', '  connector: serialdev(nouucplock=true),{},115200n81,local'.format(start_params['path']
                 ),
             ])
         else:
@@ -238,6 +238,7 @@ class SerialPortExport(ResourceExport):
                 self.ser2net_bin,
                 '-d',
                 '-n',
+                '-u',
                 '-C',
                 '{}:telnet:0:{}:115200 NONE 8DATABITS 1STOPBIT LOCAL'.format(
                     self.port, start_params['path']


### PR DESCRIPTION
See:
https://github.com/labgrid-project/labgrid/issues/565

Verified to work when using ser2net version 2.10.0 and version 4.1.8.
Test performed: 
- Start exporter
- Check which port is chosen
- Connect using telnet to the ip / port
Verify that commands be send, and output seen.