### PR TITLE
pytestplugin: workaround pytest>=6.0.0 compatibility

### DIFF
--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -76,3 +76,10 @@ def test_help_coordinator(short_test):
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
+
+def test_log_without_capturing(short_env, short_test, tmpdir):
+    with pexpect.spawn('pytest -vv -s --lg-env {} {}'.format(short_env,short_test)) as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        print(spawn.before)
+        assert spawn.exitstatus == 0

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -44,7 +44,7 @@ def test_env_fixture(short_env, short_test):
 
 def test_env_old_fixture(short_env, short_test):
     with pexpect.spawn('pytest --env-config {} {}'.format(short_env,short_test)) as spawn:
-        spawn.expect("deprecated option")
+        spawn.expect("deprecated option --env-config")
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
@@ -59,7 +59,7 @@ def test_env_env_fixture(short_env, short_test):
 
 def test_env_with_junit(short_env, short_test, tmpdir):
     x = tmpdir.join('junit.xml')
-    with pexpect.spawn('pytest --junitxml={} --env-config {} {}'.format(x,short_env,short_test)) as spawn:
+    with pexpect.spawn('pytest --junitxml={} --lg-env {} {}'.format(x,short_env,short_test)) as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0


### PR DESCRIPTION
Currently pytestplugin reporter uses pytest internal API, which was
broken with 6.0.0 release by removing safe_text_dupfile()
function. Workaround that by using EncodedFile() and porting part of old
safe_text_dupfile() implementation.

Internal implementation of TerminalWriter has also been modified and
with 6.0.0+ pytest version there is no reline() method. Workaround that
by setting self.rewrite=False for all StepReporter instances.

Fixes: #629 