### PR TITLE
Update getting_started.rst

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -213,7 +213,7 @@ Each group contains one or more resource declarations and optionally a location
 string (see the :doc:`configuration reference <configuration>` for details).
 
 For example, to export a ``USBSerialPort`` with ``ID_SERIAL_SHORT`` of
-``ID23421JLK``, the group name `example-port` and the location
+``ID23421JLK``, the group name `example-group` and the location
 `example-location`:
 
 .. code-block:: yaml
@@ -302,7 +302,7 @@ And add resources to this place (``-p`` is short for ``--place``):
 
 .. code-block:: bash
 
-    $ labgrid-client -p example-place add-match */example-port/*
+    $ labgrid-client -p example-place add-match */example-group/*
 
 Which adds the previously defined resource from the exporter to the place.
 To interact with this place, it needs to be acquired first, this is done by


### PR DESCRIPTION
Ran into an issue with the example. The example exports "example-group" but adds "example-port".
This results in `labgrid-client -p example-place console` to fail because it can't find example-port.
`labgrid-client -p example-place show` doesn't show any resources.

After releasing example-place, adding "\*/example-group/\*" and reacquiring the resource is shown and able to use with 
`labgrid-client -p example-place`

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
