### PR TITLE
ExternalPowerDriver: split into Port and Driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,7 +61,7 @@ Breaking changes in 0.3.0
   A deprecated `NetworkUSBStorageDriver` exists temporarily for compatibility
   reasons.
 - `ExternalPowerDriver` is now split into a Port and a Driver, like PDUDaemon.
-  Configuration files need to be updated to declare the `cmd_*` as a resource.
+  Configuration files need to be updated to declare the ``cmd_*`` as a resource.
 
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ New Features in 0.3.0
   ``--skip``, ``--seek``.
 - UBootDriver now allows overriding of default boot command (``run bootcmd``)
   via new ``boot_command`` argument.
+- ExternalPowerPort is a new resource, bound to ExternalPowerDriver, that can be
+  used with ``labgrid-exporter``/``labgrid-client``.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -58,6 +60,8 @@ Breaking changes in 0.3.0
   renamed to `USBStorageDriver`.
   A deprecated `NetworkUSBStorageDriver` exists temporarily for compatibility
   reasons.
+- `ExternalPowerDriver` is now split into a Port and a Driver, like PDUDaemon.
+  Configuration files need to be updated to declare the `cmd_*` as a resource.
 
 Release 0.2.0 (released Jan 4, 2019)
 ------------------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -91,7 +91,7 @@ Power Ports
 ~~~~~~~~~~~
 
 ExternalPowerPort
-++++++++++++++++
++++++++++++++++++
 A ExternalPowerPort describes a remotely switchable power port.
 
 .. code-block:: yaml

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -105,7 +105,7 @@ sequence to tcp/ip address 192.168.0.123:17123.
 
 - cmd_on (str): command to turn power to the board on
 - cmd_off (str): command to turn power to the board off
-- cycle (str): optional command to switch the board off and on
+- cmd_cycle (str): optional command to switch the board off and on
 
 
 NetworkPowerPort

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -90,6 +90,24 @@ Used by:
 Power Ports
 ~~~~~~~~~~~
 
+ExternalPowerPort
+++++++++++++++++
+A ExternalPowerPort describes a remotely switchable power port.
+
+.. code-block:: yaml
+
+   ExternalPowerPort:
+     cmd_on: 'ncat --send-only -e "/bin/echo SR 1 on" 192.168.0.123 17123'
+     cmd_off: 'ncat --send-only -e "/bin/echo SR 1 off" 192.168.0.123 17123'
+
+The example describes a power switch that can be controller by writing some ascii
+sequence to tcp/ip address 192.168.0.123:17123.
+
+- cmd_on (str): command to turn power to the board on
+- cmd_off (str): command to turn power to the board off
+- cycle (str): optional command to switch the board off and on
+
+
 NetworkPowerPort
 ++++++++++++++++
 A NetworkPowerPort describes a remotely switchable power port.
@@ -1070,7 +1088,12 @@ Arguments:
 
 ExternalPowerDriver
 ~~~~~~~~~~~~~~~~~~~
-An ExternalPowerDriver is used to control a target power state via an external command.
+An ExternalPowerDriver controls a `ExternalPowerPort`.
+It is used to control a target power state via an external (remote) command.
+
+Binds to:
+  port:
+    - `ExternalPowerPort`_
 
 Implements:
   - :any:`PowerProtocol`
@@ -1078,15 +1101,10 @@ Implements:
 .. code-block:: yaml
 
    ExternalPowerDriver:
-     cmd_on: example_command on
-     cmd_off: example_command off
-     cmd_cycle: example_command cycle
+     delay: 5
 
 Arguments:
-  - cmd_on (str): command to turn power to the board on
-  - cmd_off (str): command to turn power to the board off
-  - cycle (str): optional command to switch the board off and on
-  - delay (float): configurable delay in seconds between off and on if cycle is not set
+  - delay (int): configurable delay in seconds between off and on if cycle is not set
 
 NetworkPowerDriver
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -62,7 +62,7 @@ class ManualPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 class ExternalPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """ExternalPowerDriver - Driver using an external command to control a target's power"""
     bindings = {"port": "ExternalPowerPort", }
-    delay = attr.ib(default=2.0, validator=attr.validators.instance_of(int))
+    delay = attr.ib(default=2, validator=attr.validators.instance_of(int))
 
     @Driver.check_active
     @step()

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -61,31 +61,26 @@ class ManualPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 @attr.s(eq=False)
 class ExternalPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     """ExternalPowerDriver - Driver using an external command to control a target's power"""
-    cmd_on = attr.ib(validator=attr.validators.instance_of(str))
-    cmd_off = attr.ib(validator=attr.validators.instance_of(str))
-    cmd_cycle = attr.ib(
-        default=None,
-        validator=attr.validators.optional(attr.validators.instance_of(str))
-    )
-    delay = attr.ib(default=2.0, validator=attr.validators.instance_of(float))
+    bindings = {"port": "ExternalPowerPort", }
+    delay = attr.ib(default=2.0, validator=attr.validators.instance_of(int))
 
     @Driver.check_active
     @step()
     def on(self):
-        cmd = shlex.split(self.cmd_on)
+        cmd = shlex.split(self.port.cmd_on)
         processwrapper.check_output(cmd)
 
     @Driver.check_active
     @step()
     def off(self):
-        cmd = shlex.split(self.cmd_off)
+        cmd = shlex.split(self.port.cmd_off)
         processwrapper.check_output(cmd)
 
     @Driver.check_active
     @step()
     def cycle(self):
-        if self.cmd_cycle is not None:
-            cmd = shlex.split(self.cmd_cycle)
+        if self.port.cmd_cycle is not None:
+            cmd = shlex.split(self.port.cmd_cycle)
             processwrapper.check_output(cmd)
         else:
             self.off()

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -693,8 +693,8 @@ class ClientSession(ApplicationSession):
         action = self.args.action
         delay = self.args.delay
         target = self._get_target(place)
-        from ..driver.powerdriver import NetworkPowerDriver, PDUDaemonDriver, USBPowerDriver
-        from ..resource.power import NetworkPowerPort, PDUDaemonPort
+        from ..driver.powerdriver import ExternalPowerDriver, NetworkPowerDriver, PDUDaemonDriver, USBPowerDriver
+        from ..resource.power import ExternalPowerPort, NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort
         drv = None
         for resource in target.resources:
@@ -703,6 +703,12 @@ class ClientSession(ApplicationSession):
                     drv = target.get_driver(NetworkPowerDriver)
                 except NoDriverFoundError:
                     drv = NetworkPowerDriver(target, name=None, delay=delay)
+                break
+            elif isinstance(resource, ExternalPowerPort):
+                try:
+                    drv = target.get_driver(ExternalPowerDriver)
+                except NoDriverFoundError:
+                    drv = ExternalPowerDriver(target, name=None, delay=int(delay))
                 break
             elif isinstance(resource, NetworkUSBPowerPort):
                 try:

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -4,7 +4,7 @@ from .serialport import RawSerialPort, NetworkSerialPort
 from .modbus import ModbusTCPCoil
 from .networkservice import NetworkService
 from .onewireport import OneWirePIO
-from .power import NetworkPowerPort
+from .power import ExternalPowerPort, NetworkPowerPort
 from .remote import RemotePlace
 from .udev import USBSerialPort
 from .udev import USBSDMuxDevice

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -33,3 +33,19 @@ class PDUDaemonPort(Resource):
     host = attr.ib(validator=attr.validators.instance_of(str))
     pdu = attr.ib(validator=attr.validators.instance_of(str))
     index = attr.ib(validator=attr.validators.instance_of(int), converter=int)
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class ExternalPowerPort(Resource):
+    """The ExternalPowerPort describes a power switch, controllable
+       via a remote command execution
+
+    Args:
+        cmd_on (str): command to turn power to the board on
+        cmd_off (str): command to turn power to the board off
+        cycle (str): optional command to switch the board off and on
+    """
+    cmd_on = attr.ib(validator=attr.validators.instance_of(str))
+    cmd_off = attr.ib(validator=attr.validators.instance_of(str))
+    cycle = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -48,4 +48,4 @@ class ExternalPowerPort(Resource):
     """
     cmd_on = attr.ib(validator=attr.validators.instance_of(str))
     cmd_off = attr.ib(validator=attr.validators.instance_of(str))
-    cycle = attr.ib(validator=attr.validators.instance_of(str))
+    cmd_cycle = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -48,4 +48,4 @@ class ExternalPowerPort(Resource):
     """
     cmd_on = attr.ib(validator=attr.validators.instance_of(str))
     cmd_off = attr.ib(validator=attr.validators.instance_of(str))
-    cmd_cycle = attr.ib(validator=attr.validators.instance_of(str))
+    cmd_cycle = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -41,9 +41,11 @@ class TestManualPowerDriver:
 
 class TestExternalPowerDriver:
     def test_create(self, target):
-        d = ExternalPowerDriver(
+        r = ExternalPowerPort(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
+        d = ExternalPowerDriver(target, 'power')
+        
         assert (isinstance(d, ExternalPowerDriver))
 
     def test_on(self, target, mocker):
@@ -60,9 +62,10 @@ class TestExternalPowerDriver:
         fd_mock.read.return_value = b'Done\nDone'
         instance_mock.returncode = 0
 
-        d = ExternalPowerDriver(
+        r = ExternalPowerPort(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
+        d = ExternalPowerDriver(target, 'power')
         target.activate(d)
         d.on()
 
@@ -83,9 +86,10 @@ class TestExternalPowerDriver:
         fd_mock.read.return_value = b'Done\nDone'
         instance_mock.returncode = 0
 
-        d = ExternalPowerDriver(
+        r = ExternalPowerPort(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
+        d = ExternalPowerDriver(target, 'power')
         target.activate(d)
         d.off()
 
@@ -108,9 +112,10 @@ class TestExternalPowerDriver:
 
         m_sleep = mocker.patch('time.sleep')
 
-        d = ExternalPowerDriver(
+        r = ExternalPowerPort(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
         )
+        d = ExternalPowerDriver(target, 'power')
         target.activate(d)
         d.cycle()
 
@@ -138,12 +143,13 @@ class TestExternalPowerDriver:
 
         m_sleep = mocker.patch('time.sleep')
 
-        d = ExternalPowerDriver(
+        r = ExternalPowerPort(
             target, 'power',
             cmd_on='set -1 foo-board',
             cmd_off='set -0 foo-board',
             cmd_cycle='set -c foo-board',
         )
+        d = ExternalPowerDriver(target, 'power')
         target.activate(d)
         d.cycle()
 

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -1,4 +1,4 @@
-from labgrid.resource import NetworkPowerPort
+from labgrid.resource import ExternalPowerPort, NetworkPowerPort
 from labgrid.driver.powerdriver import ExternalPowerDriver, ManualPowerDriver, NetworkPowerDriver
 
 


### PR DESCRIPTION
To support the export of an ExternalPowerDriver as a resource,
split the declaration into Driver and Port.

Signed-off-by: Leif Middelschulte <leif.middelschulte@klsmartin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Allow `ExternalPowerDriver` to be exported as a resource, like `PDUDaemonPort`.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
