### PR TITLE
driver/pyvisadriver: add driver to support PyVISA

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ New Features in 0.3.0
 - ``labgrid-client`` now respects the ``LG_HOSTNAME`` and ``LG_USERNAME``
   environment variables to set the hostname and username when accessing
   resources.
+- PyVISA support added, allowing to use PyVISA controlled test equipment from
+  Labgrid.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ psutil==5.6.6
 -r xena-requirements.txt
 -r graph-requirements.txt
 -r docker-requirements.txt
+-r pyvisa-requirements.txt

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -627,6 +627,23 @@ A XenaManager resource describes a Xena Manager instance which is the instance t
 Used by:
   - `XenaDriver`_
 
+PyVISADevice
+~~~~~~~~~~~~
+A PyVISADevice resource describes a test stimuli device controlled by PyVISA.
+Such device could be a signal generator.
+
+.. code-block:: yaml
+
+   PyVISADevice:
+     type: "TCPIP"
+     url: "192.168.110.11"
+
+- type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
+- url (str): device identifier on selected resource, e.g. <ip> for TCPIP resource
+
+Used by:
+  - `PyVISADriver`_
+
 RemotePlace
 ~~~~~~~~~~~
 A RemotePlace describes a set of resources attached to a labgrid remote place.
@@ -1794,6 +1811,17 @@ Binds to:
 
 Implements:
   - :any:`DigitalOutputProtocol`
+
+PyVISADriver
+~~~~~~~~~~~~
+The PyVISADriver uses a PyVISADevice resource to control test equipment manageable by PyVISA.
+
+Binds to:
+  pyvisa_resource:
+    - `PyVISADevice`_
+
+Implements:
+  - None yet
 
 Strategies
 ----------

--- a/examples/pyvisa/env.yaml
+++ b/examples/pyvisa/env.yaml
@@ -1,0 +1,9 @@
+targets:
+  main:
+    resources:
+      PyVISADevice:
+        type: "TCPIP"
+        url: "192.168.110.11"
+    drivers:
+      PyVISADriver:
+        name: "PyVisa_device"

--- a/examples/pyvisa/pyvisa_example.py
+++ b/examples/pyvisa/pyvisa_example.py
@@ -1,0 +1,15 @@
+import pytest
+
+
+@pytest.fixture()
+def signal_generator(target):
+    return target.get_driver('PyVISADriver').get_session()
+
+
+def test_with_signal_generator_example(signal_generator):
+    signal_generator.write('*RST')
+
+    # Setup channel 1
+    signal_generator.write('C1:BSWV WVTP,SQUARE,HLEV,5,LLEV,0,DUTY,50')
+    # Switch on channel 1
+    signal_generator.write('C1:OUTP ON,LOAD,HZ,PLRT,NOR')

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -29,3 +29,4 @@ from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver
 from .dockerdriver import DockerDriver
 from .lxaiobusdriver import LXAIOBusPIODriver
+from .pyvisadriver import PyVISADriver

--- a/labgrid/driver/pyvisadriver.py
+++ b/labgrid/driver/pyvisadriver.py
@@ -1,0 +1,33 @@
+from importlib import import_module
+import attr
+
+from ..factory import target_factory
+from .common import Driver
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class PyVISADriver(Driver):
+    """The PyVISADriver provides a transparent layer to the PyVISA module allowing to get a pyvisa resource
+
+        Args:
+            bindings (dict): driver to use with PyVISA
+        """
+    bindings = {"pyvisa_resource": "PyVISADevice"}
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        _py_pyvisa_module = import_module('pyvisa')
+        self._pyvisa_resource_manager = _py_pyvisa_module.ResourceManager()
+        self.pyvisa_device = None
+
+    def on_activate(self):
+        device_identifier = '{}::{}::INSTR'.format(self.pyvisa_resource.type, self.pyvisa_resource.url)
+        self.pyvisa_device = self._pyvisa_resource_manager.open_resource(device_identifier)
+
+    def on_deactivate(self):
+        self.pyvisa_device = None
+
+    @Driver.check_active
+    def get_session(self):
+        return self.pyvisa_device

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -17,3 +17,4 @@ from .xenamanager import XenaManager
 from .flashrom import Flashrom, NetworkFlashrom
 from .docker import DockerManager, DockerDaemon, DockerConstants
 from .lxaiobus import LXAIOBusPIO
+from .pyvisa import PyVISADevice

--- a/labgrid/resource/pyvisa.py
+++ b/labgrid/resource/pyvisa.py
@@ -1,0 +1,17 @@
+import attr
+
+from ..factory import target_factory
+from .common import Resource
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class PyVISADevice(Resource):
+    """The PyVISADevice describes a test stimuli device controlled  with PyVISA
+
+    Args:
+        type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
+        url (str): device identifier on selected resource, e.g. <ip> for TCPIP resource
+    """
+    type = attr.ib(validator=attr.validators.instance_of(str))
+    url = attr.ib(validator=attr.validators.instance_of(str))

--- a/pyvisa-requirements.txt
+++ b/pyvisa-requirements.txt
@@ -1,0 +1,2 @@
+pyvisa==1.10.1
+PyVISA-py==0.4.1

--- a/tests/test_pyvisa.py
+++ b/tests/test_pyvisa.py
@@ -1,0 +1,14 @@
+from labgrid.resource.pyvisa import PyVISADevice
+from labgrid.driver.pyvisadriver import PyVISADriver
+
+
+def test_pyvisa_resource(target):
+    PyVISADevice(target, name=None, type='TCPIP', url='127.0.0.1')
+
+
+def test_resource_driver(target, mocker):
+    PyVISADevice(target, name=None, type='TCPIP', url='127.0.0.1')
+    driver = PyVISADriver(target, name=None)
+
+    mocker.patch('pyvisa.ResourceManager.open_resource', return_value=None)
+    target.activate(driver)


### PR DESCRIPTION
Add driver and resource to support controlling test instruments using the
PyVISA package.


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
The [PyVISA](https://pypi.org/project/PyVISA/) project provide a python package  to control measurement devices and test equipment via GPIB, RS232, Ethernet or USB.

A transparent wrapper is implemented in Labgrid to allow representing PyVISA devices as resources.

PR has been tested locally using a RSDG 2024 signal generator connected over TCP/IP. The test has been added in examples
to also serve as an example for future use.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested

