### PR TITLE
driver/sshdriver: Allow filename to be a folder

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -311,6 +311,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             "scp",
             *self.ssh_prefix,
             "-P", str(self.networkservice.port),
+            "-r",
             filename,
             "{user}@{host}:{remotepath}".format(
                 user=self.networkservice.username,
@@ -338,6 +339,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             "scp",
             *self.ssh_prefix,
             "-P", str(self.networkservice.port),
+            "-r",
             "{user}@{host}:{filename}".format(
                 user=self.networkservice.username,
                 host=self.networkservice.address,


### PR DESCRIPTION
Adding a "-r" in front of filename helps with folders, and it still works
with regular files.
Prior to commit 1d7b97b838f7, something like this was working:
ssh.put('-r <folder_name>', '<remote_location>')
but afterwards, scp fails with "unknown option --".
Add a similar change for ssh.put

Fixes: 1d7b97b838f7 (driver/sshdriver: Allow whitespaces in filenames Prevent filenames with whitespaces from beeing split.)

Signed-off-by: Mirela Rabulea <mirela.rabulea@nxp.com>

put

Signed-off-by: Mirela Rabulea <mirela.rabulea@nxp.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
