### PR TITLE
driver/sshdriver: Allow filename to be a folder

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -311,6 +311,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             "scp",
             *self.ssh_prefix,
             "-P", str(self.networkservice.port),
+            "-r",
             filename,
             "{user}@{host}:{remotepath}".format(
                 user=self.networkservice.username,
@@ -338,6 +339,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             "scp",
             *self.ssh_prefix,
             "-P", str(self.networkservice.port),
+            "-r",
             "{user}@{host}:{filename}".format(
                 user=self.networkservice.username,
                 host=self.networkservice.address,

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -71,6 +71,17 @@ def test_local_put(ssh_localhost, tmpdir):
     assert open('/tmp/test_put_yaml', 'r').readlines() == [ "PUT Teststring" ]
 
 @pytest.mark.sshusername
+def test_local_put_dir(ssh_localhost, tmpdir):
+    d = tmpdir.mkdir("test_put_dir");
+    p = d.join("config.yaml")
+    p.write(
+        """PUT Teststring"""
+    )
+
+    ssh_localhost.put(str(d), "/tmp/test_put_dir")
+    assert open('/tmp/test_put_dir/config.yaml', 'r').readlines() == [ "PUT Teststring" ]
+
+@pytest.mark.sshusername
 def test_local_get(ssh_localhost, tmpdir):
     p = tmpdir.join("config.yaml")
     p.write(
@@ -79,6 +90,17 @@ def test_local_get(ssh_localhost, tmpdir):
 
     ssh_localhost.get(str(p), "/tmp/test_get_yaml")
     assert open('/tmp/test_get_yaml', 'r').readlines() == [ "GET Teststring" ]
+
+@pytest.mark.sshusername
+def test_local_get_dir(ssh_localhost, tmpdir):
+    d = tmpdir.mkdir("test_get_dir");
+    p = d.join("config.yaml")
+    p.write(
+        """GET Teststring"""
+    )
+
+    ssh_localhost.get(str(d), "/tmp/test_get_dir")
+    assert open('/tmp/test_get_dir/config.yaml', 'r').readlines() == [ "GET Teststring" ]
 
 @pytest.mark.sshusername
 def test_local_run(ssh_localhost, tmpdir):


### PR DESCRIPTION
Adding a "-r" in front of filename helps with folders, and it still works
with regular files.
Prior to commit 1d7b97b838f7, something like this was working:
ssh.put('-r <folder_name>', '<remote_location>')
but afterwards, scp fails with "unknown option --".
Add a similar change for ssh.put

Fixes: 1d7b97b838f7 (driver/sshdriver: Allow whitespaces in filenames Prevent filenames with whitespaces from beeing split.)

Signed-off-by: Mirela Rabulea <mirela.rabulea@nxp.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
