### PR TITLE
Update pyudev to py39 compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ jinja2==2.10.3
 pexpect==4.7
 https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial
 pytest==5.3.1
-pyudev==0.21.0
+pyudev==0.22.0
 requests==2.22.0
 xmodem==0.4.5
 autobahn==19.11.1


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
collections.abc was removed in Python 3.9. pyudev 0.22.0 deals with this change.

**Checklist**
- [x] PR has been tested