### PR TITLE
serialdriver: Prevent pyserial version check fails

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -2,6 +2,7 @@ import logging
 import warnings
 
 import attr
+from packaging import version
 from pexpect import TIMEOUT
 import serial
 import serial.rfc2217
@@ -22,11 +23,11 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     """
     # pyserial 3.2.1 does not support RFC2217 under Python 3
     # https://github.com/pyserial/pyserial/pull/183
-    if tuple(int(x) for x in serial.__version__.split('.')) <= (3, 2, 1):
+    if version.parse(serial.__version__) <= version.Version('3.2.1'):
         bindings = {"port": "SerialPort", }
     else:
         bindings = {"port": {"SerialPort", "NetworkSerialPort"}, }
-    if tuple(int(x) for x in serial.__version__.split('.')) < (3, 4, 0, 1):
+    if version.parse(serial.__version__) != version.Version('3.4.0.1'):
         message = ("The installed pyserial version does not contain important RFC2217 fixes.\n"
                    "You can install the labgrid fork via:\n"
                    "pip uninstall pyserial\n"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 attrs==19.3.0
 jinja2==2.10.3
+packaging==20.4
 pexpect==4.7
 https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial
 pytest==5.3.1

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'attrs>=19.2.0',
         'ansicolors',
         'jinja2',
+        'packaging',
         'pexpect',
         'pyserial>=3.3',
         'pytest>=3.6',


### PR DESCRIPTION
The version might contain 'b' in a component, e.g., with the newest beta
version 3.5b0. This makes the int() conversion fail. Switch to packaging.version comparison.

**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested