### PR TITLE
util/proxy: if LG_PROXY set, use as only forward

### DIFF
--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -51,6 +51,7 @@ class ProxyManager:
         if cls._force_proxy:
             port = sshmanager.request_forward(cls._force_proxy, host, port)
             host = 'localhost'
+            return host, port
 
         extra = getattr(res, 'extra', {})
         if extra:


### PR DESCRIPTION
**Description**
If the LG_PROXY Variable is set, we expect to be able to reach all of
the infrastructure using this variable. Do not request a second forward
even if the resource is from an isolated exporter.



<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Tests for the feature 
- [ ] PR has been tested

Fixes https://github.com/labgrid-project/labgrid/issues/620