### PR TITLE
util/proxy: prefer isolated over LG_PROXY

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -369,3 +369,8 @@ fully remotely with only a SSH connection as a requirement.
 One remaining issue here is the forward of UDP connections, which is currently
 not possible. UDP connections are used by some of the power backends in the form
 of SNMP.
+
+.. note::
+  Labgrid prefers to connect to an isolated exporter over using the LG_PROXY
+  variable. This means that for an isolated exporter, a correct entry for the
+  exporter needs to be set up in the ~/.ssh/config file.

--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -48,10 +48,6 @@ class ProxyManager:
         else:
             port = getattr(res, 'port', None) or default_port
 
-        if cls._force_proxy:
-            port = sshmanager.request_forward(cls._force_proxy, host, port)
-            host = 'localhost'
-
         extra = getattr(res, 'extra', {})
         if extra:
             proxy_required = extra.get('proxy_required')
@@ -59,6 +55,11 @@ class ProxyManager:
             if proxy_required:
                 port = sshmanager.request_forward(proxy, host, port)
                 host = 'localhost'
+                return host, port
+
+        if cls._force_proxy:
+            port = sshmanager.request_forward(cls._force_proxy, host, port)
+            host = 'localhost'
 
         return host, port
 


### PR DESCRIPTION
**Description**
If we want to connect to an isolated exporter, prefer a connection to
the exporter over the LG_PROXY variable. We expect the user to have a
properly setup SSH config to access the exporter, document this as a
note in the proxy documentation.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**

- [x] PR has been tested

Fixes https://github.com/labgrid-project/labgrid/issues/620
