### PR TITLE
doc/configuration: document USB hub interfaces

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -176,6 +176,14 @@ The example describes port 1 on the hub with the ID_PATH
 Used by:
   - `USBPowerDriver`_
 
+.. note::
+   Labgrid requires that the interface is contained in the ID_PATH.
+   This usually means that the ID_PATH should end with ``:1.0``.
+   Only this first interface is registered with the ``hub`` driver labgrid is
+   looking for, paths without the interface will fail to match since they use
+   the ``usb`` driver.
+
+
 ModbusTCPCoil
 ~~~~~~~~~~~~~
 A ModbusTCPCoil describes a coil accessible via ModbusTCP.


### PR DESCRIPTION
**Description**
For USB hubs controlled by the USBPowerPort, the interface needs to be
included in the Paths, since the wrong driver will be detected
otherwise.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] Documentation update

Closes https://github.com/labgrid-project/labgrid/pull/291