### PR TITLE
lxaiobus: support for LXA IO Bus nodes

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -634,6 +634,34 @@ therefore auto-cleanup is important.
 Used by:
   - `DockerDriver`_
 
+LXAIOBusPIO
+~~~~~~~~~~~
+
+An :any:`LXAIOBusPIO` resource describes a single PIO pin on an LXAIOBusNode.
+
+.. code-block:: yaml
+
+   LXAIOBusPIO:
+     host: localhost:8080
+     node: IOMux-00000003
+     pin: OUT0
+     invert: False
+
+The example uses an lxa-iobus-server running on localhost:8080, with node
+IOMux-00000003 and pin OUT0.
+
+- host (str): hostname with port of the lxa-io-bus server
+- node (str): name of the node to use
+- pin (str): name of the pin to use
+- invert (bool): whether to invert the pin
+
+Used by:
+  - `LXAIOBusPIODriver`_
+
+NetworkLXAIOBusPIO
+~~~~~~~~~~~~~~~~~~
+A NetworkLXAIOBusPIO descibes an `LXAIOBusPIO`_ exported over the network.
+
 udev Matching
 ~~~~~~~~~~~~~
 udev matching allows labgrid to identify resources via their udev properties.
@@ -1673,6 +1701,23 @@ Arguments:
     instances that come alive when the container is created. The "address" argument
     which `NetworkService`_ also requires will be derived automatically upon container
     creation.
+
+LXAIOBusPIODriver
+~~~~~~~~~~~~~~~~~
+An LXAIOBusPIODriver binds to a single `LXAIOBusPIO` to toggle and read the PIO
+states.
+
+Binds to:
+  pio:
+    - `LXAIOBusPIO`_
+    - `NetworkLXAIOBusPIO`_
+
+.. code-block:: yaml
+
+   LXAIOBusPIODriver: {}
+
+Implements:
+  - :any:`DigitalOutputProtocol`
 
 Strategies
 ----------

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -27,3 +27,4 @@ from .filedigitaloutput import FileDigitalOutputDriver
 from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver
 from .dockerdriver import DockerDriver
+from .lxaiobusdriver import LXAIOBusPIODriver

--- a/labgrid/driver/lxaiobusdriver.py
+++ b/labgrid/driver/lxaiobusdriver.py
@@ -1,0 +1,55 @@
+import attr
+
+import requests
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol
+from ..util.proxy import proxymanager
+from .common import Driver
+from .exception import ExecutionError
+from ..step import step
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class LXAIOBusPIODriver(Driver, DigitalOutputProtocol):
+    bindings = {
+            "pio": {"LXAIOBusPIO", "NetworkLXAIOBusPIO"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def on_activate(self):
+        # we can only forward if the backend knows which port to use
+        host, port = proxymanager.get_host_and_port(self.pio)
+        self._url = 'http://{}:{}/nodes/{}/pins/{}/'.format(
+            host, port, self.pio.node, self.pio.pin)
+
+    @Driver.check_active
+    @step(args=['status'])
+    def set(self, status):
+        if self.pio.invert:
+            status = not status
+        r = requests.post(
+                self._url, data={'value': '1' if status else '0'}
+        )
+        r.raise_for_status()
+        j = r.json()
+        if j["code"] != 0:
+            raise ExecutionError("failed to set value: {}".format(j["error_message"]))
+
+    @Driver.check_active
+    @step(result=['True'])
+    def get(self):
+        r = requests.get(self._url)
+        r.raise_for_status()
+        j = r.json()
+        if j["code"] != 0:
+            raise ExecutionError("failed to get value: {}".format(j["error_message"]))
+        result = j["result"]
+        if result not in (0, 1):
+            raise ExecutionError("invalid input value: {}".format(repr(result)))
+        status = bool(result)
+        if self.pio.invert:
+            status = not status
+        return status

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -737,10 +737,12 @@ class ClientSession(ApplicationSession):
         from ..resource.onewireport import OneWirePIO
         from ..resource.remote import NetworkDeditecRelais8
         from ..resource.remote import NetworkSysfsGPIO
+        from ..resource.remote import NetworkLXAIOBusPIO
         from ..driver.modbusdriver import ModbusCoilDriver
         from ..driver.onewiredriver import OneWirePIODriver
         from ..driver.deditecrelaisdriver import DeditecRelaisDriver
         from ..driver.gpiodriver import GpioDigitalOutputDriver
+        from ..driver.lxaiobusdriver import LXAIOBusPIODriver
         drv = None
         for resource in target.resources:
             if isinstance(resource, ModbusTCPCoil):
@@ -770,6 +772,13 @@ class ClientSession(ApplicationSession):
                 except NoDriverFoundError:
                     target.set_binding_map({"gpio": name})
                     drv = GpioDigitalOutputDriver(target, name=name)
+                break
+            elif isinstance(resource, NetworkLXAIOBusPIO):
+                try:
+                    drv = target.get_driver(LXAIOBusPIODriver, name=name)
+                except NoDriverFoundError:
+                    target.set_binding_map({"pio": name})
+                    drv = LXAIOBusPIODriver(target, name=name)
                 break
         if not drv:
             raise UserError("target has no compatible resource available")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -478,6 +478,23 @@ class NetworkServiceExport(ResourceExport):
 
 exports["NetworkService"] = NetworkServiceExport
 
+@attr.s(eq=False)
+class LXAIOBusNodeExport(ResourceExport):
+    """ResourceExport for LXAIOBusNode devices accessed via the HTTP API"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        local_cls_name = self.cls
+        self.data['cls'] = "Network{}".format(self.cls)
+        from ..resource import lxaiobus
+        local_cls = getattr(lxaiobus, local_cls_name)
+        self.local = local_cls(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        return self.local_params
+
+exports["LXAIOBusPIO"] = LXAIOBusNodeExport
+
 
 class ExporterSession(ApplicationSession):
     def onConnect(self):

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -14,3 +14,4 @@ from .ykushpowerport import YKUSHPowerPort
 from .xenamanager import XenaManager
 from .flashrom import Flashrom, NetworkFlashrom
 from .docker import DockerManager, DockerDaemon, DockerConstants
+from .lxaiobus import LXAIOBusPIO

--- a/labgrid/resource/lxaiobus.py
+++ b/labgrid/resource/lxaiobus.py
@@ -1,0 +1,66 @@
+import logging
+from time import monotonic
+
+import attr
+import requests
+
+from ..factory import target_factory
+from .common import ManagedResource, ResourceManager
+
+
+@attr.s(eq=False)
+class LXAIOBusNodeManager(ResourceManager):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        self.log = logging.getLogger('LXAIOBusNodeManager')
+
+        self._last = 0.0
+
+    def _get_nodes(self, host):
+        try:
+            r = requests.get('http://{}/nodes/'.format(host))
+            r.raise_for_status()
+            j = r.json()
+            return j["result"]
+        except requests.exceptions.ConnectionError:
+            self.log.exception("failed to connect to host %s", host)
+            return []
+
+    def poll(self):
+        if monotonic()-self._last < 2:
+            return  # ratelimit requests
+        self._last = monotonic()
+        hosts = {r.host for r in self.resources}
+        nodes = {h: self._get_nodes(h) for h in hosts}
+        for resource in self.resources:
+            resource.avail = resource.node in nodes[resource.host]
+
+
+@attr.s(eq=False)
+class LXAIOBusNode(ManagedResource):
+    """This resource describes a generic LXA IO BUs Node.
+
+    Args:
+        host (str): hostname of the owserver e.g. localhost:4304
+        node (str): node name e.g. EthMux-5c12ca8b"""
+    manager_cls = LXAIOBusNodeManager
+
+    host = attr.ib(validator=attr.validators.instance_of(str))
+    node = attr.ib(validator=attr.validators.instance_of(str))
+
+    def __attrs_post_init__(self):
+        self.timeout = 30.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class LXAIOBusPIO(LXAIOBusNode):
+    """This resource describes a LXA IO Bus PIO Port.
+
+    Args:
+        pin (str): pin label e.g. OUT0
+        invert (bool): optional, whether the logic level is inverted (active-low)"""
+    pin = attr.ib(validator=attr.validators.instance_of(str))
+    invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -256,3 +256,20 @@ class NetworkSysfsGPIO(NetworkResource, ManagedResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()
+
+@attr.s(eq=False)
+class NetworkLXAIOBusNode(ManagedResource):
+    manager_cls = RemotePlaceManager
+
+    host = attr.ib(validator=attr.validators.instance_of(str))
+    node = attr.ib(validator=attr.validators.instance_of(str))
+
+    def __attrs_post_init__(self):
+        self.timeout = 30.0
+        super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkLXAIOBusPIO(NetworkLXAIOBusNode):
+    pin = attr.ib(validator=attr.validators.instance_of(str))
+    invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))

--- a/tests/test_lxaiobus.py
+++ b/tests/test_lxaiobus.py
@@ -1,0 +1,70 @@
+import pytest
+import requests
+
+from labgrid.resource import LXAIOBusPIO
+from labgrid.driver import LXAIOBusPIODriver
+
+@pytest.fixture(scope='function')
+def mock_server(mocker):
+    def get(url):
+        r = mocker.MagicMock()
+        if url.endswith("/nodes/"):
+            r.json.return_value = {"code": 0, "result": ["IOMux-5a6ecbea"]}
+        if "/pins/" in url:
+            r.json.return_value = {"code": 0, "result": 1}
+        return r
+    def post(url, data=None):
+        r = mocker.MagicMock()
+        if "/pins/" in url:
+            r.json.return_value = {"code": 0, "result": None}
+        return r
+    mock_get = mocker.patch('requests.get')
+    mock_get.side_effect = get
+    mock_post = mocker.patch('requests.post')
+    mock_post.side_effect = post
+    return (mock_get, mock_post)
+
+
+@pytest.fixture(scope='function')
+def lxa_pin(mock_server, target):
+    r = LXAIOBusPIO(target, name=None, host='localhost:8080', node='IOMux-5a6ecbea', pin='OUT0')
+    return r
+
+
+@pytest.fixture(scope='function')
+def lxa_driver(mock_server, target, lxa_pin):
+    mock_get, mock_post = mock_server
+
+    s = LXAIOBusPIODriver(target, name=None)
+    target.activate(s)
+    mock_get.assert_called_with('http://localhost:8080/nodes/')
+    return s
+
+
+def test_lxa_resource_instance(mock_server, lxa_pin):
+    assert (isinstance(lxa_pin, LXAIOBusPIO))
+
+
+def test_lxa_driver_instance(mock_server, lxa_driver):
+    assert isinstance(lxa_driver, LXAIOBusPIODriver)
+
+
+def test_lxa_set(mock_server, lxa_driver):
+    mock_get, mock_post = mock_server
+
+    lxa_driver.set(True)
+    mock_post.assert_called_once_with('http://localhost:8080/nodes/IOMux-5a6ecbea/pins/OUT0/', data={"value": "1"})
+
+
+def test_lxa_unset(mock_server, lxa_driver):
+    mock_get, mock_post = mock_server
+
+    lxa_driver.set(False)
+    mock_post.assert_called_once_with('http://localhost:8080/nodes/IOMux-5a6ecbea/pins/OUT0/', data={"value": "0"})
+
+
+def test_lxa_get(mock_server, lxa_driver):
+    mock_get, mock_post = mock_server
+    val = lxa_driver.get()
+    mock_get.assert_called_with('http://localhost:8080/nodes/IOMux-5a6ecbea/pins/OUT0/')
+    assert val == True


### PR DESCRIPTION
**Description**
Add support and documentation for the LXA IO Bus, through the
lxa-iobus-server. Currently only digital output pins are supported. Also
extend the documentation and add support for switching the outputs
through the remote client.

Signed-off-by: Jan Luebbe <jlu@pengutronix.de>
Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 

- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested

Supercedes https://github.com/labgrid-project/labgrid/pull/578