### PR TITLE
binding: check resources in check_active

### DIFF
--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -97,6 +97,11 @@ class BindingMixin:
                     '{} has not been activated, {} cannot be called in state "{}"'.format(
                         self, func.__qualname__, self.state.name)
                 )
+            for sup in self.suppliers:
+                if hasattr(sup, "avail") and sup.avail != True:
+                    raise StateError(
+                        'Resource {} no longer available, driver needs to be de- and reactivated'.format(sup)
+                       )
             return func(self, *_args, **_kwargs)
 
         return wrapper


### PR DESCRIPTION
**Description**
Ensure that not only the driver has been activated but that all bound
suppliers are available as well. This guards against cases where the
driver was activated at some point, but the resource is no longer
available when driver functions are used at a later point.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
