### PR TITLE
sshdriver: only remove final line if empty

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -192,7 +192,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         stdout, stderr = sub.communicate(timeout=timeout)
         stdout = stdout.decode(codec, decodeerrors).split('\n')
-        stdout.pop()
+        if stdout[-1] == '':
+            stdout.pop()
         if stderr is None:
             stderr = []
         else:

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -71,6 +71,24 @@ def test_local_put(ssh_localhost, tmpdir):
     assert open('/tmp/test_put_yaml', 'r').readlines() == [ "PUT Teststring" ]
 
 @pytest.mark.sshusername
+def test_local_no_final_line_remove(ssh_localhost, tmpdir):
+    p = tmpdir.join("test_no_line_remove")
+    p.write("teststring")
+
+    ssh_localhost.put(str(p), "/tmp/test_line_remove")
+    stdout, stderr, _ = ssh_localhost.run("cat /tmp/test_line_remove")
+    assert stdout == [ "teststring" ]
+
+@pytest.mark.sshusername
+def test_local_final_line_remove_empty(ssh_localhost, tmpdir):
+    p = tmpdir.join("test_no_line_remove")
+    p.write("teststring\n")
+
+    ssh_localhost.put(str(p), "/tmp/test_line_remove")
+    stdout, stderr, _ = ssh_localhost.run("cat /tmp/test_line_remove")
+    assert stdout == [ "teststring" ]
+
+@pytest.mark.sshusername
 def test_local_put_dir(ssh_localhost, tmpdir):
     d = tmpdir.mkdir("test_put_dir");
     p = d.join("config.yaml")


### PR DESCRIPTION
**Description**
Only remove the final line from the output if it is empty. This prevents
swallowing of output if the SSHDriver stdout does not contain a final
new line.

Related to https://github.com/labgrid-project/labgrid/issues/613

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] PR has been tested