### PR TITLE
CI Support for python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,7 @@ matrix:
           fi
     - stage: optional
       python: "nightly"
+    - stage: optional
+      python: "3.9"
   allow_failures:
     - stage: optional

--- a/setup.py
+++ b/setup.py
@@ -73,5 +73,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
 )


### PR DESCRIPTION
**Description**
Add CI for python 3.9 and adjust the classifiers in setup.py