### PR TITLE
driver/usbstoragedriver: fix bmaptool call format string

### DIFF
--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -107,7 +107,7 @@ class USBStorageDriver(Driver):
                 "bmaptool",
                 "copy",
                 "{}".format(remote_path),
-                "{}{}".format(target),
+                "{}".format(target),
             ]
         else:
             raise ValueError


### PR DESCRIPTION
Fixes: 1a5c787a ("driver/usbstoragedriver: log what actually gets written")
Signed-off-by: Bastian Krause <bst@pengutronix.de>

**Checklist**
- [ ] PR has been tested
