### PR TITLE
remote/client: remove unused variables from _get_ssh()

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -966,19 +966,15 @@ class ClientSession(ApplicationSession):
     def _get_ssh(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
-        env = os.environ.copy()
 
         from ..resource import NetworkService
         try:
-            resource = target.get_resource(NetworkService)
+            target.get_resource(NetworkService)
         except NoResourceFoundError:
             ip = self._get_ip(place)
             if not ip:
                 return
-            resource = NetworkService(target,
-                    address = str(ip),
-                    username = 'root',
-            )
+            NetworkService(target, address=str(ip), username='root')
 
         from ..driver.sshdriver import SSHDriver
         try:


### PR DESCRIPTION
**Description**
These are leftovers from the method prior to 77ee439
("driver/sshdriver: move interactive SSH access to the SSHDriver").

The instanciation of NetworkService is still needed to bind a
NetworkService with an IP of an EthernetPort resource to the target.

**Checklist**
- [x] PR has been tested