### PR TITLE
docs: improve library usage docs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -272,7 +272,7 @@ Used by:
 
 NetworkLXAIOBusPIO
 ++++++++++++++++++
-A NetworkLXAIOBusPIO descibes an `LXAIOBusPIO`_ exported over the network.
+A NetworkLXAIOBusPIO describes an `LXAIOBusPIO`_ exported over the network.
 
 HIDRelay
 ++++++++
@@ -418,15 +418,15 @@ Used by:
 
 NetworkMXSUSBLoader
 ~~~~~~~~~~~~~~~~~~~
-A NetworkMXSUSBLoader descibes an `MXSUSBLoader`_ available on a remote computer.
+A NetworkMXSUSBLoader describes an `MXSUSBLoader`_ available on a remote computer.
 
 NetworkIMXUSBLoader
 ~~~~~~~~~~~~~~~~~~~
-A NetworkIMXUSBLoader descibes an `IMXUSBLoader`_ available on a remote computer.
+A NetworkIMXUSBLoader describes an `IMXUSBLoader`_ available on a remote computer.
 
 NetworkRKUSBLoader
 ~~~~~~~~~~~~~~~~~~~
-A NetworkRKUSBLoader descibes an `RKUSBLoader`_ available on a remote computer.
+A NetworkRKUSBLoader describes an `RKUSBLoader`_ available on a remote computer.
 
 AndroidFastboot
 ~~~~~~~~~~~~~~~
@@ -664,7 +664,7 @@ Used by:
 
 NetworkFlashRom
 ~~~~~~~~~~~~~~~
-A NetworkFlashrom descibes an `Flashrom`_ available on a remote computer.
+A NetworkFlashrom describes a `Flashrom`_ available on a remote computer.
 
 XenaManager
 ~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2024,8 +2024,13 @@ Environment Configuration
 -------------------------
 The environment configuration for a test environment consists of a YAML file
 which contains targets, drivers and resources.
-The invocation order of objects is important here since drivers may depend on
-other drivers or resources.
+
+.. note::
+
+  The order is important here:
+  Objects are instantiated in the order they appear in the YAML file,
+  so if drivers depend on other drivers or resources which are only instantiated later,
+  loading the environment will fail.
 
 The skeleton for an environment consists of:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -229,8 +229,8 @@ Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
   FakeConsoleDriver(target=Target(name='main', …), name='console', …)
 
 After you are done with the target, optionally call the cleanup method on your
-target. While labgrid registers an atexit handler to cleanup targets, this has
-the advantage that exceptions can be handled by your application:::
+target. While labgrid registers an ``atexit`` handler to cleanup targets, this has
+the advantage that exceptions can be handled by your application::
 
   >>> try:
   >>>     target.cleanup()

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -204,7 +204,7 @@ Then, a :any:`Driver` needs to be created on the `Target`::
   >>> sd = SerialDriver(t, name=None)
 
 
-As the `SerialDriver` declares a binding to a SerialPort, the target binds it
+As the :any:`SerialDriver` declares a binding to a :any:`SerialPort`, the target binds it
 to the resource created above::
 
   >>> sd.port
@@ -217,8 +217,8 @@ Before the driver can be used, it needs to be activated::
   >>> t.activate(sd)
   >>> sd.write(b'test')
 
-Active drivers can be accessed by class (any `Driver` or `Protocol`) using some
-syntactic sugar::
+Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
+:any:`Protocol <labgrid.protocol>`) using some syntactic sugar::
 
   >>> target = Target('main')
   >>> console = FakeConsoleDriver(target, 'console')

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -171,8 +171,6 @@ Library
 labgrid can be used directly as a Python library, without the infrastructure
 provided by the pytest plugin.
 
-Creating and Configuring Targets
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The labgrid library provides two ways to configure targets with resources and
 drivers: either create the :any:`Target` directly or use :any:`Environment` to
 load a configuration file.
@@ -182,7 +180,7 @@ load a configuration file.
    targets using the python atexit module.
 
 Targets
-^^^^^^^
+~~~~~~~
 At the lower level, a :any:`Target` can be created directly::
 
   >>> from labgrid import Target
@@ -238,7 +236,7 @@ the advantage that exceptions can be handled by your application::
   >>>     <your code here>
 
 Environments
-^^^^^^^^^^^^
+~~~~~~~~~~~~
 In practice, is is often useful to separate the `Target` configuration from the
 code which needs to control the board (such as a test case or installation
 script).

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -181,6 +181,13 @@ load a configuration file.
 
 Targets
 ~~~~~~~
+
+.. note::
+   In most cases it is easier to :ref:`use a complete environment from a YAML
+   file <usage_environments>` instead of manually creating and activating objects.
+   Nevertheless, we explain this in the following to clarify the underlying concepts,
+   and how to work with targets on a lower level, e.g. in strategies.
+
 At the lower level, a :any:`Target` can be created directly::
 
   >>> from labgrid import Target
@@ -284,6 +291,8 @@ the advantage that exceptions can be handled by your application::
   >>>     target.cleanup()
   >>> except Exception as e:
   >>>     <your code here>
+
+.. _usage_environments:
 
 Environments
 ~~~~~~~~~~~~

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -186,34 +186,59 @@ At the lower level, a :any:`Target` can be created directly::
   >>> from labgrid import Target
   >>> t = Target('example')
 
-Next, the required :any:`Resources <Resource>` can be created::
+Next, any required :any:`Resource` objects can be created, which each represent
+a piece of hardware to be used with labgrid::
 
   >>> from labgrid.resource import RawSerialPort
   >>> rsp = RawSerialPort(t, name=None, port='/dev/ttyUSB0')
 
 .. note::
    Since we support multiple drivers of the same type, resources and drivers
-   have a required name attribute. If you don't require support for this
-   functionality set the name to `None`.
+   have a required ``name`` attribute. If you don't use multiple drivers of the
+   same type, you can set the name to ``None``.
 
-Then, a :any:`Driver` needs to be created on the `Target`::
+Further on, a :any:`Driver` encapsulates logic how to work with resources.
+Drivers need to be created on the :any:`Target`::
 
   >>> from labgrid.driver import SerialDriver
   >>> sd = SerialDriver(t, name=None)
 
-
 As the :any:`SerialDriver` declares a binding to a :any:`SerialPort`, the target binds it
-to the resource created above::
+to the resource object created above::
 
   >>> sd.port
   RawSerialPort(target=Target(name='example', env=None), name=None, state=<BindingState.bound: 1>, avail=True, port='/dev/ttyUSB0', speed=115200)
   >>> sd.port is rsp
   True
 
-Before the driver can be used, it needs to be activated::
+Driver Activation
+^^^^^^^^^^^^^^^^^
+Before a bound driver can be used, it needs to be activated.
+During activation, the driver makes sure that all hardware represented by the
+resources it is bound to can be used, and, if necessary, it acquires the
+underlying hardware on the OS level.
+For example, activating a :any:`SerialDriver` makes sure that the hardware
+represented by its bound :any:`RawSerialPort` object (e.g. something like
+``/dev/ttyUSB0``) is available, and that it can only be used labgrid and not by
+other applications while the :any:`SerialDriver` is activated.
+
+If we use a car analogy here, binding is the process of screwing the car parts
+together, and activation is igniting the engine.
+
+After activation, we can use the driver to do our work::
 
   >>> t.activate(sd)
   >>> sd.write(b'test')
+
+If an underlying hardware resource is not available (or not available after a
+certain timeout, depending on the driver), the activation step will raise an
+exception, e.g.::
+
+  >>> t.activate(sd)
+  Traceback (most recent call last):
+    File "/usr/lib/python3.8/site-packages/serial/serialposix.py", line 288, in open
+      self.fd = os.open(self.portstr, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+  FileNotFoundError: [Errno 2] No such file or directory: '/dev/ttyUSB0'
 
 Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
 :any:`Protocol <labgrid.protocol>`) using some syntactic sugar::
@@ -226,6 +251,31 @@ Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
   >>> target[FakeConsoleDriver, 'console']
   FakeConsoleDriver(target=Target(name='main', …), name='console', …)
 
+Driver Deactivation
+^^^^^^^^^^^^^^^^^^^
+Driver deactivation works in a similar manner::
+
+   >>> t.deactivate(sd)
+
+Drivers need to be deactivated in the following cases:
+
+* Some drivers have internal logic depending on the state of the target.
+  For example, the :any:`ShellDriver` remembers whether it has already logged
+  in to the shell.
+  If the target reboots, e.g. through a hardware watchdog timeout,
+  a power cycle, or by issuing a ``reboot`` command on the shell,
+  the ShellDriver's internal state becomes outdated,
+  and the ShellDriver needs to be deactivated and re-activated.
+
+* One of the driver's bound resources is required by another driver which is to
+  be activated.
+  For example, the :any:`ShellDriver` and the :any:`BareboxDriver` both
+  require access to a :any:`SerialPort` resource.
+  If both drivers are bound to the same resource object, labgrid will
+  automatically deactivate the BareboxDriver when activating the ShellDriver.
+
+Target Cleanup
+^^^^^^^^^^^^^^
 After you are done with the target, optionally call the cleanup method on your
 target. While labgrid registers an ``atexit`` handler to cleanup targets, this has
 the advantage that exceptions can be handled by your application::

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -20,6 +20,10 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     """BareboxDriver - Driver to control barebox via the console.
        BareboxDriver binds on top of a ConsoleProtocol.
 
+       On activation, the BareboxDriver will look for the barebox prompt on the
+       console, stopping any autoboot counters if necessary, and provide access
+       to the barebox shell.
+
     Args:
         prompt (str): The default Barebox Prompt
         bootstring (str): string that indicates that the Kernel is booting

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -25,6 +25,9 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     """ShellDriver - Driver to execute commands on the shell
     ShellDriver binds on top of a ConsoleProtocol.
 
+    On activation, the ShellDriver will look for the login prompt on the console,
+    and login to provide shell access.
+
     Args:
         prompt (regex): the shell prompt to detect
         login_prompt (regex): the login prompt to detect


### PR DESCRIPTION
The concept of "activation" is mentioned a few times in the docs, but it is explained nowhere. Try to change that by distilling the code from `labgrid.target.Target.activate()` into an explanation with an example. Also document how to create multiple resources of the same type and bind them to drivers through the API. While at it, add a few more links to the API doc, and throw in some smaller drive-by improvements to the docs.