### PR TITLE
driver/sshdriver: force no config when no hostname given

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -232,6 +232,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             dst = '_' + dst
 
         complete_cmd = ["scp",
+                "-F", "none",
                 "-o", "ControlPath={}".format(self.control.replace('%', '%%')),
                 src, dst,
         ]
@@ -255,6 +256,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             dst = '_' + dst
 
         ssh_cmd = ["ssh",
+                "-F", "none",
                 "-o", "ControlPath={}".format(self.control.replace('%', '%%')),
         ]
 
@@ -280,6 +282,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             raise ExecutionError("Keepalive no longer running")
 
         complete_cmd = ["sshfs",
+                "-F", "none",
                 "-f",
                 "-o", "ControlPath={}".format(self.control.replace('%', '%%')),
                 ":{}".format(path),

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -42,7 +42,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             self.ssh_prefix += ["-o", "PasswordAuthentication=no"]
 
         self.control = self._check_master()
-        self.ssh_prefix += ["-F", "/dev/null"]
+        self.ssh_prefix += ["-F", "none"]
         if self.control:
             self.ssh_prefix += ["-o", "ControlPath={}".format(self.control.replace('%', '%%'))]
 


### PR DESCRIPTION
**Description**
The scp/rsync/sshfs methods use the SSH control master. In these cases no valid hostname is required. Certain SSH config option combinations break this behavior, e.g.:

```
Host *
    CanonicalDomains          example.com
    CanonicalizePermittedCNAMEs *.example:*.example.com
```

This leads to:

`Could not resolve hostname _: Name or service not known`

or

`Could not resolve hostname : Name or service not known`

Fix this by forcing no config file for these commands.

**Checklist**
- [x] PR has been tested