### PR TITLE
driver/power: use target's name in ManualPowerDriver user prompts

### DIFF
--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -38,7 +38,7 @@ class ManualPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     @step()
     def on(self):
         self.target.interact(
-            "Turn the target {name} ON and press enter".format(name=self.name)
+            "Turn the target {name} ON and press enter".format(name=self.target.name)
         )
 
     @Driver.check_active
@@ -46,14 +46,14 @@ class ManualPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     def off(self):
         self.target.interact(
             "Turn the target {name} OFF and press enter".
-            format(name=self.name)
+            format(name=self.target.name)
         )
 
     @Driver.check_active
     @step()
     def cycle(self):
         self.target.interact(
-            "CYCLE the target {name} and press enter".format(name=self.name)
+            "CYCLE the target {name} and press enter".format(name=self.target.name)
         )
 
 

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -15,7 +15,7 @@ class TestManualPowerDriver:
         d.on()
 
         m.assert_called_once_with(
-            "Turn the target foo-board ON and press enter"
+            "Turn the target Test ON and press enter"
         )
 
     def test_off(self, target, mocker):
@@ -26,7 +26,7 @@ class TestManualPowerDriver:
         d.off()
 
         m.assert_called_once_with(
-            "Turn the target foo-board OFF and press enter"
+            "Turn the target Test OFF and press enter"
         )
 
     def test_cycle(self, target, mocker):
@@ -36,7 +36,7 @@ class TestManualPowerDriver:
         target.activate(d)
         d.cycle()
 
-        m.assert_called_once_with("CYCLE the target foo-board and press enter")
+        m.assert_called_once_with("CYCLE the target Test and press enter")
 
 
 class TestExternalPowerDriver:

--- a/tests/test_stepreporter.py
+++ b/tests/test_stepreporter.py
@@ -56,7 +56,7 @@ def test_step_reporter(power_env, pw_cycle_test, color_scheme, pytest_extra_para
         # exact match
         assert step_line.endswith("cycle state='start'")
 
-        spawn.expect("main: CYCLE the target None and press enter")
+        spawn.expect("main: CYCLE the target main and press enter")
         time.sleep(0.01) # ensure that the step measures a duration
         spawn.sendline()
 


### PR DESCRIPTION
**Description**
The user expects the name of the target instead of the name of the driver.

**Checklist**
- [x] PR has been tested
