### PR TITLE
sshdriver: include port in the ControlSocket name

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -62,7 +62,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         self.tmpdir = tempfile.mkdtemp(prefix='labgrid-ssh-tmp-')
         control = os.path.join(
-            self.tmpdir, 'control-{}'.format(self.networkservice.address)
+            self.tmpdir, 'control-{}-{}'.format(self.networkservice.address, self.networkservice.port)
         )
         # use sshpass if we have a password
         args = ["sshpass", "-e"] if self.networkservice.password else []


### PR DESCRIPTION
**Description**
Previously only the address was included in the ControlSocket name,
which leads to the SSHDriver killing the first connection by overwriting
the ControlSocket on the second connection. Include the port name in the
ControlSocket name to allow multiple connections to the same host on
different ports.

**Checklist**
- [ ] PR has been tested

Fixes #658 