### PR TITLE
driver/quartushpsdriver: support erase operation

### DIFF
--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -75,3 +75,19 @@ class QuartusHPSDriver(Driver):
             "--operation=P {}".format(mf.get_remote_path()),
         ]
         processwrapper.check_output(cmd)
+
+    @Driver.check_active
+    @step(args=['address', 'size'])
+    def erase(self, address=None, size=None):
+
+        cable_number = self._get_cable_number()
+        cmd = self.interface.command_prefix + [self.tool]
+        cmd += [
+            "--cable={}".format(cable_number),
+            "--operation=E",
+        ]
+        if address:
+            cmd += ["--addr=0x{:X}".format(address)]
+        if size:
+            cmd += ["--size=0x{:X}".format(size)]
+        processwrapper.check_output(cmd)


### PR DESCRIPTION
Beside flashing, erasing a region at a specific offset with a specific
size is a common operation with quartus_hps.

If 'size' is omited, everything starting from address will be erased.
If 'address' is omitted, a bulk erase of the entire device will be
performed.

Signed-off-by: Enrico Jorns <ejo@pengutronix.de>

**Description**

- [x] PR has been tested
