### PR TITLE
driver: add eaton epdu network power driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Release 0.5.0 (unreleased)
 
 New Features in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~
+- Support for Eaton ePDU added, and can be used as a NetworkPowerPort.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/examples/power/env.yaml
+++ b/examples/power/env.yaml
@@ -1,0 +1,10 @@
+targets:
+  main:
+    resources:
+      NetworkPowerPort:
+        model: eaton
+        host: 1.2.3.4
+        index: 1
+    drivers:
+      NetworkPowerDriver:
+        delay: 0.5

--- a/examples/power/power_example.py
+++ b/examples/power/power_example.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.fixture()
+def pdu(target):
+    return target.get_driver('NetworkPowerDriver')
+
+
+def test_something(pdu):
+    pdu.on()
+    # Note that the pdu might not have switched on when requesting it's
+    # status immediately
+    assert pdu.get() is True
+
+    # ... do something
+
+    pdu.off()
+    assert pdu.get() is False

--- a/labgrid/driver/power/eaton.py
+++ b/labgrid/driver/power/eaton.py
@@ -1,0 +1,66 @@
+from pysnmp import hlapi
+from ..exception import ExecutionError
+
+
+OID = ".1.3.6.1.4.1.534.6.6.7.6.6.1"
+NUMBER_OF_OUTLETS = 16
+
+
+class _Snmp:
+    """A class that helps wrap pysnmp"""
+    def __init__(self, host, community, port=161):
+        if port is None:
+            port = 161
+
+        self.engine = hlapi.SnmpEngine()
+        self.transport = hlapi.UdpTransportTarget((host, port))
+        self.community = hlapi.CommunityData(community, mpModel=0)
+        self.context = hlapi.ContextData()
+
+    def get(self, oid):
+        g = hlapi.getCmd(self.engine, self.community, self.transport,
+            self.context, hlapi.ObjectType(hlapi.ObjectIdentity(oid)),
+            lookupMib=False)
+
+        error_indication, error_status, _, res = next(g)
+        if error_indication or error_status:
+            raise ExecutionError("Failed to get SNMP value")
+        return res[0][1]
+
+    def set(self, oid, value):
+        identify = hlapi.ObjectType(hlapi.ObjectIdentity(oid),
+                   hlapi.Integer(value))
+        g = hlapi.setCmd(self.engine, self.community, self.transport,
+            self.context, identify, lookupMib=False)
+        next(g)
+
+
+def power_set(host, port, index, value):
+    assert 1 <= int(index) <= NUMBER_OF_OUTLETS
+
+    _snmp = _Snmp(host, 'public', port=port)
+    cmd_id = 4 if int(value) else 3
+    outlet_control_oid = "{}.{}.0.{}".format(OID, cmd_id, index)
+
+    _snmp.set(outlet_control_oid, 1)
+
+
+def power_get(host, port, index):
+    assert 1 <= int(index) <= NUMBER_OF_OUTLETS
+
+    _snmp = _Snmp(host, 'public', port=port)
+    output_status_oid = "{}.2.0.{}".format(OID, index)
+
+    value = _snmp.get(output_status_oid)
+
+    if value == 1:  # On
+        return True
+    if value == 0:  # Off
+        return False
+
+    if value == 3:  # Pending on - treat as on
+        return True
+    if value == 2:  # Pending off - treat as off
+        return False
+
+    raise ExecutionError("failed to get SNMP value")

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -162,6 +162,7 @@ class TestNetworkPowerDriver:
     def test_import_backends(self):
         import labgrid.driver.power
         import labgrid.driver.power.apc
+        import labgrid.driver.power.eaton
         import labgrid.driver.power.digipower
         import labgrid.driver.power.gude
         import labgrid.driver.power.gude24


### PR DESCRIPTION
The NetworkPowerDriver for the pdu uses PySNMP.

Signed-off-by: Nikolaj Rahbek <nikolaj@b2vn.org>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Added support for Eaton ePDU via SMNP. The resource is implements the NetworkPowerPort, and therefore works like other power drivers, e.g. the apc power driver.

An usage example has been added under `examples/power/`, and includes both an environment yaml and a pytest example.

The driver has been tested on Eaton eMMA10.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature - as a usage example
- [x] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested
