### PR TITLE
remote/config: allow use of environment variables in exporter config

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -61,6 +61,8 @@ New Features in 0.3.0
 - ``labgrid-client`` now respects the ``LG_HOSTNAME`` and ``LG_USERNAME``
   environment variables to set the hostname and username when accessing
   resources.
+- Exporter configuration file ``exporter.yaml`` now allows use of environment
+  variables.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2182,3 +2182,7 @@ Use ``#`` for line statements (like the for loops in the example) and ``##``
 for line comments.
 Statements like ``{{ 4000 + idx }}`` are expanded based on variables in the
 Jinja2 template.
+
+The template processing also supports use of OS environment variables, using
+something like `{{ env['FOOBAR'] }}` to insert the content of environment
+variable `FOOBAR`.

--- a/labgrid/remote/config.py
+++ b/labgrid/remote/config.py
@@ -2,6 +2,7 @@ from pprint import pprint
 
 import attr
 import jinja2
+import os
 
 from ..util.yaml import load
 from ..exceptions import NoConfigFoundError
@@ -23,7 +24,7 @@ class ResourceConfig:
             raise NoConfigFoundError(
                 "{} could not be found".format(self.filename)
             )
-        rendered = template.render()
+        rendered = template.render(env=os.environ)
         pprint(('rendered', rendered))
         self.data = load(rendered)
         pprint(('loaded', self.data))


### PR DESCRIPTION
**Description**

This extends the jinja2 templating support in exporter configuration file with
support for using OS environment variables, allowing for more flexibility when
using templated configurations for multiple exporters.

Tested locally by using a templated configuration with the group name
specified using an OS environment variable.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested