### PR TITLE
driver: qemudriver: prevent multiple -append QEMU arguments

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -141,6 +141,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 "if=pflash,format=raw,file={},id=nor0".format(
                     self.target.env.config.get_image_path(self.flash)))
 
+        if "-append" in shlex.split(self.extra_args):
+            raise ExecutionError("-append in extra_args not allowed, use boot_args instead")
+
         self._cmd.extend(shlex.split(self.extra_args))
         self._cmd.append("-S")
         self._cmd.append("-qmp")


### PR DESCRIPTION
**Description**
Various configuration parameters of the QEmuDriver lead to QEMU getting called with `-append`. This might not be obvious to the user. If the user specifies `-append` in `extra_args` instead of using `boot_args`, the `-append` argument in `extra_args` is ignored by QEMU. This happens because the last occurrence of `-append` is used, all other occurrences are silently ignored [1].

Add an explicit check to make sure no `-append` is given in `extra_args`, and suggest the usage of `boot_args` which leads to only a single `-append` being passed to QEMU.

[1] https://lists.gnu.org/archive/html/qemu-devel/2017-05/msg03214.html

**Checklist**
- [x] PR has been tested