### PR TITLE
Add sdwire driver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -495,6 +495,29 @@ NetworkUSBSDMuxDevice
 A :any:`NetworkUSBSDMuxDevice` resource describes a `USBSDMuxDevice`_ available
 on a remote computer.
 
+USBSDWireDevice
+~~~~~~~~~~~~~~~
+A :any:`USBSDWireDevice` resource describes a Tizen
+`SD Wire device <https://wiki.tizen.org/SDWire>`_
+device.
+
+.. code-block:: yaml
+
+   USBSDWireDevice:
+     match:
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
+
+- match (str): key and value for a udev match, see `udev Matching`_
+
+Used by:
+  - `USBSDWireDriver`_
+
+NetworkUSBSDWireDevice
+~~~~~~~~~~~~~~~~~~~~~~
+
+A :any:`NetworkUSBSDWireDevice` resource describes a `USBSDWireDevice`_ available
+on a remote computer.
+
 USBVideo
 ~~~~~~~~
 
@@ -1582,6 +1605,18 @@ USBSDMuxDriver
 ~~~~~~~~~~~~~~
 The :any:`USBSDMuxDriver` uses a USBSDMuxDevice resource to control a
 USB-SD-Mux device via `usbsdmux <https://github.com/pengutronix/usbsdmux>`_
+tool.
+
+Implements:
+  - None yet
+
+The driver can be used in test cases by calling the `set_mode()` function with
+argument being `dut`, `host`, `off`, or `client`.
+
+USBSDWireDriver
+~~~~~~~~~~~~~~~
+The :any:`USBSDWireDriver` uses a USBSDWireDevice resource to control a
+USB-SD-Wire device via `sd-mux-ctrl <https://wiki.tizen.org/SD_MUX#Software>`_
 tool.
 
 Implements:

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -16,6 +16,7 @@ from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
                          USBPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver, RKUSBDriver, UUUDriver
 from .usbsdmuxdriver import USBSDMuxDriver
+from .usbsdwiredriver import USBSDWireDriver
 from .common import Driver
 from .qemudriver import QEMUDriver
 from .modbusdriver import ModbusCoilDriver

--- a/labgrid/driver/usbsdwiredriver.py
+++ b/labgrid/driver/usbsdwiredriver.py
@@ -1,0 +1,40 @@
+# pylint: disable=no-member
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..step import step
+from .exception import ExecutionError
+from ..util.helper import processwrapper
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class USBSDWireDriver(Driver):
+    """The USBSDWireDriver uses the sd-mux-ctrl tool to control SDWire hardware
+
+    Args:
+        bindings (dict): driver to use with usbsdmux
+    """
+    bindings = {
+        "mux": {"USBSDWireDevice", "NetworkUSBSDWireDevice"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('sd-mux-ctrl') or 'sd-mux-ctrl'
+        else:
+            self.tool = 'sd-mux-ctrl'
+
+    @Driver.check_active
+    @step(title='sdmux_set', args=['mode'])
+    def set_mode(self, mode):
+        if not mode.lower() in ['dut', 'host']:
+            raise ExecutionError("Setting mode '%s' not supported by USBSDWireDriver" % mode)
+        cmd = self.mux.command_prefix + [
+            self.tool,
+            '--dut' if mode.lower() == "dut" else "--ts",
+            "-e",
+            self.mux.control_serial,
+        ]
+        processwrapper.check_output(cmd)

--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -29,7 +29,9 @@ class USBStorageDriver(Driver):
             "USBMassStorage",
             "NetworkUSBMassStorage",
             "USBSDMuxDevice",
-            "NetworkUSBSDMuxDevice"
+            "NetworkUSBSDMuxDevice",
+            "USBSDWireDevice",
+            "NetworkUSBSDWireDevice",
         },
     }
     image = attr.ib(

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -357,6 +357,25 @@ class USBSDMuxExport(USBGenericExport):
         }
 
 @attr.s(eq=False)
+class USBSDWireExport(USBGenericExport):
+    """ResourceExport for USB devices accessed directly from userspace"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': self.host,
+            'busnum': self.local.busnum,
+            'devnum': self.local.devnum,
+            'path': self.local.path,
+            'vendor_id': self.local.vendor_id,
+            'model_id': self.local.model_id,
+            'control_serial': self.local.control_serial,
+        }
+
+@attr.s(eq=False)
 class USBPowerPortExport(USBGenericExport):
     """ResourceExport for ports on switchable USB hubs"""
 
@@ -403,6 +422,7 @@ exports["AlteraUSBBlaster"] = USBGenericExport
 exports["SigrokUSBDevice"] = USBSigrokExport
 exports["SigrokUSBSerialDevice"] = USBSigrokExport
 exports["USBSDMuxDevice"] = USBSDMuxExport
+exports["USBSDWireDevice"] = USBSDWireExport
 
 exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -8,6 +8,7 @@ from .power import NetworkPowerPort
 from .remote import RemotePlace
 from .udev import USBSerialPort
 from .udev import USBSDMuxDevice
+from .udev import USBSDWireDevice
 from .udev import USBPowerPort
 from .common import Resource, ResourceManager, ManagedResource
 from .ykushpowerport import YKUSHPowerPort

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -209,6 +209,19 @@ class NetworkUSBSDMuxDevice(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkUSBSDWireDevice(RemoteUSBResource):
+    """The NetworkUSBSDWireDevice describes a remotely accessible USBSDWire device"""
+    control_serial = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkUSBPowerPort(RemoteUSBResource):
     """The NetworkUSBPowerPort describes a remotely accessible USB hub port with power switching"""
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -12,6 +12,7 @@ from .udev import (
     IMXUSBLoader,
     AndroidFastboot,
     USBSDMuxDevice,
+    USBSDWireDevice,
     AlteraUSBBlaster,
     RKUSBLoader,
     USBEthernetInterface,
@@ -37,6 +38,7 @@ class Suggester:
         self.resources.append(AndroidFastboot(**args))
         self.resources.append(USBMassStorage(**args))
         self.resources.append(USBSDMuxDevice(**args))
+        self.resources.append(USBSDWireDevice(**args))
         self.resources.append(AlteraUSBBlaster(**args))
         self.resources.append(RKUSBLoader(**args))
         self.resources.append(USBEthernetInterface(**args))


### PR DESCRIPTION
Adds a driver for the Tizen SDWire based device SD Card multiplexer.

This device is very similar to the already existing SDMux device (which
is distinct from the Tizen SDMux device on which SDWire is based).
The primary differences are:
 1) SDWire is controlled with the `sd-mux-ctrl` tool
 2) The serial number for SDWire devices is tied to the control chip
    (an FTDI-based GPIO solution).

See: https://wiki.tizen.org/SDWire

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
