### PR TITLE
remote/client: try protocols before driver

### DIFF
--- a/labgrid/exceptions.py
+++ b/labgrid/exceptions.py
@@ -28,3 +28,8 @@ class NoDriverFoundError(NoSupplierFoundError):
 @attr.s(eq=False)
 class NoResourceFoundError(NoSupplierFoundError):
     pass
+
+
+@attr.s(eq=False)
+class RegistrationError(Exception):
+    msg = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -1,7 +1,8 @@
 import inspect
 
-from .exceptions import InvalidConfigError
+from .exceptions import InvalidConfigError, RegistrationError
 from .util.dict import filter_dict
+
 
 class TargetFactory:
     def __init__(self):
@@ -13,6 +14,9 @@ class TargetFactory:
         """Register a resource with the factory.
 
         Returns the class to allow using it as a decorator."""
+        cls_name = cls.__name__
+        if cls_name in self.all_classes:
+            raise RegistrationError("resource with name {} was already registered".format(cls_name))
         self.resources[cls.__name__] = cls
         self._insert_into_all(cls)
         return cls
@@ -21,7 +25,10 @@ class TargetFactory:
         """Register a driver with the factory.
 
         Returns the class to allow using it as a decorator."""
-        self.drivers[cls.__name__] = cls
+        cls_name = cls.__name__
+        if cls_name in self.all_classes:
+            raise RegistrationError("driver with name {} was already registered".format(cls_name))
+        self.drivers[cls_name] = cls
         self._insert_into_all(cls)
         return cls
 
@@ -163,6 +170,7 @@ class TargetFactory:
         for cl in classes:
             if not self.all_classes.get(cl.__name__):
                 self.all_classes[cl.__name__] = cl
+
 
 #: Global TargetFactory instance
 #:

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -696,26 +696,30 @@ class ClientSession(ApplicationSession):
         from ..driver.powerdriver import NetworkPowerDriver, PDUDaemonDriver, USBPowerDriver
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort
+
         drv = None
-        for resource in target.resources:
-            if isinstance(resource, NetworkPowerPort):
-                try:
-                    drv = target.get_driver(NetworkPowerDriver)
-                except NoDriverFoundError:
-                    drv = NetworkPowerDriver(target, name=None, delay=delay)
-                break
-            elif isinstance(resource, NetworkUSBPowerPort):
-                try:
-                    drv = target.get_driver(USBPowerDriver)
-                except NoDriverFoundError:
-                    drv = USBPowerDriver(target, name=None, delay=delay)
-                break
-            elif isinstance(resource, PDUDaemonPort):
-                try:
-                    drv = target.get_driver(PDUDaemonDriver)
-                except NoDriverFoundError:
-                    drv = PDUDaemonDriver(target, name=None, delay=int(delay))
-                break
+        try:
+            drv = target.get_driver("PowerProtocol")
+        except NoDriverFoundError:
+            for resource in target.resources:
+                if isinstance(resource, NetworkPowerPort):
+                    try:
+                        drv = target.get_driver(NetworkPowerDriver)
+                    except NoDriverFoundError:
+                        drv = NetworkPowerDriver(target, name=None, delay=delay)
+                        break
+                elif isinstance(resource, NetworkUSBPowerPort):
+                    try:
+                        drv = target.get_driver(USBPowerDriver)
+                    except NoDriverFoundError:
+                        drv = USBPowerDriver(target, name=None, delay=delay)
+                        break
+                elif isinstance(resource, PDUDaemonPort):
+                    try:
+                        drv = target.get_driver(PDUDaemonDriver)
+                    except NoDriverFoundError:
+                        drv = PDUDaemonDriver(target, name=None, delay=int(delay))
+                        break
         if not drv:
             raise UserError("target has no compatible resource available")
         target.activate(drv)
@@ -743,43 +747,47 @@ class ClientSession(ApplicationSession):
         from ..driver.deditecrelaisdriver import DeditecRelaisDriver
         from ..driver.gpiodriver import GpioDigitalOutputDriver
         from ..driver.lxaiobusdriver import LXAIOBusPIODriver
+
         drv = None
-        for resource in target.resources:
-            if isinstance(resource, ModbusTCPCoil):
-                try:
-                    drv = target.get_driver(ModbusCoilDriver, name=name)
-                except NoDriverFoundError:
-                    target.set_binding_map({"coil": name})
-                    drv = ModbusCoilDriver(target, name=name)
-                break
-            elif isinstance(resource, OneWirePIO):
-                try:
-                    drv = target.get_driver(OneWirePIODriver, name=name)
-                except NoDriverFoundError:
-                    target.set_binding_map({"port": name})
-                    drv = OneWirePIODriver(target, name=name)
-                break
-            elif isinstance(resource, NetworkDeditecRelais8):
-                try:
-                    drv = target.get_driver(DeditecRelaisDriver, name=name)
-                except NoDriverFoundError:
-                    target.set_binding_map({"relais": name})
-                    drv = DeditecRelaisDriver(target, name=name)
-                break
-            elif isinstance(resource, NetworkSysfsGPIO):
-                try:
-                    drv = target.get_driver(GpioDigitalOutputDriver, name=name)
-                except NoDriverFoundError:
-                    target.set_binding_map({"gpio": name})
-                    drv = GpioDigitalOutputDriver(target, name=name)
-                break
-            elif isinstance(resource, NetworkLXAIOBusPIO):
-                try:
-                    drv = target.get_driver(LXAIOBusPIODriver, name=name)
-                except NoDriverFoundError:
-                    target.set_binding_map({"pio": name})
-                    drv = LXAIOBusPIODriver(target, name=name)
-                break
+        try:
+            drv = target.get_driver("DigitalOutputProtocol")
+        except NoDriverFoundError:
+            for resource in target.resources:
+                if isinstance(resource, ModbusTCPCoil):
+                    try:
+                        drv = target.get_driver(ModbusCoilDriver, name=name)
+                    except NoDriverFoundError:
+                        target.set_binding_map({"coil": name})
+                        drv = ModbusCoilDriver(target, name=name)
+                        break
+                elif isinstance(resource, OneWirePIO):
+                    try:
+                        drv = target.get_driver(OneWirePIODriver, name=name)
+                    except NoDriverFoundError:
+                        target.set_binding_map({"port": name})
+                        drv = OneWirePIODriver(target, name=name)
+                        break
+                elif isinstance(resource, NetworkDeditecRelais8):
+                    try:
+                        drv = target.get_driver(DeditecRelaisDriver, name=name)
+                    except NoDriverFoundError:
+                        target.set_binding_map({"relais": name})
+                        drv = DeditecRelaisDriver(target, name=name)
+                        break
+                elif isinstance(resource, NetworkSysfsGPIO):
+                    try:
+                        drv = target.get_driver(GpioDigitalOutputDriver, name=name)
+                    except NoDriverFoundError:
+                        target.set_binding_map({"gpio": name})
+                        drv = GpioDigitalOutputDriver(target, name=name)
+                        break
+                elif isinstance(resource, NetworkLXAIOBusPIO):
+                    try:
+                        drv = target.get_driver(LXAIOBusPIODriver, name=name)
+                    except NoDriverFoundError:
+                        target.set_binding_map({"pio": name})
+                        drv = LXAIOBusPIODriver(target, name=name)
+                        break
         if not drv:
             raise UserError("target has no compatible resource available")
         target.activate(drv)

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -111,7 +111,7 @@ class Target:
         found = []
         other_names = []
         if isinstance(cls, str):
-            cls = self._reg_class_from_string(cls)
+            cls = target_factory.class_from_string(cls)
 
         for res in self.resources:
             if not isinstance(res, cls):
@@ -146,7 +146,7 @@ class Target:
         found = []
         other_names = []
         if isinstance(cls, str):
-            cls = self._reg_class_from_string(cls)
+            cls = target_factory.class_from_string(cls)
 
         for drv in self.drivers:
             if not isinstance(drv, cls):
@@ -236,7 +236,7 @@ class Target:
         elif len(key) == 2:
             cls, name = key
         if isinstance(cls, str):
-            cls = self._reg_class_from_string(cls)
+            cls = target_factory.class_from_string(cls)
         if not issubclass(cls, (Driver, abc.ABC)): # all Protocols derive from ABC
             raise NoDriverFoundError(
                 "invalid driver class {}".format(cls)
@@ -403,7 +403,7 @@ class Target:
             return
 
         if isinstance(client, str):
-            cls = self._reg_class_from_string(client)
+            cls = target_factory.class_from_string(client)
             client = self._get_driver(cls, name=name, activate=False, active=False)
 
         assert client is not None
@@ -440,7 +440,7 @@ class Target:
         This is needed to ensure that no client has an inactive supplier.
         """
         if isinstance(client, str):
-            cls = self._reg_class_from_string(client)
+            cls = target_factory.class_from_string(client)
             client = self._get_driver(cls, name=name, activate=False, active=True)
 
         assert client is not None
@@ -481,9 +481,3 @@ class Target:
         self.deactivate_all_drivers()
         for res in reversed(self.resources):
             self.deactivate(res)
-
-    def _reg_class_from_string(self, string: str):
-        try:
-            return self._lookup_table[string]
-        except KeyError:
-            raise KeyError("No driver/resource/protocol of type '{}' in lookup table, perhaps not bound?".format(string))  # pylint: disable=line-too-long

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,158 +1,193 @@
 from collections import OrderedDict
 
+import attr
 import pytest
 
 from labgrid import Target, target_factory
-from labgrid.exceptions import InvalidConfigError
+from labgrid.driver import Driver
+from labgrid.resource import Resource
+from labgrid.exceptions import InvalidConfigError, RegistrationError
 from labgrid.resource import SerialPort
 from labgrid.util.yaml import load
 
-class TestTargetFactory:
-    def test_empty(self):
-        t = target_factory.make_target('dummy', {})
-        assert isinstance(t, Target)
+def test_empty():
+    t = target_factory.make_target('dummy', {})
+    assert isinstance(t, Target)
 
-    def test_resources(self):
-        t = target_factory.make_target(
-            'dummy', {
-                'resources': OrderedDict([
-                    ('RawSerialPort', {
-                        'port': 'foo',
-                        'speed': 115200
-                    }),
-                ]),
-            }
-        )
-        assert isinstance(t, Target)
-        assert t.get_resource(SerialPort) is not None
 
-    def test_drivers(self):
-        t = target_factory.make_target(
-            'dummy', {
-                'resources': OrderedDict([
-                    ('RawSerialPort', {
-                        'port': 'foo',
-                        'speed': 115200
-                    }),
-                ]),
-                'drivers': OrderedDict([
-                    ('FakeConsoleDriver', {}),
-                    ('ShellDriver', {
-                        'prompt': '',
-                        'login_prompt': '',
-                        'username': ''
-                    }),
-                ]),
-            }
-        )
-        assert isinstance(t, Target)
-        assert t.get_resource(SerialPort) is not None
+def test_resources():
+    t = target_factory.make_target(
+        'dummy', {
+            'resources': OrderedDict([
+                ('RawSerialPort', {
+                    'port': 'foo',
+                    'speed': 115200
+                }),
+            ]),
+        }
+    )
+    assert isinstance(t, Target)
+    assert t.get_resource(SerialPort) is not None
 
-    def test_convert_dict(self):
+
+def test_drivers():
+    t = target_factory.make_target(
+        'dummy', {
+            'resources': OrderedDict([
+                ('RawSerialPort', {
+                    'port': 'foo',
+                    'speed': 115200
+                }),
+            ]),
+            'drivers': OrderedDict([
+                ('FakeConsoleDriver', {}),
+                ('ShellDriver', {
+                    'prompt': '',
+                    'login_prompt': '',
+                    'username': ''
+                }),
+            ]),
+        }
+    )
+    assert isinstance(t, Target)
+    assert t.get_resource(SerialPort) is not None
+
+
+def test_convert_dict():
+    data = load("""
+    FooPort: {}
+    BarPort:
+      name: bar
+    """)
+    l = target_factory._convert_to_named_list(data)
+    assert l == [
+        {
+            'cls': 'FooPort',
+            'name': None,
+        },
+        {
+            'cls': 'BarPort',
+            'name': 'bar'
+        },
+    ]
+
+
+def test_convert_simple_list():
+    data = load("""
+    - FooPort: {}
+    - BarPort:
+        name: bar
+    """)
+    l = target_factory._convert_to_named_list(data)
+    assert l == [
+        {
+            'cls': 'FooPort',
+            'name': None,
+        },
+        {
+            'cls': 'BarPort',
+            'name': 'bar'
+        },
+    ]
+
+
+def test_convert_explicit_list():
+    data = load("""
+    - cls: FooPort
+    - cls: BarPort
+      name: bar
+    """)
+    l = target_factory._convert_to_named_list(data)
+    assert l == [
+        {
+            'cls': 'FooPort',
+            'name': None,
+        },
+        {
+            'cls': 'BarPort',
+            'name': 'bar'
+        },
+    ]
+
+
+def test_convert_error():
+    with pytest.raises(InvalidConfigError) as excinfo:
         data = load("""
-        FooPort: {}
-        BarPort:
-          name: bar
+        - {}
         """)
-        l = target_factory._convert_to_named_list(data)
-        assert l == [
-            {
-                'cls': 'FooPort',
-                'name': None,
-            },
-            {
-                'cls': 'BarPort',
-                'name': 'bar'
-            },
-        ]
+        target_factory._convert_to_named_list(data)
+    assert "invalid empty dict as list item" in excinfo.value.msg
 
-    def test_convert_simple_list(self):
+    with pytest.raises(InvalidConfigError) as excinfo:
         data = load("""
-        - FooPort: {}
-        - BarPort:
-            name: bar
+        - "error"
         """)
-        l = target_factory._convert_to_named_list(data)
-        assert l == [
-            {
-                'cls': 'FooPort',
-                'name': None,
-            },
-            {
-                'cls': 'BarPort',
-                'name': 'bar'
-            },
-        ]
+        target_factory._convert_to_named_list(data)
+    assert "invalid list item type <class 'str'> (should be dict)" in excinfo.value.msg
 
-    def test_convert_explicit_list(self):
+    with pytest.raises(InvalidConfigError) as excinfo:
         data = load("""
-        - cls: FooPort
-        - cls: BarPort
-          name: bar
+        - name: "bar"
+          extra: "baz"
         """)
-        l = target_factory._convert_to_named_list(data)
-        assert l == [
-            {
-                'cls': 'FooPort',
-                'name': None,
-            },
-            {
-                'cls': 'BarPort',
-                'name': 'bar'
-            },
-        ]
+        target_factory._convert_to_named_list(data)
+    assert "missing 'cls' key in OrderedDict(" in excinfo.value.msg
 
-    def test_convert_error(self):
-        with pytest.raises(InvalidConfigError) as excinfo:
-            data = load("""
-            - {}
-            """)
-            target_factory._convert_to_named_list(data)
-        assert "invalid empty dict as list item" in excinfo.value.msg
+    with pytest.raises(InvalidConfigError) as excinfo:
+        data = load("""
+        - one:
+        - two: {}
+        """)
+        target_factory._convert_to_named_list(data)
+    assert "invalid list item, add empty dict for no arguments" in excinfo.value.msg
 
-        with pytest.raises(InvalidConfigError) as excinfo:
-            data = load("""
-            - "error"
-            """)
-            target_factory._convert_to_named_list(data)
-        assert "invalid list item type <class 'str'> (should be dict)" in excinfo.value.msg
 
-        with pytest.raises(InvalidConfigError) as excinfo:
-            data = load("""
-            - name: "bar"
-              extra: "baz"
-            """)
-            target_factory._convert_to_named_list(data)
-        assert "missing 'cls' key in OrderedDict(" in excinfo.value.msg
+def test_resource_param_error():
+    with pytest.raises(InvalidConfigError) as excinfo:
+        target_factory.make_resource(
+            None, 'NetworkSerialPort', 'serial', {'port': None})
+    assert "failed to create" in excinfo.value.msg
 
-        with pytest.raises(InvalidConfigError) as excinfo:
-            data = load("""
-            - one:
-            - two: {}
-            """)
-            target_factory._convert_to_named_list(data)
-        assert "invalid list item, add empty dict for no arguments" in excinfo.value.msg
 
-    def test_resource_param_error(self):
-        with pytest.raises(InvalidConfigError) as excinfo:
-            target_factory.make_resource(
-                None, 'NetworkSerialPort', 'serial', {'port': None})
-        assert "failed to create" in excinfo.value.msg
+def test_driver_param_error():
+    with pytest.raises(InvalidConfigError) as excinfo:
+        target_factory.make_driver(
+            None, 'QEMUDriver', 'qemu', {'cpu': 'arm'})
+    assert "failed to create" in excinfo.value.msg
 
-    def test_driver_param_error(self):
-        with pytest.raises(InvalidConfigError) as excinfo:
-            target_factory.make_driver(
-                None, 'QEMUDriver', 'qemu', {'cpu': 'arm'})
-        assert "failed to create" in excinfo.value.msg
 
-    def test_resource_class_error(self):
-        with pytest.raises(InvalidConfigError) as excinfo:
-            target_factory.make_resource(
-                None, 'UnknownResource', None, {})
-        assert "unknown resource class" in excinfo.value.msg
+def test_resource_class_error():
+    with pytest.raises(InvalidConfigError) as excinfo:
+        target_factory.make_resource(
+            None, 'UnknownResource', None, {})
+    assert "unknown resource class" in excinfo.value.msg
 
-    def test_driver_class_error(self):
-        with pytest.raises(InvalidConfigError) as excinfo:
-            target_factory.make_driver(
-                None, 'UnknownDriver', None, {})
-        assert "unknown driver class" in excinfo.value.msg
+
+def test_driver_class_error():
+    with pytest.raises(InvalidConfigError) as excinfo:
+        target_factory.make_driver(
+            None, 'UnknownDriver', None, {})
+    assert "unknown driver class" in excinfo.value.msg
+
+
+def test_register_same_driver():
+
+    @attr.s
+    class SameDriver(Driver):
+        pass
+
+    with pytest.raises(RegistrationError) as excinfo:
+        target_factory.reg_driver(SameDriver)
+        target_factory.reg_driver(SameDriver)
+    assert "driver with name" in excinfo.value.msg
+
+def test_register_same_resource():
+
+    @attr.s
+    class SameResource(Resource):
+        pass
+
+    with pytest.raises(RegistrationError) as excinfo:
+        target_factory.reg_driver(SameResource)
+        target_factory.reg_driver(SameResource)
+    assert "driver with name" in excinfo.value.msg

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -4,7 +4,7 @@ import re
 import attr
 import pytest
 
-from labgrid import Target
+from labgrid import Target, target_factory
 from labgrid.binding import BindingError
 from labgrid.resource import Resource
 from labgrid.driver import Driver
@@ -269,9 +269,11 @@ def test_get_by_string(target):
     class AProtocol(abc.ABC):
         pass
 
+    @target_factory.reg_driver
     class A(Driver, AProtocol):
         pass
 
+    @target_factory.reg_driver
     class C(Resource):
         pass
 
@@ -355,23 +357,25 @@ def test_get_by_default_priority(target):
 
 def test_target_deactivate_by_string(target):
 
+    @target_factory.reg_driver
     @attr.s
-    class A(Driver):
+    class ADea(Driver):
         pass
 
-    a = A(target, None)
+    a = ADea(target, None)
     target.activate(a)
-    target.deactivate("A")
+    target.deactivate("ADea")
 
-    assert a == target.get_driver(A, activate=False)
+    assert a == target.get_driver(ADea, activate=False)
 
 def test_target_activate_by_string(target):
 
+    @target_factory.reg_driver
     @attr.s
-    class A(Driver):
+    class AActiv(Driver):
         pass
 
-    a = A(target, None)
-    target.activate("A")
+    a = AActiv(target, None)
+    target.activate("AActiv")
 
-    assert a == target.get_active_driver(A)
+    assert a == target.get_active_driver(AActiv)


### PR DESCRIPTION
For the power and digital_io command, try to get a bound driver via
protocol first. This way already instanced drivers from a passed in
environment file can be chosen, even if they are not part of upstream
labgrid, or require a driver as a supplier.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

- [x] PR has been tested