### PR TITLE
Introduce logging step reporter and logging serial reporter

### DIFF
--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -1,5 +1,6 @@
 import enum
 from functools import wraps
+import logging
 
 import attr
 
@@ -100,6 +101,20 @@ class BindingMixin:
             return func(self, *_args, **_kwargs)
 
         return wrapper
+
+    def get_logger(self):
+        if self.name:
+            return logging.getLogger("{}.{}.{}".format(
+                self.target.name, self.__class__.__name__, self.name
+            ))
+        elif self.target:
+            return logging.getLogger("{}.{}".format(
+                self.target.name, self.__class__.__name__
+            ))
+        else:
+            return logging.getLogger("{}".format(
+                self.__class__.__name__
+            ))
 
     class NamedBinding:
         """

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -62,7 +62,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         self._status = 0
 
     @Driver.check_active
-    @step(args=['cmd'])
+    @step(args=['cmd'], result=True)
     def run(self, cmd: str, *, timeout: int = 30):  # pylint: disable=unused-argument
         return self._run(cmd, timeout=timeout)
 

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -43,7 +43,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         self.re_vt100 = re.compile(
             r'(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]'
         )
-        self.logger = logging.getLogger("{}:{}".format(self, self.target))
+        self.logger = self.get_logger()
         self._status = 0
 
     def on_activate(self):

--- a/labgrid/driver/dockerdriver.py
+++ b/labgrid/driver/dockerdriver.py
@@ -62,7 +62,7 @@ class DockerDriver(PowerProtocol, Driver):
             attr.validators.instance_of(list)))
 
     def __attrs_post_init__(self):
-        self.logger = logging.getLogger("{}({})".format(self, self.target))
+        self.logger = self.get_logger()
         super().__attrs_post_init__()
         self._client = None
         self._container = None

--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -25,7 +25,7 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}({})".format(self, self.target))
+        self.logger = self.get_logger()
         self.status = 0  #pylint: disable=attribute-defined-outside-init
         self._child = None
         self.open()

--- a/labgrid/driver/fake.py
+++ b/labgrid/driver/fake.py
@@ -18,7 +18,7 @@ class FakeConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}({})".format(self, self.target))
+        self.logger = self.get_logger()
         self.rxq = []
         self.txq = []
 

--- a/labgrid/driver/flashromdriver.py
+++ b/labgrid/driver/flashromdriver.py
@@ -25,7 +25,7 @@ class FlashromDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger('{}'.format(self))
+        self.logger = self.get_logger()
         if self.target.env:
             self.tool = self.target.env.config.get_tool('flashrom')
         else:

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -48,7 +48,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}:{}".format(self, self.target))
+        self.logger = self.get_logger()
 
         # FIXME make sure we always have an environment or config
         if self.target.env:

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -73,7 +73,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}:".format(self))
+        self.logger = self.get_logger()
         self.status = 0
         self.txdelay = None
         self._child = None

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -39,7 +39,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}({})".format(self, self.target))
+        self.logger = self.get_logger()
         if isinstance(self.port, SerialPort):
             self.serial = serial.Serial()
         else:

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -58,7 +58,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         self.re_vt100 = re.compile(
             r'(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]'
         )  # pylint: disable=attribute-defined-outside-init,anomalous-backslash-in-string
-        self.logger = logging.getLogger("{}:{}".format(self, self.target))
+        self.logger = self.get_logger()
         self._status = 0  # pylint: disable=attribute-defined-outside-init
 
         self._xmodem_cached_rx_cmd = ""

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -37,7 +37,7 @@ class SigrokCommon(Driver):
             ) or 'sigrok-cli'
         else:
             self.tool = 'sigrok-cli'
-        self.log = logging.getLogger("SigrokDriver")
+        self.log = self.get_logger()
         self._running = False
 
     def _create_tmpdir(self):

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -33,7 +33,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}({})".format(self, self.target))
+        self.logger = self.get_logger()
         self._keepalive = None
 
     def on_activate(self):

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -51,7 +51,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         self.re_vt100 = re.compile(
             r'(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]'
         )
-        self.logger = logging.getLogger("{}:{}".format(self, self.target))
+        self.logger = self.get_logger()
         self._status = 0
 
     def on_activate(self):

--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -45,7 +45,7 @@ class USBStorageDriver(Driver):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}:{}".format(self, self.target))
+        self.logger = self.get_logger()
 
     def on_activate(self):
         pass

--- a/labgrid/driver/xenadriver.py
+++ b/labgrid/driver/xenadriver.py
@@ -17,7 +17,7 @@ class XenaDriver(Driver):
         super().__attrs_post_init__()
         self._xena_app = import_module('xenavalkyrie.xena_app')
         self._tgn_utils = import_module('trafficgenerator.tgn_utils')
-        self._logger = logging.getLogger("{}".format(self))
+        self._logger = self.get_logger()
         self._xm = None
 
     def on_activate(self):

--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -47,6 +47,16 @@ def pytest_addoption(parser):
         dest='lg_initial_state',
         metavar='STATE_NAME',
         help='set the strategy\'s initial state (during development)')
+    group.addoption(
+        '--lg-logging-indent',
+        action='store_true',
+        dest='lg_logging_indent',
+        help='Enable indentation for steps in the logging output')
+    group.addoption(
+        '--lg-logging-long-results',
+        action='store_true',
+        dest='lg_logging_long_results',
+        help='Enable output of long step results in the logging output')
 
 
 @pytest.fixture(scope="session")

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -6,6 +6,7 @@ import pytest
 from .. import Environment
 from ..consoleloggingreporter import ConsoleLoggingReporter
 from .reporter import StepReporter, ColoredStepReporter
+from ..stepreporter import StepLoggingReporter, SerialLoggingReporter
 from ..util.helper import processwrapper
 
 @pytest.hookimpl(trylast=True)
@@ -27,6 +28,11 @@ def pytest_configure(config):
         logging.getLogger().setLevel(logging.DEBUG)
     if lg_log:
         ConsoleLoggingReporter(lg_log)
+    slr = SerialLoggingReporter()
+    StepLoggingReporter(config.option.lg_logging_indent,
+                        config.option.lg_logging_long_results,
+                        slr)
+
     env_config = config.option.env_config
     lg_env = config.option.lg_env
     lg_coordinator = config.option.lg_coordinator

--- a/labgrid/resource/docker.py
+++ b/labgrid/resource/docker.py
@@ -34,7 +34,7 @@ class DockerManager(ResourceManager):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.log = logging.getLogger('DockerManager')
+        self.log = logging.getLogger('labgrid.DockerManager')
         self._client = dict()
         self._docker_daemons_cleaned = list()
 
@@ -90,7 +90,7 @@ class DockerDaemon(ManagedResource):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         self._nw_services = dict()
-        self.log = logging.getLogger('DockerContainer')
+        self.log = self.get_logger()
         self.timeout = 5.0
         self.avail = True
 

--- a/labgrid/resource/ethernetport.py
+++ b/labgrid/resource/ethernetport.py
@@ -13,7 +13,7 @@ class SNMPSwitch:
     hostname = attr.ib(validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
-        self.logger = logging.getLogger("{}".format(self))
+        self.logger = self.get_logger()
         self.ports = {}
         self.fdb = {}
         self.macs_by_port = {}
@@ -182,7 +182,7 @@ class EthernetPortManager(ResourceManager):
     """The EthernetPortManager periodically polls the switch for new updates."""
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}".format(self))
+        self.logger = "labgrid.{}".format(self.__class__.__name__)
         self.loop = None
         self.poll_tasks = []
         self.switches = {}

--- a/labgrid/resource/lxaiobus.py
+++ b/labgrid/resource/lxaiobus.py
@@ -13,7 +13,7 @@ class LXAIOBusNodeManager(ResourceManager):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
-        self.log = logging.getLogger('LXAIOBusNodeManager')
+        self.log = logging.getLogger('labgrid.LXAIOBusNodeManager')
 
         self._last = 0.0
 

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -10,7 +10,9 @@ from .common import NetworkResource, ManagedResource, ResourceManager
 class RemotePlaceManager(ResourceManager):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger("{}".format(self))
+        self.logger = logging.getLogger("labgrid.{}".format(
+            self.__class__.__name__
+        ))
         self.url = None
         self.realm = None
         self.loop = None

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -20,7 +20,7 @@ class UdevManager(ResourceManager):
         super().__attrs_post_init__()
         self.queue = queue.Queue()
 
-        self.log = logging.getLogger('UdevManager')
+        self.log = logging.getLogger('labgrid.UdevManager')
         self._context = pyudev.Context()
         self._monitor = pyudev.Monitor.from_netlink(self._context)
         self._observer = pyudev.MonitorObserver(self._monitor,
@@ -60,7 +60,7 @@ class USBResource(ManagedResource):
 
     def __attrs_post_init__(self):
         self.timeout = 5.0
-        self.log = logging.getLogger('USBResource')
+        self.log = self.get_logger()
         self.match.setdefault('SUBSYSTEM', 'usb')
         super().__attrs_post_init__()
 

--- a/labgrid/stepreporter.py
+++ b/labgrid/stepreporter.py
@@ -1,4 +1,11 @@
+import logging
+import pprint
+import re
+
+import attr
+
 from .step import steps
+from .protocol import ConsoleProtocol
 
 
 class StepReporter:
@@ -29,3 +36,120 @@ class StepReporter:
         step = event.step
         indent = '  '*step.level
         print("{}{}".format(indent, event))
+
+
+@attr.s
+class StepGetLoggerMixin:
+    @staticmethod
+    def get_logger(step):
+        if step.source.name:
+            return logging.getLogger("{}.{}.{}".format(
+                step.source.target.name, step.source.__class__.__name__, step.source.name
+            ))
+        else:
+            return logging.getLogger("{}.{}".format(
+                step.source.target.name, step.source.__class__.__name__
+            ))
+
+
+@attr.s
+class SerialLoggingReporter(StepGetLoggerMixin):
+    bufs = attr.ib(default=attr.Factory(dict), validator=attr.validators.instance_of(dict))
+    loggers = attr.ib(default=attr.Factory(dict), validator=attr.validators.instance_of(dict))
+    re_vt100 = attr.ib(
+        default=re.compile(
+            r'(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]'
+        ))
+
+    def __attrs_post_init__(self):
+        steps.subscribe(self.notify)
+
+    def notify(self, event):
+        step = event.step
+        if step.tag == 'console' and str(step) == 'read' \
+           and event.data.get('state') == 'stop' and step.result:
+            self.loggers[step.source] = self.get_logger(step)
+            logger = self.loggers[step.source]
+            if step.source not in self.bufs.keys():
+                self.bufs[step.source] = b''
+            self.bufs[step.source] += step.result
+            *parts, self.bufs[step.source] = self.bufs[step.source].split(b'\r\n')
+            for part in parts:
+                data = self.re_vt100.sub('', part.decode("utf-8", errors="replace"))
+                logger.info("{}␍␤".format(data))
+
+    def flush(self):
+        for source, logger in self.loggers.items():
+            data = self.re_vt100.sub('', self.bufs[source].decode("utf-8", errors="replace"))
+            if data:
+                logger.info(data)
+            self.bufs[source] = b""
+
+
+@attr.s
+class StepLoggingReporter(StepGetLoggerMixin):
+    indent = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    long_result = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    serial_reporter = attr.ib(default=None,
+                              validator=attr.validators.optional(
+                                  attr.validators.instance_of(SerialLoggingReporter)))
+
+    def __attrs_post_init__(self):
+        steps.subscribe(self.notify)
+
+    def notify(self, event):
+        # ignore tagged events
+        if event.step.tag:
+            return
+        if self.serial_reporter:
+            self.serial_reporter.flush()
+
+        self._line_format(event)
+
+    @staticmethod
+    def format_arguments(args):
+        if args is None:
+            return ""
+        if isinstance(args, dict):
+            collected_args = []
+            for k, v in args.items():
+                collected_args.append("{}={}".format(k, v))
+
+            return "".join(collected_args)
+        else:
+            return "{}".format(args)
+
+    @staticmethod
+    def format_duration(duration):
+        if duration < 0.001:
+            return ""
+
+        return "[{:.3f}s]".format(duration)
+
+    def format_result(self, result):
+        if result is None:
+            return ""
+
+        if self.long_result:
+            return "result={} ".format(result)
+
+        if len(str(result)) < 20:
+            return "result={} ".format(result)
+        else:
+            return "result={:.19}… ".format(repr(result))
+
+    def _line_format(self, event):
+        indent = "  "*event.step.level if self.indent else ""
+        step = event.step
+
+        logger = self.get_logger(step)
+        prefix = "→" if event.data.get("state") == "start" else "←"
+        if event.step.exception:
+            prefix = "⚠"
+        title = '{} {}'.format(prefix, event.step.title)
+        line = ["{}({}) {}{}".format(title,
+                                     self.format_arguments(event.data.get('args', {})),
+                                     self.format_result(event.data.get('result', None)),
+                                     self.format_duration(event.data.get('duration', 0.0)))
+                ]
+        logger.info("%s%s", indent, line[0])

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -20,7 +20,7 @@ class Target:
     env = attr.ib(default=None)
 
     def __attrs_post_init__(self):
-        self.log = logging.getLogger("target({})".format(self.name))
+        self.log = logging.getLogger("{}.{}".format(self.name, self.__class__.__name__))
         self.resources = []
         self.drivers = []
         self.last_update = 0.0

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -34,7 +34,7 @@ class ProcessWrapper:
     @step(args=['command'], result=True, tag='process')
     def check_output(self, command, *, print_on_silent_log=False):
         """Run a command and supply the output to callback functions"""
-        logger = logging.getLogger("Process")
+        logger = logging.getLogger("labgrid.process")
         res = []
         mfd, sfd = pty.openpty()
         flags = fcntl.fcntl(mfd, fcntl.F_GETFL)
@@ -114,7 +114,7 @@ class ProcessWrapper:
     @staticmethod
     def log_callback(message, process):
         """Logs process output message along with its pid."""
-        logger = logging.getLogger("Process")
+        logger = logging.getLogger("labgrid.process")
         message = message.decode(encoding="utf-8", errors="replace").strip("\n")
         if message:
             logger.log(ProcessWrapper.loglevel, "[%d] %s", process.pid, message)

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -40,7 +40,7 @@ class ManagedFile:
     def __attrs_post_init__(self):
         if not os.path.isfile(self.local_path):
             raise FileNotFoundError("Local file {} not found".format(self.local_path))
-        self.logger = logging.getLogger("{}".format(self))
+        self.logger = logging.getLogger("labgrid.{}".format(self.__class__.__name__))
         self.hash = None
         self.rpath = None
         self._on_nfs_cached = None

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -158,7 +158,7 @@ class SSHConnection:
             self._logger.info("Using existing SSH connection to %s", self.host)
         else:
             self._start_own_master()
-            self._logger.info("Created new SSH connection to %s", self.host)
+            self._logger.debug("Created new SSH connection to %s", self.host)
         self._start_keepalive()
         self._connected = True
 

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -29,7 +29,7 @@ class SSHConnectionManager:
     )
 
     def __attrs_post_init__(self):
-        self.logger = logging.getLogger("{}".format(self))
+        self.logger = logging.getLogger("labgrid.{}".format(self.__class__.__name__))
         atexit.register(self.close_all)
 
     def get(self, host: str):
@@ -128,7 +128,7 @@ class SSHConnection:
     _forwards = attr.ib(init=False, default=attr.Factory(dict))
 
     def __attrs_post_init__(self):
-        self._logger = logging.getLogger("{}".format(self))
+        self._logger = logging.getLogger("labgrid.{}.{}".format(self.__class__.__name__, self.host))
         self._socket = None
         self._master = None
         self._keepalive = None


### PR DESCRIPTION
**Description**
The new SerialLoggingReporter and StepLoggingReporter output step
information using the logging framework. This allows the user to
configure the logging output and filtering by himself using the python
logging framework.
The previous commits switched over all logging within labgrid to a new
hierarchy:
- labgrid.* contains logging messages which are not associated with a  target
- <targetname>.* contains all output from drivers and resources and output for each step emitted by the driver.

The StepLoggingReporter can take a SerialLoggingReporter as input. Since
the SerialLoggingReporter retains some state and only outputs lines that
end with \r\n, the flush function is used to flush out the pending
buffer before the StepLoggingReporter outputs logs.

Also always register both reporters when running pytest and provide
configuration options to enable indentation and output of long logging
results.

Indentation can be used if the logging output is for the logger is
configured to be the same for all loggers, enable it with
--lg-logging-indent for pytest runs:
Format: "%(levelname)-8s %(name).16s: %(message)s"
```
    INFO     main.DistroKitSt:   → transition({'status': 'barebox'})
    INFO     main.DistroKitSt:     → transition({'status': <Status.bootstrap: 1>})
    INFO     main.DistroKitSt:       → transition({'status': <Status.off: 2>})
    INFO     main.USBPowerDri:         → off(None)
    INFO     labgrid.process: Current status for hub 1-3 [05e3:0608 USB2.0 Hub, USB 2.10, 4 ports]
    INFO     labgrid.process:   Port 1: 0100 power
    INFO     labgrid.process: Sent power off request
    INFO     labgrid.process: New status for hub 1-3 [05e3:0608 USB2.0 Hub, USB 2.10, 4 ports]
    INFO     labgrid.process:   Port 1: 0000 off
    INFO     main.USBPowerDri:         ← off(None)
    INFO     main.USBPowerDri:          ┗duration=0.5077122499933466
    INFO     main.DistroKitSt:       ← transition(None)
    INFO     main.DistroKitSt:        ┗duration=1.512932803016156
    INFO     main.USBSDMuxDri:       → sdmux_set({'mode': 'host'})
    INFO     labgrid.process: Success
    INFO     main.USBSDMuxDri:       ← sdmux_set(None)
    INFO     main.USBSDMuxDri:        ┗duration=2.0959847940248437
    INFO     main.USBStorageD:       → write_image({'filename': '/home/phoenix/work/ptx/git/labgrid-PTX-DistroKit/platform-v7a/images/sabrelite.hdimg'})
    INFO     labgrid.ManagedF: Synchronizing /home/phoenix/work/ptx/git/labgrid-PTX-DistroKit/platform-v7a/images/sabrelite.hdimg to dollysisters.discworld.emantor.de
    INFO     main.USBStorageD:         → get_size(None)
    INFO     main.USBStorageD:         ← get_size(None)
    INFO     main.USBStorageD:          ┣result=0
    INFO     main.USBStorageD:          ┗duration=0.01915904600173235
    INFO     main.USBStorageD:         → get_size(None)
    INFO     main.USBStorageD:         ← get_size(None)
    INFO     main.USBStorageD:          ┣result=0
    INFO     main.USBStorageD:          ┗duration=0.01871735299937427
    INFO     main.USBStorageD:         → get_size(None)
    INFO     main.USBStorageD:         ← get_size(None)
    INFO     main.USBStorageD:          ┣result=0
    INFO     main.USBStorageD:          ┗duration=0.01951914798701182
    INFO     main.USBStorageD:         → get_size(None)
    INFO     main.USBStorageD:         ← get_size(None)
    INFO     main.USBStorageD:          ┣result=15931539456
    INFO     main.USBStorageD:          ┗duration=0.016976686019916087
    INFO     main.USBStorageD: Writing /var/cache/labgrid/phoenix/9b76de17f2785fa9be00f38f2e4595282921da29128466b03304b7498a4acd65/sabrelite.hdimg to /dev/sde using dd.
    INFO     main.USBStorageD:       ← write_image(None)
    INFO     main.USBStorageD:        ┗duration=2.0650354670360684
    INFO     main.DistroKitSt:     ← transition(None)
    INFO     main.DistroKitSt:      ┗duration=7.182933396019507
    INFO     main.DistroKitSt:   ← transition(None)
    INFO     main.DistroKitSt:    ┗duration=7.185481628985144
```
Likewise, by default the StepLoggingReporter shortens long results:
```
    INFO     main.SerialDrive: barebox@Boundary Devices i.MX6 Quad Nitrogen6x Board:/
    INFO     main.BareboxDriv:   ← run_check(None)
    INFO     main.BareboxDriv:    ┣result=['* allow_color: 1',
    INFO     main.BareboxDriv:    ┣ '  autoboot_abort_key: any (values: "any", "ctrl-c")',
    INFO     main.BareboxDriv:    ┣ '* autoboot_timeout: 3',
    INFO     main.BareboxDriv:    ┣ […] (shortened, enable long_result for all elements)
    INFO     main.BareboxDriv:    ┗duration=0.9304373920313083
```
These can be enabled with --lg-logging-long-results.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated