### PR TITLE
pytestplugin/fixture: exit early if not acquired

### DIFF
--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -64,7 +64,10 @@ def env(request, record_testsuite_property):
     record_testsuite_property('TARGETS', targets)
 
     for target_name in targets:
-        target = env.get_target(target_name)
+        try:
+            target = env.get_target(target_name)
+        except UserError as e:
+            pytest.exit(e)
         try:
             remote_place = target.get_resource(RemotePlace, wait_avail=False)
             remote_name = remote_place.name
@@ -109,12 +112,9 @@ def env(request, record_testsuite_property):
 def target(env):
     """Return the default target `main` configured in the supplied
     configuration file."""
-    try:
-        target = env.get_target()
-        if target is None:
-            raise UserError("Using target fixture without 'main' target in config")
-    except UserError as e:
-        pytest.exit(e)
+    target = env.get_target()
+    if target is None:
+        raise UserError("Using target fixture without 'main' target in config")
 
     return target
 


### PR DESCRIPTION
Commit 1773cf8a3edd ("pytestplugin/fixtures: exit with error if target
init failed") tried to catch the UserError in case the target is not
locked, however the UserError already occurs in the env fixture, when
trying to record the target properties:
```
  request = <SubRequest 'env' for <Function test_barebox_log_level>>, record_testsuite_property = <function record_testsuite_property.<locals>.record_func at 0x7f7dad25f8b0>

      @pytest.fixture(scope="session")
      def env(request, record_testsuite_property):
          """Return the environment configured in the supplied configuration file.
          It contains the targets contained in the configuration file.
          """
          env = request.config._labgrid_env

          if not env:
              pytest.skip("missing environment config (use --lg-env)")

          record_testsuite_property('ENV_CONFIG', env.config_file)
          targets = list(env.config.get_targets().keys())
          record_testsuite_property('TARGETS', targets)

          for target_name in targets:
  >           target = env.get_target(target_name)

  labgrid/pytestplugin/fixtures.py:77:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  labgrid/environment.py:48: in get_target
      target = target_factory.make_target(role, config, env=self)
  labgrid/factory.py:145: in make_target
      self.make_resource(target, resource, name, args)
  labgrid/factory.py:116: in make_resource
      r = cls(target, name, **args)
  labgrid/resource/remote.py:103: in __attrs_post_init__
      super().__attrs_post_init__()
  labgrid/resource/common.py:123: in __attrs_post_init__
      self.manager._add_resource(self)
  labgrid/resource/common.py:99: in _add_resource
      self.on_resource_added(resource)
  labgrid/resource/remote.py:54: in on_resource_added
      resource_entries = self.session.get_target_resources(place)
  labgrid/remote/client.py:637: in get_target_resources
      self._check_allowed(place)
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

  self = <labgrid.remote.client.ClientSession object at 0x7f7dad01e130>
  place = Place(name='nitrogen6x', aliases=set(), comment='', tags={'board': 'nitrogen6x'}, matches=[dollysisters.discworld.eman...ed=None, acquired_resources=[], allowed=set(), created=1570420213.4898052, changed=1606985493.327576, reservation=None)

      def _check_allowed(self, place):
          if not place.acquired:
  >           raise UserError("place {} is not acquired".format(place.name))
  E           labgrid.remote.client.UserError: place nitrogen6x is not acquired
```
Catch the UserError in the env property as well. Also remove the check
in the target property, since by than we should have caught the error
already.

Fixes: 1773cf8a3edd ("pytestplugin/fixtures: exit with error if target init failed")

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested