### PR TITLE
doc/development: add libsnappy-dev as requirement

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -22,7 +22,7 @@ Install required dependencies:
 
 .. code-block:: bash
 
-   sudo apt install python3-dev libow-dev
+   sudo apt install python3-dev libow-dev libsnappy-dev
 
 Install the development requirements:
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -187,7 +187,7 @@ extra virtualenv and install the dependencies via the requirements file.
     $ git clone https://github.com/labgrid-project/labgrid
     $ cd labgrid && virtualenv -p python3 crossbar_venv
     $ source crossbar_venv/bin/activate
-    $ sudp apt install libsnappy-dev
+    $ sudo apt install libsnappy-dev
     $ pip install -r crossbar-requirements.txt
     $ python setup.py install
 


### PR DESCRIPTION
**Description**
The development environment installs crossbar as well, and subsequently
requires python-snappy which will only install if the headers can be
found.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] PR has been tested
