### PR TITLE
util/helper: allow multiple callbacks

### DIFF
--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -101,12 +101,10 @@ class ProcessWrapper:
 
     def register(self, callback):
         """Register a callback with the ProcessWrapper"""
-        assert callback not in self.callbacks
         self.callbacks.append(callback)
 
     def unregister(self, callback):
         """Unregister a callback with the ProcessWrapper"""
-        assert callback in self.callbacks
         self.callbacks.remove(callback)
 
     @staticmethod


### PR DESCRIPTION
when pytest plugin pytester runs a testdir based test enable_logging is
called more than once. This triggers the assertion in register.
So remove it an take multiple entries of the callback

Signed-off-by: Jan Remmet <j.remmet@phytec.de>

Fixes #684