### PR TITLE
util/helper: multiple registration of callbacks

### DIFF
--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -101,12 +101,14 @@ class ProcessWrapper:
 
     def register(self, callback):
         """Register a callback with the ProcessWrapper"""
-        assert callback not in self.callbacks
+        if callback in self.callbacks:
+            return
         self.callbacks.append(callback)
 
     def unregister(self, callback):
         """Unregister a callback with the ProcessWrapper"""
-        assert callback in self.callbacks
+        if callback not in self.callbacks:
+            return
         self.callbacks.remove(callback)
 
     @staticmethod


### PR DESCRIPTION
**Description**
The pytester pytest plugin will setup multiple pytest sessions and calls
the pytest_configure multiple times. This leads to multiple registration
of the logging callback, which triggers the assert that the callback can
only be registered once. Remove the assert and replace it with a check
to register the callback only once.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

**Checklist**
- [x] PR has been tested

Fixes https://github.com/labgrid-project/labgrid/issues/684
