### PR TITLE
usbstoragedriver: Try blockdev command to get disk size

### DIFF
--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -76,13 +76,9 @@ class USBStorageDriver(Driver):
         # wait for medium
         timeout = Timeout(10.0)
         while not timeout.expired:
-            try:
-                if self.get_size() > 0:
-                    break
-                time.sleep(0.5)
-            except ValueError:
-                # when the medium gets ready the sysfs attribute is empty for a short time span
-                continue
+            if self.get_size() > 0:
+                break
+            time.sleep(0.5)
         else:
             raise ExecutionError("Timeout while waiting for medium")
 
@@ -147,9 +143,11 @@ class USBStorageDriver(Driver):
     @Driver.check_active
     @step(result=True)
     def get_size(self):
-        args = ["cat", "/sys/class/block/{}/size".format(self.storage.path[5:])]
-        size = subprocess.check_output(self.storage.command_prefix + args)
-        return int(size)*512
+        args = ["blockdev", "--getsize64", self.storage.path]
+        p = subprocess.run(self.storage.command_prefix + args, stdout=subprocess.PIPE)
+        if p.returncode != 0:
+            return 0
+        return int(p.stdout.decode('utf-8'))
 
 
 @target_factory.reg_driver


### PR DESCRIPTION
Attempt to use the blockdev command to determine the size of a block
device. This command has the advantage that it directly calls
ioctl(BLKGETSIZE64) on the device, meaning it will work as long as the
user has read permission on the actual block device (e.g. /dev/sdb)
instead of requiring permissions to read the sysfs file.

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
