### PR TITLE
client: Add LG_CLAIM_HOSTNAME/LG_CLAIM_USER

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ New Features in 0.3.0
 - Add power driver to support GEMBIRD SiS-PM implementing SiSPMPowerDriver.
 - A cleanup of the cleanup functions was performed, labgrid should now clean up
   after itself and throws an error if the user needs to handle it himself.
+- ``labgrid-client`` now respects the ``LG_HOSTNAME`` and ``LG_USERNAME``
+  environment variables to set the hostname and username when accessing
+  resources.
 
 Breaking changes in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -96,6 +96,16 @@ This variable can be used to specify a SSH proxy hostname which should be used
 to connect to the coordinator and any resources which are normally accessed
 directly.
 
+LG_HOSTNAME
+~~~~~~~~~~~
+Override the hostname used when accessing a resource. Typically only useful for
+CI pipelines where the hostname may not be consistent between pipeline stages.
+
+LG_USERNAME
+~~~~~~~~~~~
+Override the username used when accessing a resource. Typically only useful for
+CI pipelines where the username may not be consistent between pipeline stages.
+
 MATCHES
 -------
 Match patterns are used to assign a resource to a specific place. The format is:


### PR DESCRIPTION
Adds environment variables LG_CLAIM_HOSTNAME/LG_CLAIM_USER to control
the hostname and user that used to make a claim on a place. This is
useful in container based build pipelines where multiple pipeline stages
may need to use a claim, but the hostname and user name running in each
container differs (e.g. Tekton in Kubernetes).

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
