### PR TITLE
Update Crossbar & Autobahn to 20.12.x

### DIFF
--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 setuptools>=38.0.0
-crossbar==20.8.1
+crossbar==20.12.3
 urllib3==1.24.3
 idna==2.5
 msgpack==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pytest==6.1.2
 pyudev==0.22.0
 requests==2.24.0
 xmodem==0.4.5
-autobahn==20.7.1
+autobahn==20.12.3
 PyYAML==5.3.1
 ansicolors==1.1.8
 pyusb==1.1.0


### PR DESCRIPTION
**Description**
Two version bumps to fix our python 3.9 builds. Autobahn is not strictly necessary, but it's nice to keep things in sync.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested

Due to autobahn and crossbar dropping Python 3.5, this PR break Python 3.5 as well, at least for the CI.