### PR TITLE
resource: DeditecRelais8: add ID_MODEL

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -577,8 +577,8 @@ class DeditecRelais8(USBResource):
 
     def __attrs_post_init__(self):
         self.match['ID_VENDOR'] = 'DEDITEC'
-        # the serial is the same for all boards with the same model
-        self.match['ID_SERIAL_SHORT'] = 'DT000014'
+        # Deditec does not set proper model/vendor IDs, so we use ID_MODEL instead
+        self.match['ID_MODEL'] = 'DEDITEC_USB-OPT_REL-8'
         super().__attrs_post_init__()
 
     @property


### PR DESCRIPTION
Newer (?) Deditec 8 way relais board have a device individual and unique
serial number. In order to make those work with labgrid, the
ID_SERIAL_SHORT must be user definable.
To not break existing setups, the fallback value will be the already
existing default.