### PR TITLE
remote: require that all matches are fulfilled when places are locked

### DIFF
--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -221,6 +221,16 @@ class Place:
         """
         return self.getmatch(resource_path) is not None
 
+    def unmatched(self, resource_paths):
+        """Returns a match which could not be matched to the list of resource_path
+
+        A resource_path has the structure (exporter, group, cls, name).
+        """
+        for match in self.matches:
+            if not any([match.ismatch(resource) for resource in resource_paths]):
+                return match
+
+
     def touch(self):
         self.changed = time.time()
 

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -149,6 +149,29 @@ def test_place_aquire(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+def test_place_aquire_enforce(place):
+    with pexpect.spawn('python -m labgrid.remote.client -p test add-match does/not/exist') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
+        spawn.expect("Match does/not/exist has no matching remote resource")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus != 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire --allow-unmatched') as spawn:
+        spawn.expect("acquired place test")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
 def test_place_aquire_broken(place, exporter):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/Broken/*"') as spawn:
         spawn.expect(pexpect.EOF)

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -132,7 +132,7 @@ def test_place_match(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
-def test_place_aquire(place):
+def test_place_acquire(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
@@ -149,7 +149,7 @@ def test_place_aquire(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
-def test_place_aquire_enforce(place):
+def test_place_acquire_enforce(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match does/not/exist') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
@@ -172,7 +172,7 @@ def test_place_aquire_enforce(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
-def test_place_aquire_broken(place, exporter):
+def test_place_acquire_broken(place, exporter):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/Broken/*"') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()


### PR DESCRIPTION
**Description**
Labgrid client now requires that all matches are fulfilled when locking
a place:
```
  $ lgc -p cc add-match this/isatest/match
  $ labgrid-client -p cc lock
  labgrid-client: error: Match this/isatest/match has no matching resource
```
Use the -l argument to loosen this requirement.
```
  $ lgc -p cc add-match this/isatest/match
  $ labgrid-client -p cc lock -l
  $
```
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Tests for the feature
- [x] PR has been tested
