### PR TITLE
labgrid-bound-connect: Delete IP cache

### DIFF
--- a/helpers/labgrid-bound-connect
+++ b/helpers/labgrid-bound-connect
@@ -7,6 +7,7 @@ import argparse
 import os
 import sys
 import ipaddress
+import subprocess
 
 
 def main(ifname, address, port):
@@ -33,6 +34,12 @@ def main(ifname, address, port):
         prefix = "TCP6:[{}]:{}".format(address, port)
     else:
         raise RuntimeError("Invalid IP version '{}'".format(address.version))
+
+    # Delete the IP lookup cache for the address in case it is stale
+    subprocess.run(["ip", "neigh", "del", str(address), "dev", ifname], 
+        stdout=suprocess.DEVNULL, 
+        stderr=subprocess.DEVNULL
+    )
 
     args.append(','.join([
         prefix,


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Delete the ARP or NDP cache before attempting to connect to a service.
For devices that are assigned an ephemeral MAC address on boot instead
of using a fixed one, these caches may be out of date which results in
the connection failing.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
