### PR TITLE
config/environment/target: move get_target_features() from Env to Config, add Target helpers

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -232,6 +232,25 @@ class Config:
         trg = self.data['targets'].setdefault(target, {})
         trg.setdefault('options', {})[name] = value
 
+    def get_target_features(self, target):
+        """
+        Retrieve all entries from the features subkey under the specified
+        target subkey
+
+        Args:
+            target (str): name of the target
+
+        Returns:
+            set: feature strings
+
+        Raises:
+            KeyError: if the requested target name is not found in the config
+        """
+        if target not in self.data['targets']:
+            raise KeyError("No target '{}' found in configuration".format(target))
+
+        return set(self.data['targets'][target].get('features', tuple()))
+
     def get_targets(self):
         return self.data.get('targets', {})
 

--- a/labgrid/environment.py
+++ b/labgrid/environment.py
@@ -54,9 +54,20 @@ class Environment:
         return self.config.get_features()
 
     def get_target_features(self):
+        """
+        Retrieve all entries from the features subkey under all targets in the
+        config
+
+        Returns:
+            set: feature strings
+        """
+        import warnings
+        warnings.warn("Enironment.get_target_features() is deprecated, use {Target,Config}.get_target_features() instead",
+                      DeprecationWarning)
+
         flags = set()
-        for value in self.config.get_targets().values():
-            flags = flags | set(value.get('features', {}))
+        for target in self.targets.keys():
+            flags |= self.config.get_target_features(target)
         return flags
 
     def cleanup(self):

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -485,3 +485,7 @@ class Target:
     def get_target_features(self):
         """Helper to retrieve all features of this target"""
         return self.env.config.get_target_features(self.name)
+
+    def get_target_option(self, name, default=None):
+        """Helper to retrieve target option of this target"""
+        return self.env.config.get_target_option(self.name, name, default=default)

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -481,3 +481,7 @@ class Target:
         self.deactivate_all_drivers()
         for res in reversed(self.resources):
             self.deactivate(res)
+
+    def get_target_features(self):
+        """Helper to retrieve all features of this target"""
+        return self.env.config.get_target_features(self.name)


### PR DESCRIPTION
**Description**
As discussed in #490 move `get_target_features()` from `Environment` to `Config`. Also add helpers for target options and features to `Target`.

The pytest plugin uses the now deprecated `Environment.get_target_features()`. I wonder how we can change that since the target seems not known at that time in `pytest_configure()`/`pytest_collection_modifyitems()`.
