### PR TITLE
Xilinx JTAG support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -563,6 +563,9 @@ A XilinxUSBJTAG resource describes a Xilinx-compatible USB JTAG adapter:
 - Xilinx Platform Cable USB
 - Xilinx Platform Cable USB II
 
+The exporter launches a Vivado hardware server bound to the respective USB JTAG
+adapter.
+
 .. code-block:: yaml
 
    XilinxUSBJTAG:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -560,8 +560,8 @@ A XilinxUSBJTAG resource describes a Xilinx-compatible USB JTAG adapter:
 - Digilent JTAG-HS3
 - Digilent JTAG-SMT2
 - Trenz Electronic TE0790-03
-- Xilinx Platform Cable USB
-- Xilinx Platform Cable USB II
+- Xilinx Platform Cable USB (see `Matching a Xilinx Platform Cable USB (II)`_)
+- Xilinx Platform Cable USB II (see `Matching a Xilinx Platform Cable USB (II)`_)
 
 The exporter launches a Vivado hardware server bound to the respective USB JTAG
 adapter.
@@ -578,15 +578,17 @@ adapter.
      extra_args: ['-S']
 
 - match (dict): key and value for a udev match, see `udev Matching`_
-- hw_server_bin (str): optional, path to `hw_server` binary. The minimum Vivado
-  hardware server version supported is 2018.3
+- hw_server_bin (str): optional, path to :program:`hw_server` binary. The
+  minimum Vivado hardware server version supported is 2018.3
+- serial: (str): only required for adapters that do not expose the serial
+  number via udev, see `Matching a Xilinx Platform Cable USB (II)`_
 - agent_url (str): optional, agent listening port and protocol. By default, a
   random free TCP port is chosen.
 - gdb_port (int): optional, base port number for Xilinx GDB server. By default,
   a random free port is chosen.
 - log_level ([str]): optional, set log level as a list of categories. Run
-  `hw_server -h` to get all available categories.
-- extra_args ([str]): optional, extra arguments passed to `hw_server`
+  ``hw_server -h`` to get all available categories.
+- extra_args ([str]): optional, extra arguments passed to :program:`hw_server`
 
 Used by:
   - `XSDBDriver`_
@@ -1163,6 +1165,36 @@ To check if your device has a serial number, you can use ``udevadm info``:
 
   $ udevadm info /dev/ttyUSB5 | grep SERIAL_SHORT
   E: ID_SERIAL_SHORT=P-00-00679
+
+Matching a Xilinx Platform Cable USB (II)
++++++++++++++++++++++++++++++++++++++++++
+
+A Xilinx Platform Cable USB (II) does not expose its unique serial number via
+udev. Therefore, we have to match the USB device via the respective port
+(directly, without parent match).
+
+Accordingly, one must set the ``serial`` attribute to enable the Vivado
+hardware server to filter for the respective port. Run the XSDB command ``jtag
+targets`` to get the serial number of the respective Platform Cable USB (II):
+
+.. code-block:: console
+   :emphasize-lines: 4
+
+   $ xsdb
+   …
+   xsdb% jtag targets
+     1  Platform Cable USB II 00001296718a01
+        2  xczu9 (idcode 24738093 irlen 12 fpga)
+        3  arm_dap (idcode 5ba00477 irlen 4)
+
+.. code-block:: yaml
+   :emphasize-lines: 5
+
+   XilinxUSBJTAG:
+     match:
+       'sys_name': '3-3'
+     hw_server_bin: '/path/to/Xilinx/Vivado/2018.3/bin/hw_server'
+     serial: 00001296718a01
 
 Drivers
 -------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -553,6 +553,38 @@ Used by:
   - `OpenOCDDriver`_
   - `QuartusHPSDriver`_
 
+XilinxUSBJTAG
+~~~~~~~~~~~~~~~~
+A XilinxUSBJTAG resource describes a Xilinx-compatible USB JTAG adapter:
+
+- Digilent JTAG-HS3
+- Digilent JTAG-SMT2
+- Trenz Electronic TE0790-03
+- Xilinx Platform Cable USB
+- Xilinx Platform Cable USB II
+
+.. code-block:: yaml
+
+   XilinxUSBJTAG:
+     match:
+      'ID_SERIAL_SHORT': '210308A11F1A'
+     hw_server_bin: '/path/to/Xilinx/Vivado/2018.3/bin/hw_server'
+     agent_url: tcp::3121
+     gdb_port: 3000
+     log_level: [events, protocol]
+     extra_args: ['-S']
+
+- match (dict): key and value for a udev match, see `udev Matching`_
+- hw_server_bin (str): optional, path to `hw_server` binary. The minimum Vivado
+  hardware server version supported is 2018.3
+- agent_url (str): optional, agent listening port and protocol. By default, a
+  random free TCP port is chosen.
+- gdb_port (int): optional, base port number for Xilinx GDB server. By default,
+  a random free port is chosen.
+- log_level ([str]): optional, set log level as a list of categories. Run
+  `hw_server -h` to get all available categories.
+- extra_args ([str]): optional, extra arguments passed to `hw_server`
+
 USBDebugger
 ~~~~~~~~~~~
 An USBDebugger resource describes a JTAG USB adapter (for example an FTDI

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -571,15 +571,28 @@ adapter.
    XilinxUSBJTAG:
      match:
       'ID_SERIAL_SHORT': '210308A11F1A'
-     hw_server_bin: '/path/to/Xilinx/Vivado/2018.3/bin/hw_server'
+     hw_server_cmd: '/path/to/Xilinx/Vivado/2018.3/bin/hw_server'
      agent_url: tcp::3121
      gdb_port: 3000
      log_level: [events, protocol]
      extra_args: ['-S']
 
 - match (dict): key and value for a udev match, see `udev Matching`_
-- hw_server_bin (str): optional, path to :program:`hw_server` binary. The
-  minimum Vivado hardware server version supported is 2018.3
+- hw_server_cmd (str): optional, shell command to run the Vivado hardware
+  server (defaults to ``hw_server``). The minimum Vivado hardware server
+  version supported is 2018.3.
+
+  Note that the Vivado Design Suite and Vivado Lab Solutions come with an
+  environment script that must be sourced first, i.e.:
+
+  .. code-block:: yaml
+
+     hw_server_cmd: 'source /path/to/Xilinx/Vivado/2018.3/settings64.sh && hw_server'
+
+  Since for the Vivado Lab Solutions, the environment script only adds the
+  :program:`hw_server` binary to :envvar:`PATH`, you can also directly provide
+  an absolute path as shown in the example; however, this might change in the
+  future.
 - serial: (str): only required for adapters that do not expose the serial
   number via udev, see `Matching a Xilinx Platform Cable USB (II)`_
 - agent_url (str): optional, agent listening port and protocol. By default, a
@@ -1193,7 +1206,7 @@ targets`` to get the serial number of the respective Platform Cable USB (II):
    XilinxUSBJTAG:
      match:
        'sys_name': '3-3'
-     hw_server_bin: '/path/to/Xilinx/Vivado/2018.3/bin/hw_server'
+     hw_server_cmd: '/path/to/Xilinx/Vivado/2018.3/bin/hw_server'
      serial: 00001296718a01
 
 Drivers

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -585,6 +585,9 @@ A XilinxUSBJTAG resource describes a Xilinx-compatible USB JTAG adapter:
   `hw_server -h` to get all available categories.
 - extra_args ([str]): optional, extra arguments passed to `hw_server`
 
+Used by:
+  - `XSDBDriver`_
+
 USBDebugger
 ~~~~~~~~~~~
 An USBDebugger resource describes a JTAG USB adapter (for example an FTDI
@@ -1462,6 +1465,25 @@ Arguments:
 
 The driver can be used in test cases by calling the `flash` function. An
 example strategy is included in labgrid.
+
+XSDBDriver
+~~~~~~~~~~
+A XSDBDriver connects to a Vivado hardware server to control a Xilinx device
+via JTAG.
+
+Binds to:
+  interface:
+    - `XilinxUSBJTAG`_
+
+Implements:
+  - None
+
+Arguments:
+  - bitstream (str): filename of bitstream for programmable logic (PL)
+
+The driver can be used in test cases to program a bitstream via the
+`program_bitstream` function or run arbitrary XSDB Tcl commands by calling the
+`run` function.
 
 ManualPowerDriver
 ~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/xsdbdriver.py
+++ b/labgrid/driver/xsdbdriver.py
@@ -1,0 +1,52 @@
+"Xilinx System Debugger (XSDB) driver"
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..resource.udev import XilinxUSBJTAG
+from ..resource.remote import NetworkXilinxUSBJTAG
+from ..step import step
+from ..util.helper import processwrapper
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class XSDBDriver(Driver):
+    bindings = {
+        "interface": {XilinxUSBJTAG, NetworkXilinxUSBJTAG},
+    }
+
+    bitstream = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        # FIXME make sure we always have an environment or config
+        if self.target.env:
+            self.xsdb_bin = self.target.env.config.get_tool('xsdb') or 'xsdb'
+        else:
+            self.xsdb_bin = 'xsdb'
+
+    @Driver.check_active
+    @step(args=['tcl_cmds'])
+    def run(self, tcl_cmds):
+        url = self.interface.agent_url.split(":")
+        if not url[2]:
+            url[2] = self.interface.host
+
+        tcl_cmd = "connect -url {}; ".format(":".join(url))
+        tcl_cmd += "; ".join(tcl_cmds)
+
+        cmd = [self.xsdb_bin, "-eval", tcl_cmd]
+        processwrapper.check_output(cmd)
+
+    @Driver.check_active
+    @step(args=['filename'])
+    def program_bitstream(self, filename):
+        if filename is None and self.bitstream is not None:
+            filename = self.target.env.config.get_image_path(self.bitstream)
+
+        self.run(["fpga {}".format(filename)])

--- a/labgrid/driver/xsdbdriver.py
+++ b/labgrid/driver/xsdbdriver.py
@@ -34,8 +34,8 @@ class XSDBDriver(Driver):
     @step(args=['tcl_cmds'])
     def run(self, tcl_cmds):
         url = self.interface.agent_url.split(":")
-        if not url[2]:
-            url[2] = self.interface.host
+        if not url[1]:
+            url[1] = self.interface.host
 
         tcl_cmd = "connect -url {}; ".format(":".join(url))
         tcl_cmd += "; ".join(tcl_cmds)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1271,10 +1271,10 @@ class ClientSession(ApplicationSession):
 
     def _check_xlx_env(self):
         if not "XILINX_VIVADO" in os.environ:
-            print("xlx subcommands must be invoked from within a Vivado environment", file=sys.stderr)
+            print("xsdb must be invoked from within a Vivado environment", file=sys.stderr)
             exit(1)
 
-    def _get_xlx(self, name):
+    def _get_fpga(self, name):
         place = self.get_acquired_place()
         target = self._get_target(place)
         from ..driver.xsdbdriver import XSDBDriver
@@ -1293,17 +1293,17 @@ class ClientSession(ApplicationSession):
         target.activate(drv)
         return drv
 
-    def xlx_run_xsdb(self):
+    def fpga_run_xsdb(self):
         self._check_xlx_env()
-        drv = self._get_xlx(self.args.resource)
+        drv = self._get_fpga(self.args.resource)
 
         processwrapper.enable_print()
         drv.run([self.args.tcl_cmds])
         processwrapper.disable_print()
 
-    def xlx_program_bitstream(self):
+    def fpga_program_bitstream(self):
         self._check_xlx_env()
-        drv = self._get_xlx(self.args.resource)
+        drv = self._get_fpga(self.args.resource)
 
         processwrapper.enable_print()
         drv.program_bitstream(self.args.bitstream)
@@ -1784,23 +1784,23 @@ def main():
     tmc_subparser.add_argument('action', choices=['info', 'values'])
     tmc_subparser.set_defaults(func=ClientSession.tmc_channel)
 
-    subparser = subparsers.add_parser('xlx', help="connect to a Xilinx Vivado hardware server")
+    subparser = subparsers.add_parser('fpga', help="interact with FPGA")
     subparser.set_defaults(func=lambda _: subparser.print_help())
-    xlx_subparsers = subparser.add_subparsers(
+    fpga_subparsers = subparser.add_subparsers(
         dest='subcommand',
         title='available subcommands',
         metavar="SUBCOMMAND",
     )
 
-    xlx_subparser = xlx_subparsers.add_parser('xsdb', help="run XSDB")
-    xlx_subparser.add_argument('-r,', '--resource', help="resource name")
-    xlx_subparser.add_argument('tcl_cmds', help="Tcl commands")
-    xlx_subparser.set_defaults(func=ClientSession.xlx_run_xsdb)
+    fpga_subparser = fpga_subparsers.add_parser('xsdb', help="run XSDB")
+    fpga_subparser.add_argument('-r,', '--resource', help="resource name")
+    fpga_subparser.add_argument('tcl_cmds', help="Tcl commands")
+    fpga_subparser.set_defaults(func=ClientSession.fpga_run_xsdb)
 
-    xlx_subparser = xlx_subparsers.add_parser('program-bitstream', help="program bitstream")
-    xlx_subparser.add_argument('-r,', '--resource', help="resource name")
-    xlx_subparser.add_argument('bitstream', type=pathlib.PurePath, help="bistream file")
-    xlx_subparser.set_defaults(func=ClientSession.xlx_program_bitstream)
+    fpga_subparser = fpga_subparsers.add_parser('program-bitstream', help="program bitstream")
+    fpga_subparser.add_argument('-r,', '--resource', help="resource name")
+    fpga_subparser.add_argument('bitstream', type=pathlib.PurePath, help="bitstream file")
+    fpga_subparser.set_defaults(func=ClientSession.fpga_program_bitstream)
 
     subparser = subparsers.add_parser('write-image', help="write an image onto mass storage")
     subparser.add_argument('-w', '--wait', type=float, default=10.0)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1297,17 +1297,14 @@ class ClientSession(ApplicationSession):
         self._check_xlx_env()
         drv = self._get_fpga(self.args.resource)
 
-        processwrapper.enable_print()
-        drv.run([self.args.tcl_cmds])
-        processwrapper.disable_print()
+        drv.run([self.args.tcl_cmds],
+                interactive=self.args.interactive or not bool(self.args.tcl_cmds))
 
     def fpga_program_bitstream(self):
         self._check_xlx_env()
         drv = self._get_fpga(self.args.resource)
 
-        processwrapper.enable_print()
         drv.program_bitstream(self.args.bitstream)
-        processwrapper.disable_print()
 
     def write_image(self):
         place = self.get_acquired_place()
@@ -1792,9 +1789,10 @@ def main():
         metavar="SUBCOMMAND",
     )
 
-    fpga_subparser = fpga_subparsers.add_parser('xsdb', help="run XSDB")
+    fpga_subparser = fpga_subparsers.add_parser('xsdb', help="run XSDB and connect to Vivado hardware server")
     fpga_subparser.add_argument('-r,', '--resource', help="resource name")
-    fpga_subparser.add_argument('tcl_cmds', help="Tcl commands")
+    fpga_subparser.add_argument('tcl_cmds', nargs='?', default='', help="execute Tcl command then exit")
+    fpga_subparser.add_argument('-i', '--interactive', action='store_true', help="enter interactive mode after executing Tcl command")
     fpga_subparser.set_defaults(func=ClientSession.fpga_run_xsdb)
 
     fpga_subparser = fpga_subparsers.add_parser('program-bitstream', help="program bitstream")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -297,10 +297,17 @@ class VivadoHWServerExport(ResourceExport):
         if self.child is not None:
             self.stop()
 
+    def _get_serial(self):
+        if self.local.serial:
+            return self.local.serial
+        else:
+            return self.local.serial_short
+
     def _get_params(self):
         """Helper function to return parameters"""
         return {
             'host': self.host,
+            'serial': self._get_serial(),
             'hw_server_bin': self.local.hw_server_bin,
             'agent_url': self.local.agent_url,
             'gdb_port': self.local.gdb_port,
@@ -321,7 +328,7 @@ class VivadoHWServerExport(ResourceExport):
 
         args = [
             self.local.hw_server_bin,
-            '-e', 'set jtag-port-filter {}'.format(self.local.serial_short),
+            '-e', "set jtag-port-filter {}".format(self._get_serial()),
             '-s{}'.format(self.local.agent_url),
             '-p{}'.format(self.local.gdb_port),
         ]

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -308,7 +308,7 @@ class VivadoHWServerExport(ResourceExport):
         return {
             'host': self.host,
             'serial': self._get_serial(),
-            'hw_server_bin': self.local.hw_server_bin,
+            'hw_server_cmd': self.local.hw_server_cmd,
             'agent_url': self.local.agent_url,
             'gdb_port': self.local.gdb_port,
             'log_level': self.local.log_level,
@@ -327,8 +327,8 @@ class VivadoHWServerExport(ResourceExport):
             self.local.gdb_port = get_free_port()
 
         args = [
-            self.local.hw_server_bin,
-            '-e', "set jtag-port-filter {}".format(self._get_serial()),
+            self.local.hw_server_cmd,
+            '-e', "'set jtag-port-filter {}'".format(self._get_serial()),
             '-s{}'.format(self.local.agent_url),
             '-p{}'.format(self.local.gdb_port),
         ]
@@ -336,7 +336,8 @@ class VivadoHWServerExport(ResourceExport):
             args.append('-l{}'.format(','.join(self.local.log_level)))
         args.extend(self.local.extra_args)
         # TODO: Add timeout
-        self.child = subprocess.Popen(args, preexec_fn=os.setsid)
+        self.child = subprocess.Popen(' '.join(args), preexec_fn=os.setsid,
+                shell=True)
         self.logger.info("started hw_server on %s", self.local.agent_url)
 
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -321,6 +321,7 @@ class VivadoHWServerExport(ResourceExport):
 
         args = [
             self.local.hw_server_bin,
+            '-e', 'set jtag-port-filter {}'.format(self.local.serial_short),
             '-s{}'.format(self.local.agent_url),
             '-p{}'.format(self.local.gdb_port),
         ]

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -336,7 +336,7 @@ class VivadoHWServerExport(ResourceExport):
             args.append('-l{}'.format(','.join(self.local.log_level)))
         args.extend(self.local.extra_args)
         # TODO: Add timeout
-        self.child = subprocess.Popen(' '.join(args), preexec_fn=os.setsid,
+        self.child = subprocess.Popen(' '.join(args), start_new_session=True,
                 shell=True)
         self.logger.info("started hw_server on %s", self.local.agent_url)
 

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -11,6 +11,7 @@ from .udev import USBSDMuxDevice
 from .udev import USBSDWireDevice
 from .udev import USBPowerPort
 from .udev import SiSPMPowerPort
+from .udev import XilinxUSBJTAG
 from .common import Resource, ResourceManager, ManagedResource
 from .ykushpowerport import YKUSHPowerPort
 from .xenamanager import XenaManager

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -155,6 +155,7 @@ class NetworkAlteraUSBBlaster(RemoteUSBResource):
 @attr.s(eq=False)
 class NetworkXilinxUSBJTAG(NetworkResource, ManagedResource):
     hw_server_bin = attr.ib(default='hw_server')
+    serial = attr.ib(factory=str)
     agent_url = attr.ib(factory=str)
     gdb_port = attr.ib(factory=int)
     log_level = attr.ib(factory=list)

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -153,6 +153,20 @@ class NetworkAlteraUSBBlaster(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkXilinxUSBJTAG(NetworkResource, ManagedResource):
+    hw_server_bin = attr.ib(default='hw_server')
+    agent_url = attr.ib(factory=str)
+    gdb_port = attr.ib(factory=int)
+    log_level = attr.ib(factory=list)
+    extra_args = attr.ib(factory=list)
+
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkSigrokUSBDevice(RemoteUSBResource):
     """The NetworkSigrokUSBDevice describes a remotely accessible sigrok USB device"""
     driver = attr.ib(

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -154,7 +154,7 @@ class NetworkAlteraUSBBlaster(RemoteUSBResource):
 @target_factory.reg_resource
 @attr.s(eq=False)
 class NetworkXilinxUSBJTAG(NetworkResource, ManagedResource):
-    hw_server_bin = attr.ib(default='hw_server')
+    hw_server_cmd = attr.ib(default='hw_server')
     serial = attr.ib(factory=str)
     agent_url = attr.ib(factory=str)
     gdb_port = attr.ib(factory=int)

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -206,6 +206,14 @@ class USBResource(ManagedResource):
 
         return None
 
+    @property
+    def serial_short(self):
+        device = self._get_usb_device()
+        if device:
+            return device.properties.get('ID_SERIAL_SHORT')
+
+        return None
+
     def read_attr(self, attribute):
         """read uncached attribute value from sysfs
 

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -355,6 +355,30 @@ class AlteraUSBBlaster(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class XilinxUSBJTAG(USBResource):
+    hw_server_bin = attr.ib(default='hw_server')
+    agent_url = attr.ib(factory=str)
+    gdb_port = attr.ib(factory=int)
+    log_level = attr.ib(factory=list)
+    extra_args = attr.ib(factory=list)
+
+    def __attrs_post_init__(self):
+        self.match['DEVTYPE'] = 'usb_device'
+        super().__attrs_post_init__()
+
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [("0403", "6010"),  # Trenz Electronic TE0790-03
+                         ("0403", "6014"),  # Digilent JTAG-SMT2/JTAG-HS3
+                         ("03fd", "0013"),  # Xilinx Platform Cable USB
+                         ("03fd", "0008")]: # Xilinx Platform Cable USB II
+            return False
+
+        return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class SigrokUSBDevice(USBResource):
     """The SigrokUSBDevice describes an attached sigrok device with driver and
     optional channel mapping, it is identified via usb using udev.

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -364,7 +364,7 @@ class AlteraUSBBlaster(USBResource):
 @target_factory.reg_resource
 @attr.s(eq=False)
 class XilinxUSBJTAG(USBResource):
-    hw_server_bin = attr.ib(default='hw_server')
+    hw_server_cmd = attr.ib(default='hw_server')
     serial = attr.ib(factory=str)
     agent_url = attr.ib(factory=str)
     gdb_port = attr.ib(factory=int)

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -365,6 +365,7 @@ class AlteraUSBBlaster(USBResource):
 @attr.s(eq=False)
 class XilinxUSBJTAG(USBResource):
     hw_server_bin = attr.ib(default='hw_server')
+    serial = attr.ib(factory=str)
     agent_url = attr.ib(factory=str)
     gdb_port = attr.ib(factory=int)
     log_level = attr.ib(factory=list)

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -48,16 +48,16 @@ This is the client to control a boards status and interface with it on remote ma
 .B \-h\fP,\fB  \-\-help
 display command line help
 .TP
-.BI \-p \ PLACE\fP,\fB \ \-\-place \ PLACE
+.BI \-p \ PLACE\fR,\fB \ \-\-place \ PLACE
 specify the place to operate on
 .TP
 .B \-x\fP,\fB  \-\-crossbar\-url
 the crossbar url of the coordinator, defaults to \fBws://127.0.0.1:20408/ws\fP
 .TP
-.BI \-c \ CONFIG\fP,\fB \ \-\-config \ CONFIG
+.BI \-c \ CONFIG\fR,\fB \ \-\-config \ CONFIG
 set the configuration file
 .TP
-.BI \-s \ STATE\fP,\fB \ \-\-state \ STATE
+.BI \-s \ STATE\fR,\fB \ \-\-state \ STATE
 set an initial state before executing a command, requires a configuration
 file and strategy
 .TP
@@ -67,7 +67,7 @@ enable debugging
 .B \-v\fP,\fB  \-\-verbose
 increase verbosity
 .TP
-.BI \-P \ PROXY\fP,\fB \ \-\-proxy \ PROXY
+.BI \-P \ PROXY\fR,\fB \ \-\-proxy \ PROXY
 proxy connections over ssh
 .UNINDENT
 .SH CONFIGURATION FILE
@@ -183,6 +183,8 @@ matches anything.
 \fBvideo\fP                       Start a video stream
 .sp
 \fBtmc\fP command                 Control a USB TMC device
+.sp
+\fBxlx\fP command                 Connect to a Xilinx Vivado hardware server
 .sp
 \fBwrite\-image\fP                 Write images onto block devices (USBSDMux, USB Sticks, …)
 .sp

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -178,6 +178,8 @@ LABGRID-CLIENT COMMANDS
 
 ``tmc`` command                 Control a USB TMC device
 
+``xlx`` command                 Connect to a Xilinx Vivado hardware server
+
 ``write-image``                 Write images onto block devices (USBSDMux, USB Sticks, …)
 
 ``reserve`` filter              Create a reservation


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Provides support for accessing Xilinx devices via JTAG:
- `XilinxUSBJTAG` resource describing a Xilinx-compatible USB JTAG adapter
- `VivadoHWServerExport` resource export, spawning a Vivado hardware server for each `XilinxUSBJTAG` resource
- `XSDBDriver`, which runs Xilinx System Debugger (XSDB) Tcl commands via the Vivado hardware server
- `xlx` client subcommands, showcasing how to program a bitstream using the `XSDBDriver`

The list of supported JTAG adapters is by no means exhaustive, but is limited by our lab inventory we were able to test with.

In our lab we have seen more complicated scenarios, in which one needs to start/stop Vivado hardware server(s), sometimes even of different versions, during a test run. Right now, such use cases are not supported by the current architecture, but we could provide an alternative `VivadoHWServerDriver` that dynamically spawns a Vivado hardware server on the target via SSH. The `VivadoHWServerExport` must then be deactivated, likely with a flag in the respective `XilinxUSBJTAG` resource.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated