### PR TITLE
debian/doc: extend copyright period to 2021

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,8 +3,8 @@ Upstream-Name: labgrid
 Source: https://github.com/labgrid-project/labgrid
 
 Files: *
-Copyright: Copyright (C) 2016-2019 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
-           Copyright (C) 2016-2019 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+Copyright: Copyright (C) 2016-2021 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
+           Copyright (C) 2016-2021 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
 License: LGPL-2.1+
 
 Files: man/*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'labgrid'
-copyright = '2016-2019 Pengutronix, Jan Luebbe and Rouven Czerwinski'
+copyright = '2016-2021 Pengutronix, Jan Luebbe and Rouven Czerwinski'
 author = 'Jan Luebbe, Rouven Czerwinski'
 
 # The version info for the project you're documenting, acts as replacement for


### PR DESCRIPTION
**Description**
labgrid is in active development, so extend the copyright period to reflect that.
