### PR TITLE
strategy: use name-based bindings and enable console early

### DIFF
--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -2,9 +2,7 @@ import enum
 
 import attr
 
-from ..driver import BareboxDriver, ShellDriver
 from ..factory import target_factory
-from ..protocol import PowerProtocol
 from ..step import step
 from .common import Strategy, StrategyError
 
@@ -21,9 +19,9 @@ class Status(enum.Enum):
 class BareboxStrategy(Strategy):
     """BareboxStrategy - Strategy to switch to barebox or shell"""
     bindings = {
-        "power": PowerProtocol,
-        "barebox": BareboxDriver,
-        "shell": ShellDriver,
+        "power": "PowerProtocol",
+        "barebox": "BareboxDriver",
+        "shell": "ShellDriver",
     }
 
     status = attr.ib(default=Status.unknown)

--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -20,6 +20,7 @@ class BareboxStrategy(Strategy):
     """BareboxStrategy - Strategy to switch to barebox or shell"""
     bindings = {
         "power": "PowerProtocol",
+        "console": "ConsoleProtocol",
         "barebox": "BareboxDriver",
         "shell": "ShellDriver",
     }
@@ -39,12 +40,12 @@ class BareboxStrategy(Strategy):
             step.skip("nothing to do")
             return  # nothing to do
         elif status == Status.off:
-            self.target.deactivate(self.barebox)
-            self.target.deactivate(self.shell)
+            self.target.deactivate(self.console)
             self.target.activate(self.power)
             self.power.off()
         elif status == Status.barebox:
             self.transition(Status.off)  # pylint: disable=missing-kwoa
+            self.target.activate(self.console)
             # cycle power
             self.power.cycle()
             # interrupt barebox

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -19,6 +19,7 @@ class ShellStrategy(Strategy):
     """ShellStrategy - Strategy to switch to shell"""
     bindings = {
         "power": "PowerProtocol",
+        "console": "ConsoleProtocol",
         "shell": "ShellDriver",
     }
 
@@ -37,11 +38,12 @@ class ShellStrategy(Strategy):
             step.skip("nothing to do")
             return  # nothing to do
         elif status == Status.off:
-            self.target.deactivate(self.shell)
+            self.target.deactivate(self.console)
             self.target.activate(self.power)
             self.power.off()
         elif status == Status.shell:
             self.transition(Status.off)  # pylint: disable=missing-kwoa
+            self.target.activate(self.console)
             self.power.cycle()
             self.target.activate(self.shell)
         else:

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -2,9 +2,7 @@ import enum
 
 import attr
 
-from ..driver import ShellDriver
 from ..factory import target_factory
-from ..protocol import PowerProtocol
 from ..step import step
 from .common import Strategy, StrategyError
 
@@ -20,8 +18,8 @@ class Status(enum.Enum):
 class ShellStrategy(Strategy):
     """ShellStrategy - Strategy to switch to shell"""
     bindings = {
-        "power": PowerProtocol,
-        "shell": ShellDriver,
+        "power": "PowerProtocol",
+        "shell": "ShellDriver",
     }
 
     status = attr.ib(default=Status.unknown)


### PR DESCRIPTION
This updates the default strategies to what we've been using internally for some time.

The console enable change makes sure that we don't miss bootloader output when enabling power to the board.