### PR TITLE
Pass delay to power drivers only if specified explicitly

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1230,7 +1230,7 @@ Implements:
      delay: 5
 
 Arguments:
-  - delay (int): optional delay in seconds between off and on
+  - delay (float): optional delay in seconds between off and on
 
 YKUSHPowerDriver
 ~~~~~~~~~~~~~~~~

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -1,5 +1,6 @@
 import shlex
 import time
+import math
 from importlib import import_module
 
 import attr
@@ -338,7 +339,7 @@ class USBPowerDriver(Driver, PowerResetMixin, PowerProtocol):
 class PDUDaemonDriver(Driver, PowerResetMixin, PowerProtocol):
     """PDUDaemonDriver - Driver using a PDU port available via pdudaemon"""
     bindings = {"port": "PDUDaemonPort", }
-    delay = attr.ib(default=5, validator=attr.validators.instance_of(int))
+    delay = attr.ib(default=5.0, validator=attr.validators.instance_of(float))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -350,7 +351,7 @@ class PDUDaemonDriver(Driver, PowerResetMixin, PowerProtocol):
         res = "http://{}:{}/power/control/{}?hostname={}&port={}".format(
             self._host, self._port, cmd, self.port.pdu, self.port.index)
         if cmd == 'reboot':
-            res += "&delay={}".format(self.delay)
+            res += "&delay={}".format(math.ceil(self.delay))
         return res
 
     def on_activate(self):

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -732,7 +732,7 @@ class ClientSession(ApplicationSession):
                     try:
                         drv = target.get_driver(PDUDaemonDriver)
                     except NoDriverFoundError:
-                        drv = PDUDaemonDriver(target, name=None, delay=int(delay))
+                        drv = PDUDaemonDriver(target, name=None, delay=delay)
                         break
         if not drv:
             raise UserError("target has no compatible resource available")

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -714,28 +714,30 @@ class ClientSession(ApplicationSession):
                     try:
                         drv = target.get_driver(NetworkPowerDriver)
                     except NoDriverFoundError:
-                        drv = NetworkPowerDriver(target, name=None, delay=delay)
+                        drv = NetworkPowerDriver(target, name=None)
                         break
                 elif isinstance(resource, NetworkUSBPowerPort):
                     try:
                         drv = target.get_driver(USBPowerDriver)
                     except NoDriverFoundError:
-                        drv = USBPowerDriver(target, name=None, delay=delay)
+                        drv = USBPowerDriver(target, name=None)
                         break
                 elif isinstance(resource, NetworkSiSPMPowerPort):
                     try:
                         drv = target.get_driver(SiSPMPowerDriver)
                     except NoDriverFoundError:
-                        drv = SiSPMPowerDriver(target, name=None, delay=delay)
+                        drv = SiSPMPowerDriver(target, name=None)
                     break
                 elif isinstance(resource, PDUDaemonPort):
                     try:
                         drv = target.get_driver(PDUDaemonDriver)
                     except NoDriverFoundError:
-                        drv = PDUDaemonDriver(target, name=None, delay=delay)
+                        drv = PDUDaemonDriver(target, name=None)
                         break
         if not drv:
             raise UserError("target has no compatible resource available")
+        if delay is not None:
+            drv.delay = delay
         target.activate(drv)
         res = getattr(drv, action)()
         if action == 'get':
@@ -1439,7 +1441,7 @@ def main():
                                       aliases=('pw',),
                                       help="change (or get) a place's power status")
     subparser.add_argument('action', choices=['on', 'off', 'cycle', 'get'])
-    subparser.add_argument('-t', '--delay', type=float, default=1.0,
+    subparser.add_argument('-t', '--delay', type=float, default=None,
                            help='wait time in seconds between off and on during cycle')
     subparser.set_defaults(func=ClientSession.power)
 


### PR DESCRIPTION
**Description**

Each power driver defines its own default delay value. Respect that by dropping the default from the client's delay cli argument and only passing the delay value when it is actually specified via the cli.

In order to make that simpler, make the PDUDaemonDriver expect its delay as a float value (not an int) as all other power drivers do.

**Checklist**
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested