### PR TITLE
Labgrid __version__ and client version support

### DIFF
--- a/labgrid/__init__.py
+++ b/labgrid/__init__.py
@@ -5,3 +5,7 @@ from .exceptions import NoConfigFoundError
 from .factory import target_factory
 from .step import step, steps
 from .stepreporter import StepReporter
+
+from importlib.metadata import version
+
+__version__ = version("labgrid")

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -26,6 +26,7 @@ from .. import Target, target_factory
 from ..util.proxy import proxymanager
 from ..util.helper import processwrapper
 from ..driver import Mode
+from .. import __version__ as lg_version
 
 txaio.use_asyncio()
 txaio.config.loop = asyncio.get_event_loop()
@@ -1208,6 +1209,9 @@ class ClientSession(ApplicationSession):
             print("Reservation '{}':".format(res.token))
             res.show(level=1)
 
+    async def print_version(self):
+        print("Labgrid version", lg_version)
+
 
 def start_session(url, realm, extra):
     from autobahn.asyncio.wamp import ApplicationRunner
@@ -1572,6 +1576,9 @@ def main():
 
     subparser = subparsers.add_parser('reservations', help="list current reservations")
     subparser.set_defaults(func=ClientSession.print_reservations)
+
+    subparser = subparsers.add_parser('version', help="retrieve installed labgrid version")
+    subparser.set_defaults(func=ClientSession.print_version)
 
     # make any leftover arguments available for some commands
     args, leftover = parser.parse_known_args()

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -193,6 +193,8 @@ matches anything.
 \fBwait\fP token                  Wait for a reservation to be allocated
 .sp
 \fBreservations\fP                List current reservations
+.sp
+\fBversion\fP                     Print current labgrid version
 .SH ADDING NAMED RESOURCES
 .sp
 If a target contains multiple Resources of the same type, named matches need to

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -188,6 +188,8 @@ LABGRID-CLIENT COMMANDS
 
 ``reservations``                List current reservations
 
+``version``                     Print current labgrid version
+
 ADDING NAMED RESOURCES
 ----------------------
 If a target contains multiple Resources of the same type, named matches need to


### PR DESCRIPTION
**Description**
PEP 396 compliant `__version__` and output in the labgrid-client command.

**Checklist**
- [ ] Tests for the feature 
- [x] PR has been tested
- [x] Man pages have been regenerated

Fixes #714 
