### PR TITLE
add support for USB HID relays

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -274,6 +274,28 @@ NetworkLXAIOBusPIO
 ++++++++++++++++++
 A NetworkLXAIOBusPIO descibes an `LXAIOBusPIO`_ exported over the network.
 
+HIDRelay
+++++++++
+An :any:`HIDRelay` resource describes a single output of a HID protocol based
+USB relays.
+It currently supports the widely used "dcttech USBRelay".
+
+.. code-block:: yaml
+
+   HIDRelay:
+     index: 2
+     invert: False
+
+- index (int): number of the relay to use (defaults to 1)
+- invert (bool): whether to invert the relay
+
+Used by:
+  - `HIDRelayDriver`_
+
+NetworkHIDRelay
++++++++++++++++
+A NetworkHIDRelay descibes an `HIDRelay`_ exported over the network.
+
 NetworkService
 ~~~~~~~~~~~~~~
 A NetworkService describes a remote SSH connection.
@@ -1396,6 +1418,26 @@ Implements:
 .. code-block:: yaml
 
    ModbusCoilDriver: {}
+
+Arguments:
+  - None
+
+HIDRelayDriver
+~~~~~~~~~~~~~~
+A HIDRelayDriver controls a `HIDRelay` or `NetworkHIDRelay` resource.
+It can set and get the current state of the resource.
+
+Binds to:
+  relay:
+    - `HIDRelay`_
+    - `NetworkHIDRelay`_
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   HIDRelayDriver: {}
 
 Arguments:
   - None

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -203,8 +203,11 @@ The example describes port 1 on the hub with the ID_PATH
 Used by:
   - `SiSPMPowerDriver`_
 
+Digital Outputs
+~~~~~~~~~~~~~~~
+
 ModbusTCPCoil
-~~~~~~~~~~~~~
++++++++++++++
 A ModbusTCPCoil describes a coil accessible via ModbusTCP.
 
 .. code-block:: yaml
@@ -222,6 +225,54 @@ The example describes the coil with the address 1 on the ModbusTCP device
 
 Used by:
   - `ModbusCoilDriver`_
+
+OneWirePIO
+++++++++++
+A OneWirePIO describes a onewire programmable I/O pin.
+
+.. code-block:: yaml
+
+   OneWirePIO:
+     host: example.computer
+     path: /29.7D6913000000/PIO.0
+     invert: false
+
+The example describes a `PIO.0` at device address `29.7D6913000000` via the onewire
+server on `example.computer`.
+
+- host (str): hostname of the remote system running the onewire server
+- path (str): path on the server to the programmable I/O pin
+- invert (bool): optional, whether the logic level is be inverted (active-low)
+
+Used by:
+  - `OneWirePIODriver`_
+
+LXAIOBusPIO
++++++++++++
+An :any:`LXAIOBusPIO` resource describes a single PIO pin on an LXAIOBusNode.
+
+.. code-block:: yaml
+
+   LXAIOBusPIO:
+     host: localhost:8080
+     node: IOMux-00000003
+     pin: OUT0
+     invert: False
+
+The example uses an lxa-iobus-server running on localhost:8080, with node
+IOMux-00000003 and pin OUT0.
+
+- host (str): hostname with port of the lxa-io-bus server
+- node (str): name of the node to use
+- pin (str): name of the pin to use
+- invert (bool): whether to invert the pin
+
+Used by:
+  - `LXAIOBusPIODriver`_
+
+NetworkLXAIOBusPIO
+++++++++++++++++++
+A NetworkLXAIOBusPIO descibes an `LXAIOBusPIO`_ exported over the network.
 
 NetworkService
 ~~~~~~~~~~~~~~
@@ -252,27 +303,6 @@ These and the sudo configuration needs to be prepared by the administrator.
 
 Used by:
   - `SSHDriver`_
-
-OneWirePIO
-~~~~~~~~~~
-A OneWirePIO describes a onewire programmable I/O pin.
-
-.. code-block:: yaml
-
-   OneWirePIO:
-     host: example.computer
-     path: /29.7D6913000000/PIO.0
-     invert: false
-
-The example describes a `PIO.0` at device address `29.7D6913000000` via the onewire
-server on `example.computer`.
-
-- host (str): hostname of the remote system running the onewire server
-- path (str): path on the server to the programmable I/O pin
-- invert (bool): optional, whether the logic level is be inverted (active-low)
-
-Used by:
-  - `OneWirePIODriver`_
 
 USBMassStorage
 ~~~~~~~~~~~~~~
@@ -692,34 +722,6 @@ therefore auto-cleanup is important.
 
 Used by:
   - `DockerDriver`_
-
-LXAIOBusPIO
-~~~~~~~~~~~
-
-An :any:`LXAIOBusPIO` resource describes a single PIO pin on an LXAIOBusNode.
-
-.. code-block:: yaml
-
-   LXAIOBusPIO:
-     host: localhost:8080
-     node: IOMux-00000003
-     pin: OUT0
-     invert: False
-
-The example uses an lxa-iobus-server running on localhost:8080, with node
-IOMux-00000003 and pin OUT0.
-
-- host (str): hostname with port of the lxa-io-bus server
-- node (str): name of the node to use
-- pin (str): name of the pin to use
-- invert (bool): whether to invert the pin
-
-Used by:
-  - `LXAIOBusPIODriver`_
-
-NetworkLXAIOBusPIO
-~~~~~~~~~~~~~~~~~~
-A NetworkLXAIOBusPIO descibes an `LXAIOBusPIO`_ exported over the network.
 
 udev Matching
 ~~~~~~~~~~~~~

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -30,3 +30,4 @@ from .xenadriver import XenaDriver
 from .dockerdriver import DockerDriver
 from .lxaiobusdriver import LXAIOBusPIODriver
 from .pyvisadriver import PyVISADriver
+from .usbhidrelay import HIDRelayDriver

--- a/labgrid/driver/usbhidrelay.py
+++ b/labgrid/driver/usbhidrelay.py
@@ -1,0 +1,49 @@
+# pylint: disable=no-member
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..resource.remote import NetworkHIDRelay
+from ..step import step
+from ..protocol import DigitalOutputProtocol
+from ..util.agentwrapper import AgentWrapper
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class HIDRelayDriver(Driver, DigitalOutputProtocol):
+    bindings = {
+        "relay": {"HIDRelay", NetworkHIDRelay},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.wrapper = None
+
+    def on_activate(self):
+        if isinstance(self.relay, NetworkHIDRelay):
+            host = self.relay.host
+        else:
+            host = None
+        self.wrapper = AgentWrapper(host)
+        self.proxy = self.wrapper.load('usb_hid_relay')
+
+    def on_deactivate(self):
+        self.wrapper.close()
+        self.wrapper = None
+        self.proxy = None
+
+    @Driver.check_active
+    @step(args=['status'])
+    def set(self, status):
+        if self.relay.invert:
+            status = not status
+        self.proxy.set(self.relay.busnum, self.relay.devnum, self.relay.index, status)
+
+    @Driver.check_active
+    @step(result=True)
+    def get(self):
+        status = self.proxy.get(self.relay.busnum, self.relay.devnum, self.relay.index)
+        if self.relay.invert:
+            status = not status
+        return status

--- a/labgrid/protocol/digitaloutputprotocol.py
+++ b/labgrid/protocol/digitaloutputprotocol.py
@@ -2,14 +2,14 @@ import abc
 
 
 class DigitalOutputProtocol(abc.ABC):
-    """Abstract class providing the OneWireProtocol interface"""
+    """Abstract class providing the DigitalOutputProtocol interface"""
 
     @abc.abstractmethod
     def get(self):
-        """Implementations should return the status of the OneWirePort."""
+        """Implementations should return the status of the digital output."""
         raise NotImplementedError
 
     @abc.abstractmethod
     def set(self, status):
-        """Implementations should set the status of the OneWirePort"""
+        """Implementations should set the status of the digital output"""
         raise NotImplementedError

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -432,6 +432,25 @@ class USBDeditecRelaisExport(USBGenericExport):
             'index': self.local.index,
         }
 
+@attr.s(eq=False)
+class USBHIDRelayExport(USBGenericExport):
+    """ResourceExport for outputs on simple USB HID relays"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': self.host,
+            'busnum': self.local.busnum,
+            'devnum': self.local.devnum,
+            'path': self.local.path,
+            'vendor_id': self.local.vendor_id,
+            'model_id': self.local.model_id,
+            'index': self.local.index,
+        }
+
 
 exports["AndroidFastboot"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
@@ -449,6 +468,7 @@ exports["USBTMC"] = USBGenericExport
 exports["SiSPMPowerPort"] = SiSPMPowerPortExport
 exports["USBPowerPort"] = USBPowerPortExport
 exports["DeditecRelais8"] = USBDeditecRelaisExport
+exports["HIDRelay"] = USBHIDRelayExport
 
 
 @attr.s

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -270,6 +270,17 @@ class NetworkDeditecRelais8(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkHIDRelay(RemoteUSBResource):
+    """The NetworkHIDRelay describes a remotely accessible USB relay port"""
+    index = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkSysfsGPIO(NetworkResource, ManagedResource):
     manager_cls = RemotePlaceManager
 

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -580,3 +580,15 @@ class DeditecRelais8(USBResource):
         # Deditec does not set proper model/vendor IDs, so we use ID_MODEL instead
         self.match['ID_MODEL'] = 'DEDITEC_USB-OPT_REL-8'
         super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class HIDRelay(USBResource):
+    index = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+
+    def __attrs_post_init__(self):
+        self.match['ID_VENDOR_ID'] = '16c0'
+        self.match['ID_MODEL_ID'] = '05df'
+        super().__attrs_post_init__()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -580,10 +580,3 @@ class DeditecRelais8(USBResource):
         # Deditec does not set proper model/vendor IDs, so we use ID_MODEL instead
         self.match['ID_MODEL'] = 'DEDITEC_USB-OPT_REL-8'
         super().__attrs_post_init__()
-
-    @property
-    def path(self):
-        if self.device is not None:
-            return self.device.device_path
-
-        return None

--- a/labgrid/util/agents/usb_hid_relay.py
+++ b/labgrid/util/agents/usb_hid_relay.py
@@ -1,0 +1,68 @@
+"""
+This module implements the communication protocol to switch the digital outputs
+on a "dcttech" USB Relay.
+
+Supported modules:
+
+- USBRelay2 (and likely others)
+
+Supported Functionality:
+
+- Turn digital output on and off
+"""
+import usb.core
+import usb.util
+
+GET_REPORT = 0x1
+SET_REPORT = 0x9
+REPORT_TYPE_FEATURE = 3
+
+
+class USBHIDRelay:
+    def __init__(self, **args):
+        self._dev = usb.core.find(**args)
+        if self._dev is None:
+            raise ValueError("Device not found")
+        if self._dev.is_kernel_driver_active(0):
+            self._dev.detach_kernel_driver(0)
+
+    def set_output(self, number, status):
+        assert 1 <= number <= 8
+        req = [0xFF if status else 0xFD, number]
+        resp = self._dev.ctrl_transfer(
+            usb.util.CTRL_TYPE_CLASS | usb.util.CTRL_RECIPIENT_DEVICE | usb.util.ENDPOINT_OUT,
+            SET_REPORT,
+            (REPORT_TYPE_FEATURE << 8) | 0, # no report ID
+            0,
+            req, # payload
+        )
+
+    def get_output(self, number):
+        assert 1 <= number <= 8
+        resp = self._dev.ctrl_transfer(
+            usb.util.CTRL_TYPE_CLASS | usb.util.CTRL_RECIPIENT_DEVICE | usb.util.ENDPOINT_IN,
+            GET_REPORT,
+            (REPORT_TYPE_FEATURE << 8) | 0, # no report ID
+            0,
+            8, # size
+        )
+        return bool(resp[7] & (1 << (number-1)))
+
+    def __del__(self):
+        usb.util.release_interface(self._dev, 0)
+
+
+def handle_set(busnum, devnum, number, status):
+    relay = USBHIDRelay(bus=busnum, address=devnum)
+    relay.set_output(number, status)
+
+
+def handle_get(busnum, devnum, number):
+    relay = USBHIDRelay(bus=busnum, address=devnum)
+    return relay.get_output(number)
+
+
+methods = {
+    'set': handle_set,
+    'get': handle_get,
+}

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -106,7 +106,10 @@ def test_all_modules():
     methods = aw.list()
     assert 'sysfsgpio.set' in methods
     assert 'sysfsgpio.get' in methods
-
+    aw.load('usb_hid_relay')
+    methods = aw.list()
+    assert 'usb_hid_relay.set' in methods
+    assert 'usb_hid_relay.get' in methods
 
 def test_import_modules():
     import labgrid.util.agents


### PR DESCRIPTION
**Description**
This adds local and remote support for simple USB HID relays. Support for more protocols can be added easily to the agent.

**Checklist**
- [x] Documentation for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested