### PR TITLE
Fix DuplicateBinding Error for optional bindings of the same protcol

### DIFF
--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -347,7 +347,7 @@ class Target:
                 raise NoSupplierFoundError("conflicting suppliers matching {} found in target {}".format(requirements, self))  # pylint: disable=line-too-long
             else:
                 supplier = suppliers[0]
-            if (requirement, supplier) in bound_req_pairs:
+            if supplier is not None and (requirement, supplier) in bound_req_pairs:
                 raise BindingError(
                     "duplicate bindings of {} for {} found in target {}".format(
                         supplier, requirement, self)

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -349,8 +349,8 @@ class Target:
                 supplier = suppliers[0]
             if supplier is not None and (requirement, supplier) in bound_req_pairs:
                 raise BindingError(
-                    "duplicate bindings of {} for {} found in target {}".format(
-                        supplier, requirement, self)
+                    "duplicate bindings of {} to {} for {} found in target {}".format(
+                        supplier, name, requirement, self)
                 )
             bound_req_pairs.add((requirement, supplier))
             setattr(client, name, supplier)

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -468,3 +468,28 @@ def test_allow_optional_no_available_binding_by_different_protocols(target):
 
     assert s.a == None
     assert s.b == None
+
+def test_allow_optional_no_double_same_protocol_by_different_protocols(target):
+    class AOpt4DiffProtocol(abc.ABC):
+        pass
+
+    class Opt4DiffDriver(Driver, AOpt4DiffProtocol):
+        pass
+
+    class Opt4DiffStrategy(Strategy):
+        bindings = {
+            "a": {AOpt4DiffProtocol, None},
+            "b": {AOpt4DiffProtocol, None},
+            "c": {AOpt4DiffProtocol, None},
+            "d": {AOpt4DiffProtocol, None},
+        }
+
+    d1 = Opt4DiffDriver(target, name="driver1")
+    d2 = Opt4DiffDriver(target, name="driver2")
+    target.set_binding_map({"c": "driver1", "d": "driver2"})
+    s = Opt4DiffStrategy(target, None)
+
+    assert s.a is None
+    assert s.b is None
+    assert s.c == d1
+    assert s.d == d2


### PR DESCRIPTION
**Description**

Allow optional bindings to the same protocol if both are not available. We simply ignore this case since we don't care about a duplicate binding than.

**Checklist**

- [x] Tests for the feature 
- [x] PR has been tested
