### PR TITLE
exporter: Correctly handle serial baud rates other than 115200

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -230,7 +230,7 @@ class SerialPortExport(ResourceExport):
                 '-d',
                 '-n',
                 '-Y', 'connection: &con01#  accepter: telnet(rfc2217,mode=server),{}'.format(self.port),
-                '-Y', '  connector: serialdev(nouucplock=true),{},115200n81,local'.format(start_params['path']
+                '-Y', '  connector: serialdev(nouucplock=true),{},{}n81,local'.format(start_params['path'], start_params['speed'],
                 ),
             ])
         else:
@@ -240,8 +240,8 @@ class SerialPortExport(ResourceExport):
                 '-n',
                 '-u',
                 '-C',
-                '{}:telnet:0:{}:115200 NONE 8DATABITS 1STOPBIT LOCAL'.format(
-                    self.port, start_params['path']
+                '{}:telnet:0:{}:{} NONE 8DATABITS 1STOPBIT LOCAL'.format(
+                    self.port, start_params['path'], start_params['speed']
                 ),
             ])
         try:


### PR DESCRIPTION
The exporter was ignoring the device baud rate when invoking ser2net and
always connected at 115200 baud. Change the exporter to correctly
respect the device baud rate.

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
