### PR TITLE
driver/power: add support for REST based relays controlling power

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ New Features in 0.4.0
   supports 8 or 256 colors, and defaults to the respective dark variant.
   The 256-color schemes now use purple instead of green for the ``run`` lines to
   make them easier distinguishable from pytest's "PASSED" output.
+- Network controlled relay providing GET/PUT based REST API
 
 Breaking changes in 0.4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -108,6 +108,56 @@ The example describes port 0 on the remote power switch
 - host (str): hostname of the power switch
 - index (int): number of the port to switch
 
+The `model` property selects one of several `backend implementations
+<https://github.com/labgrid-project/labgrid/tree/master/labgrid/driver/power>`_.
+Currently available are:
+
+``apc``
+  Controls an APU PDU via SNMP.
+
+``digipower``
+  Controls a DigiPower PDU via a simple HTTP API.
+
+``gude``
+  Controls a Gude PDU via a simple HTTP API.
+
+``gude24``
+  Controls a Gude Expert Power Control 8008 PDU via a simple HTTP API.
+
+``gude8031``
+  Controls a Gude Expert Power Control 8031 PDU via a simple HTTP API.
+
+``gude8316``
+  Controls a Gude Expert Power Control 8316 PDU via a simple HTTP API.
+
+``netio``
+  Controls a NETIO 4-Port PDU via a simple HTTP API.
+
+``netio_kshell``
+  Controls a NETIO 4C PDU via a Telnet interface.
+
+``rest``
+  This is a generic backend for PDU implementations which can be controled via
+  HTTP PUT and GET requests.
+  See the `docstring in the module
+  <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/rest.py>`__
+  for details.
+
+``senty``
+  Controls a Sentry PDU via SNMP using Sentry3-MIB.
+  It was tested on CW-24VDD and 4805-XLS-16.
+
+``siglent``
+  Controls Siglent SPD3000X series modules via the `vxi11 Python module
+  <https://pypi.org/project/python-vxi11/>`_.
+
+``simplerest``
+  This is a generic backend for PDU implementations which can be controled via
+  HTTP GET requests (both set and get).
+  See the `docstring in the module
+  <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
+  for details.
+
 Used by:
   - `NetworkPowerDriver`_
 

--- a/labgrid/driver/power/rest.py
+++ b/labgrid/driver/power/rest.py
@@ -1,0 +1,26 @@
+"""Rest interface for controlling power port, using PUT / GET on a URL.
+
+  NetworkPowerPort:
+      model: rest
+      host: 'http://192.168.0.42/relay/{index}/value'
+      index: 3
+
+  Will do a GET request to http://192.168.0.42/relay/3/value to get current
+  relay state, expecting a response of either '0' (relay off) or '1' (relay
+  on), and a PUT request to http://192.168.0.42/relay/3/value with request
+  data of '0' or '1' to change relay state.
+
+"""
+
+import requests
+
+def power_set(host, port, index, value):
+    assert port is None
+    value = b"1" if value else b"0"
+    requests.put(host.format(index=index), data=value)
+
+def power_get(host, port, index):
+    assert port is None
+    r = requests.get(host.format(index=index))
+    r.raise_for_status()
+    return r.text == "1"

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -167,6 +167,7 @@ class TestNetworkPowerDriver:
         import labgrid.driver.power.gude24
         import labgrid.driver.power.netio
         import labgrid.driver.power.netio_kshell
+        import labgrid.driver.power.rest
         import labgrid.driver.power.sentry
 
     def test_import_backend_siglent(self):


### PR DESCRIPTION
**Description**

Add a new driver to support relay based power control where relay is controlled with a REST API with a simple GET/PUT request to the same URL.

This is different from simplerest driver, as it relies on REST interface using
GET to query status, and PUT to change status, where as simplerest driver uses
GET for both purposes.

These two models are therefore inherently incompatible, and supplements each
other.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested