### PR TITLE
ubootdriver: allow overriding of await boot timeout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features in 0.4.0
 
 - The `NetworkPowerDriver` now additionally supports:
   - Siglent SPD3000X series power supplies
+- UBootDriver now allows overriding of currently fixed await boot timeout
+  via new ``boot_timeout`` argument.
 
 Breaking changes in 0.4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -30,6 +30,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         bootstring (str): string that indicates that the Kernel is booting
         boot_command (str): optional boot command to boot target
         login_timeout (int): optional, timeout for login prompt detection
+        boot_timeout (int): optional, timeout for initial Linux version detection
 
     """
     bindings = {"console": ConsoleProtocol, }
@@ -43,6 +44,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     bootstring = attr.ib(default=r"Linux version \d", validator=attr.validators.instance_of(str))
     boot_command = attr.ib(default="run bootcmd", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
+    boot_timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -173,7 +175,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         """Wait for the initial Linux version string to verify we succesfully
         jumped into the kernel.
         """
-        self.console.expect(self.bootstring)
+        self.console.expect(self.bootstring, timeout=self.boot_timeout)
 
     @Driver.check_active
     @step(args=['name'])


### PR DESCRIPTION
**Description**

Current 30 second timeout used by default in `await_boot()` might not be
enough in some corner cases where we for example boot large initramfs
images over network, which take some time to load, decompress and boot:

```
 await_boot state='start'
    expect state='start', args={'pattern': 'Linux version \\d'}
    expect state='stop', result=(0, b"bootm 0x83000000 ... b'Linux version 4'), duration=42.025
```

So make it possible to override the default timeout via new `boot_timeout` variable.

**Checklist**
- [x] Documentation for the feature
- [x] CHANGES.rst has been updated
- [x] PR has been tested on ipq40xx based device
