### PR TITLE
docker: base: fix Python cryptography build failure

### DIFF
--- a/dockerfiles/base/Dockerfile
+++ b/dockerfiles/base/Dockerfile
@@ -9,6 +9,7 @@ COPY ./ /opt/labgrid/
 RUN set -e ;\
     apt update -q=2 ;\
     apt install -q=2 --yes --no-install-recommends python3 python3-dev python3-pip python3-setuptools python3-wheel git build-essential libsnappy-dev ;\
+    pip3 install -U pip;\
     apt clean ;\
     rm -rf /var/lib/apt/lists/* ;\
     git clone git://github.com/vishnubob/wait-for-it.git opt/wait-for-it && cd opt/wait-for-it  && git reset --hard 54d1f0bfeb6557adf8a3204455389d0901652242


### PR DESCRIPTION
It seems like recent Python cryptography package versions need Rust
compiler present for OpenSSL wrapper, which leads to following error:

```
 generating cffi module 'build/temp.linux-x86_64-3.7/_openssl.c'
 running build_rust
 ...
 error: Can not find Rust compiler
```

There is following note regarding this issue in the documentation:

> If you are on RHEL/CentOS/Fedora/Debian/Ubuntu or another distribution
 derived from the preceding list, then you should upgrade pip (in a
 virtual environment!) and attempt to install cryptography again before
 trying to install the Rust toolchain. These platforms will receive a
 binary wheel and require no compiler if you have an updated pip!

So fix this by recommended pip update.

References: https://cryptography.io/en/latest/installation.html#rust