### PR TITLE
ColoredStepReporter: be compatible with 8-color terminals

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
-        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev
+        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev ncurses-term
         sudo mkdir -p /var/cache/labgrid/runner && sudo chown runner /var/cache/labgrid/runner
     - name: Prepare local SSH
       run: |
@@ -51,7 +51,7 @@ jobs:
     #    flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner -k "not test_docker_with_daemon"
+        TERM=xterm pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner -k "not test_docker_with_daemon"
     - name: Build documentation
       run: |
         python setup.py build_sphinx

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ New Features in 0.4.0
   - Siglent SPD3000X series power supplies
 - UBootDriver now allows overriding of currently fixed await boot timeout
   via new ``boot_timeout`` argument.
+- With ``--lg-colored-steps``, two new ``dark`` and ``light`` color schemes
+  which only use the standard 8 ANSI colors can be set in ``LG_COLOR_SCHEME``.
+  The existing color schemes have been renamed to ``dark-256color`` and ``light-256color``.
+  Also, the `ColoredStepReporter` now tries to autodetect whether the terminal
+  supports 8 or 256 colors, and defaults to the respective dark variant.
+  The 256-color schemes now use purple instead of green for the ``run`` lines to
+  make them easier distinguishable from pytest's "PASSED" output.
 
 Breaking changes in 0.4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -344,9 +344,13 @@ Behaves like ``LG_ENV`` for :doc:`labgrid-client <man/client>`.
 
 LG_COLOR_SCHEME
 ^^^^^^^^^^^^^^^
-Influences the color scheme used for the Colored Step Reporter. ``dark``
-(default) is meant for dark terminal background.
+Influences the color scheme used for the Colored Step Reporter.
+``dark`` is meant for dark terminal background.
 ``light`` is optimized for light terminal background.
+``dark-256color`` and ``light-256color`` are respective variants for terminals
+that support 256 colors.
+By default, ``dark`` or ``dark-256color`` (depending on the terminal) are used.
+
 Takes effect only when used with ``--lg-colored-steps``.
 
 LG_PROXY

--- a/labgrid/pytestplugin/reporter.py
+++ b/labgrid/pytestplugin/reporter.py
@@ -129,7 +129,7 @@ class StepReporter:
 class ColoredStepReporter(StepReporter):
     EVENT_COLORS_DARK = {
         'expect$': 8, # dark gray (a lot of output, blend into background)
-        'run': 10, # green
+        'run': 129, # light purple
         'state_': 51, # light blue
         'transition$': 45, # blue
         'cycle$|on$|off$': 246, # light gray
@@ -137,7 +137,7 @@ class ColoredStepReporter(StepReporter):
 
     EVENT_COLORS_LIGHT = {
         'expect$': 250, # light gray (a lot of output, blend into background)
-        'run': 10, # green
+        'run': 93, # purple
         'state_': 51, # light blue
         'transition$': 45, # blue
         'cycle$|on$|off$': 8, # dark gray

--- a/labgrid/pytestplugin/reporter.py
+++ b/labgrid/pytestplugin/reporter.py
@@ -128,6 +128,22 @@ class StepReporter:
 
 class ColoredStepReporter(StepReporter):
     EVENT_COLORS_DARK = {
+        'expect$': 'blue', # (a lot of output, blend into background)
+        'run': 'magenta',
+        'state_': 'cyan',
+        'transition$': 'yellow',
+        'cycle$|on$|off$': 'white',
+    }
+
+    EVENT_COLORS_LIGHT = {
+        'expect$': 'white', # (a lot of output, blend into background)
+        'run': 'magenta',
+        'state_': 'cyan',
+        'transition$': 'yellow',
+        'cycle$|on$|off$': 'blue',
+    }
+
+    EVENT_COLORS_DARK_256COLOR = {
         'expect$': 8, # dark gray (a lot of output, blend into background)
         'run': 129, # light purple
         'state_': 51, # light blue
@@ -135,7 +151,7 @@ class ColoredStepReporter(StepReporter):
         'cycle$|on$|off$': 246, # light gray
     }
 
-    EVENT_COLORS_LIGHT = {
+    EVENT_COLORS_LIGHT_256COLOR = {
         'expect$': 250, # light gray (a lot of output, blend into background)
         'run': 93, # purple
         'state_': 51, # light blue
@@ -146,15 +162,26 @@ class ColoredStepReporter(StepReporter):
     EVENT_COLOR_SCHEMES = {
         'dark': EVENT_COLORS_DARK,
         'light': EVENT_COLORS_LIGHT,
+        'dark-256color': EVENT_COLORS_DARK_256COLOR,
+        'light-256color': EVENT_COLORS_LIGHT_256COLOR,
     }
 
     def __init__(self, terminalreporter, *, rewrite=False):
         super().__init__(terminalreporter, rewrite=rewrite)
 
-        scheme = os.environ.get('LG_COLOR_SCHEME', 'dark')
-        if not scheme in ColoredStepReporter.EVENT_COLOR_SCHEMES.keys():
-            logging.warning("Color scheme '{}' unknown".format(scheme))
-            scheme = 'dark'
+        try:
+            import curses
+            default_scheme = 'dark'
+            curses.setupterm()
+            if curses.tigetnum("colors") >= 256:
+                default_scheme = 'dark-256color'
+        except ModuleNotFoundError:
+            default_scheme = 'dark-256color'
+
+        scheme = os.environ.get('LG_COLOR_SCHEME', default_scheme)
+        if scheme not in ColoredStepReporter.EVENT_COLOR_SCHEMES.keys():
+            logging.warning("Color scheme '%s' unknown", scheme)
+            scheme = default_scheme
 
         self.color_scheme = ColoredStepReporter.EVENT_COLOR_SCHEMES[scheme]
 

--- a/labgrid/pytestplugin/reporter.py
+++ b/labgrid/pytestplugin/reporter.py
@@ -143,14 +143,20 @@ class ColoredStepReporter(StepReporter):
         'cycle$|on$|off$': 8, # dark gray
     }
 
+    EVENT_COLOR_SCHEMES = {
+        'dark': EVENT_COLORS_DARK,
+        'light': EVENT_COLORS_LIGHT,
+    }
+
     def __init__(self, terminalreporter, *, rewrite=False):
         super().__init__(terminalreporter, rewrite=rewrite)
 
         scheme = os.environ.get('LG_COLOR_SCHEME', 'dark')
-        if scheme == 'light':
-            self.color_scheme = ColoredStepReporter.EVENT_COLORS_LIGHT
-        else:
-            self.color_scheme = ColoredStepReporter.EVENT_COLORS_DARK
+        if not scheme in ColoredStepReporter.EVENT_COLOR_SCHEMES.keys():
+            logging.warning("Color scheme '{}' unknown".format(scheme))
+            scheme = 'dark'
+
+        self.color_scheme = ColoredStepReporter.EVENT_COLOR_SCHEMES[scheme]
 
     def __event_color(self, event):
         for pattern, color in self.color_scheme.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import logging
 import sys
 import threading
 from importlib.util import find_spec
@@ -9,6 +10,16 @@ from labgrid import Target
 from labgrid.driver import SerialDriver
 from labgrid.resource import RawSerialPort, NetworkSerialPort
 from labgrid.driver.fake import FakeConsoleDriver
+
+@pytest.fixture(scope="session")
+def curses_init():
+    """ curses only reads the terminfo DB once on the first import, so make
+    sure we prime it correctly."""
+    try:
+        import curses
+        curses.setupterm("linux")
+    except ModuleNotFoundError:
+        logging.warning("curses module not found, not setting up a default terminal – tests may fail")
 
 def keep_reading(spawn):
     "The output from background processes must be read to avoid blocking them."


### PR DESCRIPTION
The default color schemes use 256-color escape sequences, which are not fully supported by all terminals (e.g. the Linux virtual console).

First refactor the exiting code a bit.

Then add two more dark and light color schemes that only use the original 8 colors. Then try to detect if the terminal in use understands the enhanced escape codes, and in that case use the 256-color dark scheme by default.

As a side effect, the two new color schemes also work well in terminals with "solarized" color schemes.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested