### PR TITLE
README: update badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Welcome to labgrid
 ==================
 
-|license| |unit-tests| |coverage-status| |docs-status| |chat|
+|license| |unit-tests| |docker-build| |coverage-status| |docs-status| |chat|
 
 Purpose
 -------
@@ -100,6 +100,10 @@ Tests can now run via:
 .. |unit-tests| image:: https://github.com/labgrid-project/labgrid/workflows/unit%20tests/badge.svg
     :alt: unit tests status
     :target: https://github.com/labgrid-project/labgrid/actions?query=workflow%3A%22unit+tests%22+branch%3Amaster
+
+.. |docker-build| image:: https://github.com/labgrid-project/labgrid/workflows/docker%20build/badge.svg
+    :alt: docker build status
+    :target: https://github.com/labgrid-project/labgrid/actions?query=workflow%3A%22docker+build%22+branch%3Amaster
 
 .. |coverage-status| image:: https://codecov.io/gh/labgrid-project/labgrid/branch/master/graph/badge.svg
     :alt: coverage status

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 Welcome to labgrid
 ==================
 
-|license| |build-status| |coverage-status| |docs-status| |chat|
+|license| |unit-tests| |coverage-status| |docs-status| |chat|
 
 Purpose
 -------
@@ -97,9 +97,9 @@ Tests can now run via:
     :alt: LGPLv2.1
     :target: https://raw.githubusercontent.com/labgrid-project/labgrid/master/LICENSE
 
-.. |build-status| image:: https://img.shields.io/travis/com/labgrid-project/labgrid/master.svg?style=flat
-    :alt: build status
-    :target: https://travis-ci.com/labgrid-project/labgrid
+.. |unit-tests| image:: https://github.com/labgrid-project/labgrid/workflows/unit%20tests/badge.svg
+    :alt: unit tests status
+    :target: https://github.com/labgrid-project/labgrid/actions?query=workflow%3A%22unit+tests%22+branch%3Amaster
 
 .. |coverage-status| image:: https://codecov.io/gh/labgrid-project/labgrid/branch/master/graph/badge.svg
     :alt: coverage status


### PR DESCRIPTION
**Description**
Drop the Travis CI badge in favor of GitHub actions unit tests/docker build workflow badges.