### PR TITLE
driver: quartushpsdriver: retry on broken JTAG chain

### DIFF
--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -28,18 +28,14 @@ class QuartusHPSDriver(Driver):
         # FIXME make sure we always have an environment or config
         if self.target.env:
             self.tool = self.target.env.config.get_tool('quartus_hps') or 'quartus_hps'
+            self.jtag_tool = self.target.env.config.get_tool('jtagconfig') or 'jtagconfig'
         else:
             self.tool = 'quartus_hps'
+            self.jtag_tool = 'jtagconfig'
 
     def _get_cable_number(self):
         """Returns the JTAG cable numer for the USB path of the device"""
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            jtagconfig_tool = self.target.env.config.get_tool('jtagconfig') or 'jtagconfig'
-        else:
-            jtagconfig_tool = 'jtagconfig'
-
-        cmd = self.interface.command_prefix + [jtagconfig_tool]
+        cmd = self.interface.command_prefix + [self.jtag_tool]
         jtagconfig_process = subprocess.Popen(
             cmd,
             stdout=subprocess.PIPE


### PR DESCRIPTION
**Description**
It might take a while until an intact JTAG chain is available, so keep retrying for a while. There is no point in using a JTAG cable with a broken chain, so bail out in case no intact chain is found.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] CHANGES.rst has been updated
- [x] PR has been tested