### PR TITLE
driver/sshdriver: use SSH_ASKPASS instead of sshpass

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -359,7 +359,7 @@ A NetworkService describes a remote SSH connection.
 The example describes a remote SSH connection to the computer `example.computer`
 with the username `root`.
 Set the optional password password property to make SSH login with a password
-instead of the key file (needs sshpass to be installed)
+instead of the key file.
 
 When used with ``labgrid-exporter``, the address can contain a device scope
 suffix (such as ``%eth1``), which is especially useful with overlapping address

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -26,7 +26,7 @@ RUN set -e ;\
     pip3 install --no-cache-dir -r requirements.txt ;\
     SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" python3 setup.py install ;\
     apt update -q=2 ;\
-    apt install -q=2 --yes --no-install-recommends microcom openssh-client sshpass rsync jq qemu-system; \
+    apt install -q=2 --yes --no-install-recommends microcom openssh-client rsync jq qemu-system; \
     apt clean ;\
     rm -rf /var/lib/apt/lists/*
 

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -399,7 +399,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def _start_keepalive(self):
         """Starts a keepalive connection via the own or external master."""
-        args = ["ssh", *self.ssh_prefix, "cat"]
+        args = ["ssh", *self.ssh_prefix, self.networkservice.address, "cat"]
 
         assert self._keepalive is None
         self._keepalive = subprocess.Popen(

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -12,10 +12,7 @@ from labgrid.exceptions import NoResourceFoundError
 
 
 def check_external_progs_present():
-    """Determine if host machine has sshpass and a usable docker daemon"""
-    from shutil import which
-    if not which('sshpass'):
-        return False
+    """Determine if host machine has a usable docker daemon"""
     try:
         import docker
         dock = docker.from_env()


### PR DESCRIPTION
**Description**

Fixes bug #697 when connecting to a place via ssh proxy. I have tried to use both, subprocess/Popen/write and pexpect/spawn/expect/sendline to write the password to stdin, but as sshpass, it only works when connecting without proxy and fails when connecting via ssh proxycommand. Then I found the builtin ssh option SSH_ASKPASS, which is the only left way to pass the password from a script, or a graphical user interface to the agent. It may not be the most elegant solution, but it works for us and it is robust.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated

<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
