### PR TITLE
requirements.txt: move pyvisa requirements to general requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,5 +13,4 @@ psutil==5.6.6
 -r xena-requirements.txt
 -r graph-requirements.txt
 -r docker-requirements.txt
--r pyvisa-requirements.txt
 -r vxi11-requirements.txt

--- a/pyvisa-requirements.txt
+++ b/pyvisa-requirements.txt
@@ -1,2 +1,0 @@
-pyvisa==1.10.1
-PyVISA-py==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ PyYAML==5.3.1
 ansicolors==1.1.8
 pyusb==1.1.0
 six>=1.13.0
+pyvisa==1.10.1
+PyVISA-py==0.4.1


### PR DESCRIPTION
**Description**
As pyvisa has no host OS dependencies there is no good reason for
managing the dependencies for this in it's own file

Tested locally and by rebuilding docker images

**Checklist**
- [x] PR has been tested

