### PR TITLE
Dockerfile: Add dev-requirements dependencies to client image

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -21,14 +21,14 @@ FROM labgrid-base AS labgrid-client
 ARG VERSION
 
 RUN set -e ;\
+    apt update -q=2 ;\
+    apt install -q=2 --yes --no-install-recommends microcom openssh-client sshpass rsync jq qemu-system libow-dev ;\
+    apt clean ;\
+    rm -rf /var/lib/apt/lists/* ;\
     cd /opt/labgrid ;\
     pip3 install yq ;\
-    pip3 install --no-cache-dir -r requirements.txt ;\
-    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" python3 setup.py install ;\
-    apt update -q=2 ;\
-    apt install -q=2 --yes --no-install-recommends microcom openssh-client sshpass rsync jq qemu-system; \
-    apt clean ;\
-    rm -rf /var/lib/apt/lists/*
+    pip3 install --no-cache-dir -r requirements.txt -r dev-requirements.txt ;\
+    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" python3 setup.py install
 
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
**Description**
Add dev-requirements and lib onewire to the labgrid-client  image 

- [x] PR has been tested

