### PR TITLE
add NetworkManager remote control via agent

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,7 +181,9 @@ autodoc_mock_imports = ['onewire',
                         'autobahn.twisted',
                         'autobahn.twisted.wamp',
                         'autobahn.wamp.exception',
-                        'twisted.internet.defer']
+                        'twisted.internet.defer',
+                        'gi',
+                        'gi.repository',]
 
 # -- Options for autosection ----------------------------------------------
 autosectionlabel_prefix_document = True

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -493,13 +493,14 @@ An AndroidFastboot resource describes a USB device in the fastboot state.
 Used by:
   - `AndroidFastbootDriver`_
 
-USBEthernetInterface
+USBNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~
-A USBEthernetInterface resource describes a USB ethernet adapter.
+A USBNetworkInterface resource describes a USB network adapter (such as
+Ethernet or WiFi)
 
 .. code-block:: yaml
 
-   USBEthernetInterface:
+   USBNetworkInterface:
      match:
        'ID_PATH': 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -506,6 +506,11 @@ Ethernet or WiFi)
 
 - match (str): key and value for a udev match, see `udev Matching`_
 
+RemoteNetworkInterface
+~~~~~~~~~~~~~~~~~~~~~~
+A :any:`RemoteNetworkInterface` resource describes a :any:`USBNetworkInterface`
+resource available on a remote computer.
+
 AlteraUSBBlaster
 ~~~~~~~~~~~~~~~~
 An AlteraUSBBlaster resource describes an Altera USB blaster.
@@ -2057,6 +2062,33 @@ The PyVISADriver uses a PyVISADevice resource to control test equipment manageab
 Binds to:
   pyvisa_resource:
     - `PyVISADevice`_
+
+Implements:
+  - None yet
+
+NetworkInterfaceDriver
+~~~~~~~~~~~~~~~~~~~~~~
+This driver allows controlling a network interface (such as Ethernet or WiFi) on
+the exporter using NetworkManager.
+
+The configuration is based on dictionaries with contents similar to NM's
+connection files in INI-format.
+Currently basic wired and wireless configuration options have been tested.
+
+To use it, `PyGObject <https://pygobject.readthedocs.io/>`_ must be installed
+(on the same system as the network interface).
+For Debian, the necessary packages are `python3-gi` and `gir1.2-nm-1.0`.
+
+It supports:
+- static and DHCP address configuration
+- WiFi client or AP
+- connection sharing (DHCP server with NAT)
+- listing DHCP leases (if the client has sufficient permissions)
+
+Binds to:
+  iface:
+    - `USBNetworkInterface`_
+    - `RemoteNetworkInterface`_
 
 Implements:
   - None yet

--- a/examples/networkmanager/nm.env
+++ b/examples/networkmanager/nm.env
@@ -1,0 +1,9 @@
+targets:
+  main:
+    resources:
+      RemotePlace:
+        name: nm-test
+    drivers:
+      NetworkInterfaceDriver: {}
+options:
+  crossbar_url: 'ws://labgrid/ws'

--- a/examples/networkmanager/nm.py
+++ b/examples/networkmanager/nm.py
@@ -1,0 +1,86 @@
+import logging, sys
+from pprint import pprint
+
+from labgrid import *
+
+
+# enable debug logging
+logging.basicConfig(
+    level=logging.DEBUG,
+    format='%(levelname)7s: %(message)s',
+    stream=sys.stderr,
+)
+
+# show labgrid steps on the console
+StepReporter()
+
+
+e = Environment('nm.env')
+t = e.get_target()
+d = t.get_driver('NetworkInterfaceDriver')
+
+# based on https://developer.gnome.org/NetworkManager/stable/ch01.html, but adapted to python dicts
+s_client = {
+    'connection': {
+        'type': "802-11-wireless",
+    },
+    '802-11-wireless': {
+        'mode': "infrastructure",
+        'ssid': "local-rpi",
+    },
+    '802-11-wireless-security': {
+        'key-mgmt': "wpa-psk",
+        'psk': "obMinwyurArc5",
+    },
+    'ipv4': {
+        'method': "auto",
+        'ignore-auto-dns': True,
+        'ignore-auto-routes': True,
+        'never-default': True,
+    },
+    'ipv6': {
+        'method': "link-local",
+    },
+}
+s_ap = {
+    'connection': {
+        'type': "802-11-wireless",
+    },
+    '802-11-wireless': {
+        'mode': "ap",
+        'ssid': "local-rpi",
+    },
+    '802-11-wireless-security': {
+        'key-mgmt': "wpa-psk",
+        'psk': "obMinwyurArc5",
+    },
+    'ipv4': {
+        #'method': "auto",
+        #'method': "link-local",
+        'method': "shared",
+        'addresses': ["172.16.0.2/29"],
+    },
+    'ipv6': {
+        'method': "link-local",
+    },
+}
+
+d.disable()
+d.wait_state('disconnected')
+print("access points after scan")
+pprint(d.get_access_points())
+
+d.configure(s_ap)
+d.wait_state('activated')
+print("settings in AP mode")
+pprint(d.get_settings())
+print("state in AP mode")
+pprint(d.get_state())
+
+#d.configure(s_client)
+#d.wait_state('activated')
+#print("settings in client mode")
+#pprint(d.get_settings())
+#print("state in client mode")
+#pprint(d.get_state())
+

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -33,3 +33,4 @@ from .pyvisadriver import PyVISADriver
 from .usbhidrelay import HIDRelayDriver
 from .flashscriptdriver import FlashScriptDriver
 from .usbaudiodriver import USBAudioInputDriver
+from .networkinterfacedriver import NetworkInterfaceDriver

--- a/labgrid/driver/networkinterfacedriver.py
+++ b/labgrid/driver/networkinterfacedriver.py
@@ -1,0 +1,109 @@
+# pylint: disable=no-member
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..step import step
+from ..util.agentwrapper import AgentWrapper
+from ..resource.remote import RemoteNetworkInterface
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class NetworkInterfaceDriver(Driver):
+    bindings = {
+        "iface": {"RemoteNetworkInterface", "USBNetworkInterface"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.wrapper = None
+
+    def on_activate(self):
+        if isinstance(self.iface, RemoteNetworkInterface):
+            host = self.iface.host
+        else:
+            host = None
+        self.wrapper = AgentWrapper(host)
+        self.proxy = self.wrapper.load('network_interface')
+
+    def on_deactivate(self):
+        try:
+            self.proxy.disable(self.iface.ifname)
+        finally:
+            self.wrapper.close()
+            self.wrapper = None
+            self.proxy = None
+
+    # basic
+    @Driver.check_active
+    @step()
+    def configure(self, settings):
+        "Set a configuration on this interface and activate it."
+        self.proxy.configure(self.iface.ifname, settings)
+
+    @Driver.check_active
+    @step()
+    def wait_state(self, expected, timeout=60):
+        """Wait until the expected state is reached or the timeout expires.
+
+        Possible states include disconnected and activated. See NM's
+        DeviceState for more details.
+        """
+        self.proxy.wait_state(self.iface.ifname, expected, timeout)
+
+    @Driver.check_active
+    @step()
+    def disable(self):
+        "Disable and remove the created labgrid connection."
+        self.proxy.disable(self.iface.ifname)
+
+    @Driver.check_active
+    @step()
+    def get_active_settings(self):
+        "Get the currently active settings from this interface."
+        return self.proxy.get_active_settings(self.iface.ifname)
+
+    @Driver.check_active
+    @step()
+    def get_settings(self):
+        "Get the settings of the labgrid connection for this interface."
+        return self.proxy.get_settings(self.iface.ifname)
+
+    @Driver.check_active
+    @step()
+    def get_state(self):
+        """Get the current state of this interface.
+
+        This includes information such as the addresses or WiFi connection.
+        """
+        return self.proxy.get_state(self.iface.ifname)
+
+    # dhcpd
+    @Driver.check_active
+    @step()
+    def get_dhcpd_leases(self):
+        """Get the list of active DHCP leases in shared mode.
+
+        This requires read access to /var/lib/NetworkManager/dnsmasq-* on the
+        exporter.
+        """
+
+        return self.proxy.get_dhcpd_leases(self.iface.ifname)
+
+    # wireless
+    @Driver.check_active
+    @step()
+    def request_scan(self):
+        "Request a scan to update the list visible access points."
+        return self.proxy.request_scan(self.iface.ifname)
+
+    @Driver.check_active
+    @step()
+    def get_access_points(self, scan=None):
+        """Get the list of currently visible access points.
+
+        When scan is None (the default), it will automatically trigger a scan
+        if the last scan is more than 30 seconds old.
+        """
+        return self.proxy.get_access_points(self.iface.ifname, scan)

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -274,25 +274,26 @@ exports["USBSerialPort"] = SerialPortExport
 exports["RawSerialPort"] = SerialPortExport
 
 @attr.s(eq=False)
-class USBEthernetExport(ResourceExport):
-    """ResourceExport for a USB ethernet interface"""
+class USBNetworkExport(ResourceExport):
+    """ResourceExport for a USB network interface"""
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        from ..resource.udev import USBEthernetInterface
-        self.data['cls'] = "EthernetInterface"
-        self.local = USBEthernetInterface(target=None, name=None, **self.local_params)
+        from ..resource.udev import USBNetworkInterface
+        self.data['cls'] = "RemoteNetworkInterface"
+        self.local = USBNetworkInterface(target=None, name=None, **self.local_params)
 
     def _get_params(self):
         """Helper function to return parameters"""
         return {
+            'host': self.host,
             'ifname': self.local.ifname,
             'extra': {
                 'state': self.local.if_state,
             }
         }
 
-exports["USBEthernetInterface"] = USBEthernetExport
+exports["USBNetworkInterface"] = USBNetworkExport
 
 @attr.s(eq=False)
 class USBGenericExport(ResourceExport):

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -1,4 +1,4 @@
-from .base import SerialPort, EthernetInterface, EthernetPort
+from .base import SerialPort, NetworkInterface, EthernetPort
 from .ethernetport import SNMPEthernetPort
 from .serialport import RawSerialPort, NetworkSerialPort
 from .modbus import ModbusTCPCoil

--- a/labgrid/resource/base.py
+++ b/labgrid/resource/base.py
@@ -16,8 +16,8 @@ class SerialPort(Resource):
 
 
 @attr.s(eq=False)
-class EthernetInterface(Resource):
-    """The basic EthernetInterface contains an interfacename
+class NetworkInterface(Resource):
+    """The basic NetworkInterface contains an interface name
 
     Args:
         ifname (str): name of the interface"""

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -328,3 +328,10 @@ class NetworkUSBFlashableDevice(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 30.0
         super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class RemoteNetworkInterface(NetworkResource, ManagedResource):
+    manager_cls = RemotePlaceManager
+
+    ifname = attr.ib(default=None)

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -15,7 +15,7 @@ from .udev import (
     USBSDWireDevice,
     AlteraUSBBlaster,
     RKUSBLoader,
-    USBEthernetInterface,
+    USBNetworkInterface,
     SiSPMPowerPort,
     USBAudioInput,
 )
@@ -43,7 +43,7 @@ class Suggester:
         self.resources.append(USBSDWireDevice(**args))
         self.resources.append(AlteraUSBBlaster(**args))
         self.resources.append(RKUSBLoader(**args))
-        self.resources.append(USBEthernetInterface(**args))
+        self.resources.append(USBNetworkInterface(**args))
         self.resources.append(SiSPMPowerPort(**args))
         self.resources.append(USBAudioInput(**args))
 

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -10,7 +10,7 @@ import pyudev
 
 from ..factory import target_factory
 from .common import ManagedResource, ResourceManager
-from .base import SerialPort, EthernetInterface
+from .base import SerialPort, NetworkInterface
 from ..util import Timeout
 
 
@@ -323,7 +323,7 @@ class AndroidFastboot(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
-class USBEthernetInterface(USBResource, EthernetInterface):
+class USBNetworkInterface(USBResource, NetworkInterface):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'net'
         self.match['@SUBSYSTEM'] = 'usb'

--- a/labgrid/util/agents/network_interface.py
+++ b/labgrid/util/agents/network_interface.py
@@ -1,0 +1,356 @@
+import sys
+import socket
+import threading
+from time import monotonic, sleep
+
+import gi
+gi.require_version('NM', '1.0')
+from gi.repository import GLib, NM
+
+# ensure all wrapper objects for Settings types are created
+for name in dir(NM):
+    if name.startswith('Setting'):
+        getattr(NM, name)
+
+class Future:
+    def __init__(self):
+        self._event = threading.Event()
+        self._result = None
+
+    def set(self, result):
+        assert self._result is None
+        self._result = result
+        self._event.set()
+
+    def wait(self):
+        self._event.wait()
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+class BackgroundLoop(threading.Thread):
+    def __init__(self):
+        super().__init__(daemon=True)
+
+    def run(self):
+        try:
+            GLib.MainLoop(None).run()
+        except Exception:
+            import traceback
+            traceback.print_exc()
+            sys.exit(1)
+
+    def block_on(self, func, *args, **kwargs):
+        done = threading.Event()
+        result = [None]
+
+        def cb(data):
+            result[0] = func(*args, **kwargs)
+            done.set()
+
+        GLib.main_context_default().invoke_full(GLib.PRIORITY_DEFAULT, cb, None)
+        done.wait()
+        return result[0]
+
+def address_from_str(s):
+    assert '/' in s, "IP address must be in the form address/prefix"
+    (addr, prefix) = s.split('/', 1)
+    return NM.IPAddress.new(
+            socket.AF_INET6 if ':' in addr else socket.AF_INET,
+            addr,
+            int(prefix))
+
+
+def connection_from_dict(data):
+    con = NM.SimpleConnection.new()
+    for setting_name, setting_data in data.items():
+        typ = NM.Setting.lookup_type(setting_name).pytype
+        setting = typ()
+        for k, v in setting_data.items():
+            if not v:
+                continue
+
+            if k == 'mac-address':
+                v = ':'.join("%02X" % x for x in v)
+            elif k == 'ssid':
+                if isinstance(v, str):
+                    v = v.encode()
+                v = GLib.Bytes(v)
+            elif k == 'addresses':
+                # setting addresses via the property doesn't seem to work
+                for x in v:
+                    setting.add_address(address_from_str(x))
+                v = None
+
+            if not v:
+                continue
+            try:
+                setting.set_property(k, v)
+            except TypeError as e:
+                raise TypeError("Failed to set propery {}".format(k)) from e
+        con.add_setting(setting)
+    return con
+
+class NMDev:
+    def __init__(self, interface):
+        self._interface = interface
+        self._nm_dev = nm.get_device_by_iface(interface)
+
+    def _delete_connection(self, con):
+        future = Future()
+        def cb(con, res, error):
+            assert error is None
+            try:
+                res = con.delete_finish(res)
+                future.set(res)
+            except Exception as e:
+                future.set(e)
+
+        con.delete_async(
+            None,  # cancellable
+            cb,
+            None,
+        )
+
+    def get_settings(self):
+        lg_con = nm.get_connection_by_id("labgrid-{}".format(self._interface))
+        if lg_con:
+            return dict(lg_con.to_dbus(NM.ConnectionSerializationFlags.ALL))
+
+    def get_active_settings(self):
+        active_con = self._nm_dev.get_active_connection()
+        if active_con:
+            con = active_con.get_connection()
+            return dict(con.to_dbus(NM.ConnectionSerializationFlags.ALL))
+
+    def configure(self, data):
+        lg_con = nm.get_connection_by_id("labgrid-{}".format(self._interface))
+        if lg_con:
+            self._delete_connection(lg_con)
+        data['connection'].update({
+            'id': "labgrid-{}".format(self._interface),
+            'autoconnect': False,
+            'interface-name': self._interface,
+        })
+        con = connection_from_dict(data)
+
+        future = Future()
+        def cb(dev, res, error):
+            assert error is None
+            try:
+                res = nm.add_and_activate_connection_finish(res)
+                future.set(res)
+            except Exception as e:
+                future.set(e)
+
+        nm.add_and_activate_connection_async(
+            con,
+            self._nm_dev,
+            None,  # specific_object
+            None,  # cancellable
+            cb,
+            None,
+        )
+
+        active_con = future.wait()  # we must wait, but don't need to return it here
+
+    def wait_state(self, expected, timeout):
+        res, out_value, _ = NM.utils_enum_from_str(NM.DeviceState, expected)
+        if not res:
+            raise ValueError("invalid state '{}'".format(expected))
+        expected = NM.DeviceState(out_value)
+
+        timeout = monotonic() + timeout
+        while monotonic() < timeout:
+            sleep(0.25)
+            if self._nm_dev.get_state() == expected:
+                break
+        else:
+            raise TimeoutError("state is '{}' instead of '{}'".format(
+                self._nm_dev.get_state().value_nick,
+                expected.value_nick))
+
+    def disable(self):
+        lg_con = nm.get_connection_by_id("labgrid-{}".format(self._interface))
+        if lg_con:
+            self._delete_connection(lg_con)
+
+    def _flags_to_str(self, flags):
+        return NM.utils_enum_to_str(type(flags), flags)
+
+    def _accesspoint_to_dict(self, ap):
+        res = {}
+
+        res['flags'] = self._flags_to_str(ap.get_flags())
+        res['wpa-flags'] = self._flags_to_str(ap.get_wpa_flags())
+        res['rsn-flags'] = self._flags_to_str(ap.get_rsn_flags())
+        res['bssid'] = ap.get_bssid()
+        res['ssid'] = ap.get_ssid().get_data().decode(errors='surrogateescape')
+        res['frequency'] = ap.get_frequency()
+        res['mode'] = self._flags_to_str(ap.get_mode())
+        res['max-bitrate'] = ap.get_max_bitrate()
+        res['strength'] = ap.get_strength()
+
+        return res
+
+    def get_state(self):
+        state = {}
+
+        device = {}
+        device['capabilities'] = self._flags_to_str(self._nm_dev.get_capabilities())
+        device['device-type'] = self._flags_to_str(self._nm_dev.get_device_type())
+        device['state'] = self._flags_to_str(self._nm_dev.get_state())
+        device['state-reason'] = self._flags_to_str(self._nm_dev.get_state_reason())
+        device['hw-address'] = self._nm_dev.get_hw_address()
+        device['driver'] = self._nm_dev.get_driver()
+        device['udi'] = self._nm_dev.get_udi()
+        device['mtu'] = self._nm_dev.get_mtu()
+        device['vendor'] = self._nm_dev.get_vendor()
+        device['product'] = self._nm_dev.get_product()
+        state['device'] = device
+
+        for name, ip_cfg in (
+                ('ip4-config', self._nm_dev.get_ip4_config()),
+                ('ip6-config', self._nm_dev.get_ip6_config()),
+                ):
+            if ip_cfg is None:
+                continue
+            cfg = {}
+            cfg['addresses'] = []
+            for address in ip_cfg.get_addresses():
+                cfg['addresses'].append("{}/{}".format(
+                    address.get_address(),
+                    address.get_prefix(),
+                    ))
+            cfg['gateway'] = ip_cfg.get_gateway()
+            state[name] = cfg
+
+        try:
+            ap = self._nm_dev.get_active_access_point()
+        except AttributeError:
+            ap = None
+        if ap:
+            state['active-access-point'] = self._accesspoint_to_dict(ap)
+
+        return state
+
+    def request_scan(self):
+        future = Future()
+        def cb(dev, res, error):
+            assert error is None
+            try:
+                res = dev.request_scan_finish(res)
+                future.set(res)
+            except Exception as e:
+                future.set(e)
+
+        self._nm_dev.request_scan_async(
+            None,  # cancellable
+            cb,
+            None,
+        )
+
+        res = future.wait()  # we must wait, but don't need to return it here
+
+    def get_access_points(self, scan):
+        if scan is None: # automatically scan if needed
+            age = NM.utils_get_timestamp_msec() - self._nm_dev.get_last_scan()
+            scan = bool(age > 30_000)
+
+        if scan:
+            timeout = monotonic() + 60
+            last = self._nm_dev.get_last_scan()
+            self.request_scan()
+
+            while monotonic() < timeout:
+                sleep(0.25)
+                if self._nm_dev.get_last_scan() > last:
+                    break
+            else:
+                raise TimeoutError("scan did not complete")
+
+        aps = self._nm_dev.get_access_points()
+        return [self._accesspoint_to_dict(ap) for ap in aps]
+
+    def get_dhcpd_leases(self):
+        leases = []
+        for line in open("/var/lib/NetworkManager/dnsmasq-{}.leases".format(self._interface)):
+            line = line.strip().split()
+            if line[3] == '*':
+                line[3] = None
+            if line[4] == '*':
+                line[4] = None
+            leases.append({
+                'expire': int(line[0]),
+                'mac': line[1],
+                'ip': line[2],
+                'hostname': line[3],
+                'id': line[4],
+            })
+        return leases
+
+if getattr(NM.Client, '__gtype__', None):
+    # hide this from sphinx autodoc
+    bl = BackgroundLoop()
+    bl.start()
+    nm = bl.block_on(NM.Client.new, None)
+
+_nmdevs = {}
+
+def _get_nmdev(interface):
+    if interface not in _nmdevs:
+        _nmdevs[interface] = NMDev(interface)
+    return _nmdevs[interface]
+
+def handle_configure(interface, settings):
+    nmdev = _get_nmdev(interface)
+    return nmdev.configure(settings)
+
+def handle_wait_state(interface, expected, timeout=60):
+    nmdev = _get_nmdev(interface)
+    return nmdev.wait_state(expected, timeout)
+
+def handle_disable(interface):
+    nmdev = _get_nmdev(interface)
+    return nmdev.disable()
+
+def handle_get_active_settings(interface):
+    nmdev = _get_nmdev(interface)
+    return nmdev.get_active_settings()
+
+def handle_get_settings(interface):
+    nmdev = _get_nmdev(interface)
+    return nmdev.get_settings()
+
+def handle_get_state(interface):
+    nmdev = _get_nmdev(interface)
+    return nmdev.get_state()
+
+def handle_get_dhcpd_leases(interface):
+    nmdev = _get_nmdev(interface)
+    return nmdev.get_dhcpd_leases()
+
+def handle_request_scan(interface):
+    nmdev = _get_nmdev(interface)
+    return nmdev.request_scan()
+
+def handle_get_access_points(interface, scan=None):
+    nmdev = _get_nmdev(interface)
+    return nmdev.get_access_points(scan)
+
+
+methods = {
+    # basic
+    'configure': handle_configure,
+    'wait_state': handle_wait_state,
+    'disable': handle_disable,
+    'get_active_settings': handle_get_active_settings,
+    'get_settings': handle_get_settings,
+    'get_state':  handle_get_state,
+    # dhcpd
+    'get_dhcpd_leases': handle_get_dhcpd_leases,
+    # wireless
+    'request_scan': handle_request_scan,
+    'get_access_points': handle_get_access_points,
+}


### PR DESCRIPTION
**Description**
This adds support for controlling an exported NetworkInterface remotely using NetworkManager over an agent connection.

Via NetworkManager, we can configure and inspect Ethernet and WiFi (client&AP) interfaces. This is especially useful for testing WiFi interfaces on the DUT.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested