### PR TITLE
client: Add support for HIDRelay GPIOs

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -775,11 +775,13 @@ class ClientSession(ApplicationSession):
         from ..resource.remote import NetworkDeditecRelais8
         from ..resource.remote import NetworkSysfsGPIO
         from ..resource.remote import NetworkLXAIOBusPIO
+        from ..resource.remote import NetworkHIDRelay
         from ..driver.modbusdriver import ModbusCoilDriver
         from ..driver.onewiredriver import OneWirePIODriver
         from ..driver.deditecrelaisdriver import DeditecRelaisDriver
         from ..driver.gpiodriver import GpioDigitalOutputDriver
         from ..driver.lxaiobusdriver import LXAIOBusPIODriver
+        from ..driver.usbhidrelay import HIDRelayDriver
 
         drv = None
         try:
@@ -821,6 +823,14 @@ class ClientSession(ApplicationSession):
                         target.set_binding_map({"pio": name})
                         drv = LXAIOBusPIODriver(target, name=name)
                         break
+                elif isinstance(resource, NetworkHIDRelay):
+                    try:
+                        drv = target.get_driver(HIDRelayDriver, name=name)
+                    except NoDriverFoundError:
+                        target.set_binding_map({"relay": name})
+                        drv = HIDRelayDriver(target, name=name)
+                        break
+
         if not drv:
             raise UserError("target has no compatible resource available")
         target.activate(drv)


### PR DESCRIPTION
Adds support for the client to control relays attached to a USB HID
Relay using the "io" subcommand

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
