### PR TITLE
.codecov.yaml: disable github check annotations

### DIFF
--- a/.codecov.yaml
+++ b/.codecov.yaml
@@ -1,3 +1,5 @@
 coverage:
   precision: 1
   range: "50..70"
+github_checks:
+  annotations: false


### PR DESCRIPTION
As significant parts of labgrid are not practical to test, these annotations
are only distracting during code review.