### PR TITLE
ConsoleLoggingReporter: create log path and improve error handling

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ New Features in 0.4.0
   make them easier distinguishable from pytest's "PASSED" output.
 - Network controlled relay providing GET/PUT based REST API
 
+Bug fixes in 0.4.0
+~~~~~~~~~~~~~~~~~~
+- ``pytest --lg-log foobar`` now creates the folder ``foobar`` before trying to
+  write the log into it, and error handling was improved so that all possible
+  errors that can occur when opening the log file are reported to stderr.
+
 Breaking changes in 0.4.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/labgrid/consoleloggingreporter.py
+++ b/labgrid/consoleloggingreporter.py
@@ -30,6 +30,8 @@ class ConsoleLoggingReporter:
     def __init__(self, logpath):
         self._logcache = {}
         self.logpath = logpath
+        if not os.path.exists(self.logpath):
+            os.makedirs(self.logpath)
         steps.subscribe(self.notify)
 
     def _stop(self):

--- a/labgrid/consoleloggingreporter.py
+++ b/labgrid/consoleloggingreporter.py
@@ -54,8 +54,8 @@ class ConsoleLoggingReporter:
             try:
                 log = self._logcache[source] = open(name, mode='ab',
                                                     buffering=0)
-            except PermissionError:
-                print("failed to open log file {}".format(name), file=sys.stderr)
+            except OSError as e:
+                print("failed to open log file {}: {}".format(name, e), file=sys.stderr)
                 log = self._logcache[source] = None
             if not log:
                 return None


### PR DESCRIPTION
I was confused why `pytest --lg-log foobar` would silently refuse to log anything, but I found out why:

* the directory `foobar` did not exist before, and it was not created anywhere
* the error handling in `ConsoleLoggingReporter.get_logfile()` only caught PermissionErrors when opening the log file, but `open()` raised a FileNotFoundError when opening the log file because the directory did not exist (but I did not figure out why pytest didn't report this uncaught exception…)

Solve both of those issues by creating the log path in `ConsoleLoggingReporter.__init__()`, and improving the error handling.

**Checklist**
- [ ] Documentation for the feature (not sure if needed?)
- [ ] Tests for the feature (not sure if needed?)
- [x] CHANGES.rst has been updated
- [x] PR has been tested