### PR TITLE
tests: fix warnings and atexit exceptions

### DIFF
--- a/tests/test_stepreporter.py
+++ b/tests/test_stepreporter.py
@@ -93,6 +93,8 @@ def test_step_reporter_color_scheme(caplog, curses_init, color_scheme, result_co
 
     class MockTW:
         _file = None
+        def line(self, line):
+            pass
     class MockTerminalReporter:
         def __init__(self, f):
             self._tw = MockTW()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 import os.path
 import subprocess
 import socket
+import atexit
 
 from shutil import which
 
@@ -183,6 +184,9 @@ def test_sshconnection_get_file(connection_localhost, tmpdir):
 def test_sshconnection_cleanup(connection_localhost_no_cleanup):
 
     connection_localhost_no_cleanup.cleanup()
+
+    # do not call cleanup() again on termination
+    atexit.unregister(connection_localhost_no_cleanup.cleanup)
 
 @pytest.mark.localsshmanager
 def test_sshmanager_open(sshmanager_fix):


### PR DESCRIPTION
**Description**
When running the test suite, various warnings and exceptions happen. Some occur because cleanup actions are called explicitly during tests leading to errors once the atexit registered cleanup methods run. Unregister the atexit cleanup methods for these tests explicitly. Another warning happens because not all of pytest's TerminalWriter features that we use are mocked. Extend `MockTW` accordingly.

**Checklist**
- [x] PR has been tested

Fixes #730
Fixes #687