### PR TITLE
resource: serialport: raise exception rather than only instantiating it

### DIFF
--- a/labgrid/resource/serialport.py
+++ b/labgrid/resource/serialport.py
@@ -12,7 +12,7 @@ class RawSerialPort(SerialPort, Resource):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         if self.port is None:
-            ValueError("RawSerialPort must be configured with a port")
+            raise ValueError("RawSerialPort must be configured with a port")
 
 # This does not derive from SerialPort because it is not directly accessible
 @target_factory.reg_resource


### PR DESCRIPTION
**Description**
Instantiating an exception, but not raising it, has no effect.

**Checklist**
- [ ] PR has been tested

Fixes: e21a5eba ("resource: rename SerialPort to RawSerialPort")
