### PR TITLE
driver: externalconsoledriver: allow multiple close() calls

### DIFF
--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -67,6 +67,9 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         if errs:
             self.logger.warning("child error while closing: %s", errs)
 
+        self._child = None
+        self.status = 0
+
     def _read(self, size: int = 1024, timeout: int = 0):
         """
         Reads 'size' bytes from the serialport


### PR DESCRIPTION
**Description**
The docstring states that this method does nothing if it is already closed. This is not the case, multiple calls lead to "child has
vanished" ExecutionErrors. Fix that by resetting the driver state, so the next close() call returns early.

**Checklist**
- [ ] PR has been tested

Fixes 69d5c69c
