### PR TITLE
add support for Linux Automation USB-Mux

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -616,6 +616,27 @@ NetworkUSBSDMuxDevice
 A :any:`NetworkUSBSDMuxDevice` resource describes a `USBSDMuxDevice`_ available
 on a remote computer.
 
+LXAUSBMux
+~~~~~~~~~
+A :any:`LXAUSBMux` resource describes a Linux Automation GmbH USB-Mux device.
+
+.. code-block:: yaml
+
+   LXAUSBMux:
+     match:
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
+
+- match (str): key and value for a udev match, see `udev Matching`_
+
+Used by:
+  - `LXAUSBMuxDriver`_
+
+NetworkLXAUSBMux
+~~~~~~~~~~~~~~~~
+
+A :any:`NetworkLXAUSBMux` resource describes a `LXAUSBMux`_ available on a
+remote computer.
+
 USBSDWireDevice
 ~~~~~~~~~~~~~~~
 A :any:`USBSDWireDevice` resource describes a Tizen
@@ -1841,6 +1862,19 @@ Implements:
 
 The driver can be used in test cases by calling the `set_mode()` function with
 argument being `dut`, `host`, `off`, or `client`.
+
+LXAUSBMuxDriver
+~~~~~~~~~~~~~~~
+The :any:`LXAUSBMuxDriver` uses a LXAUSBMux resource to control a USB-Mux
+device via the `usbmuxctl <https://github.com/linux-automation/usbmuxctl>`_
+tool.
+
+Implements:
+  - None yet
+
+The driver can be used in test cases by calling the `set_links()` function with
+a list containing one or more of "dut-device", "host-dut" and "host-device".
+Not all combinations can be configured at the same time.
 
 USBSDWireDriver
 ~~~~~~~~~~~~~~~

--- a/labgrid/driver/lxausbmuxdriver.py
+++ b/labgrid/driver/lxausbmuxdriver.py
@@ -1,0 +1,49 @@
+# pylint: disable=no-member
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..step import step
+from .exception import ExecutionError
+from ..util.helper import processwrapper
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class LXAUSBMuxDriver(Driver):
+    """The LXAUSBMuxDriver uses the usbmuxctl tool to control the USBMux
+    hardware
+    """
+    bindings = {
+        "mux": {"LXAUSBMux", "NetworkLXAUSBMux"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('usbmuxctl') or 'usbmuxctl'
+        else:
+            self.tool = 'usbmuxctl'
+
+    @Driver.check_active
+    @step(title='usbmux_set', args=['links'])
+    def set_links(self, links):
+        args = []
+        for link in links:
+            link = link.lower()
+            if link == 'dut-device':
+                args.append('--dut-device')
+            elif link == 'host-dut':
+                args.append('--host-dut')
+            elif link == 'host-device':
+                args.append('--host-device')
+            else:
+                raise ExecutionError("Link '%s' not supported by LXAUSBMuxDriver" % link)
+
+        cmd = self.mux.command_prefix + [
+            self.tool,
+            "--path",
+            self.mux.path,
+            "connect",
+            *args,
+        ]
+        processwrapper.check_output(cmd)

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -501,6 +501,7 @@ exports["USBPowerPort"] = USBPowerPortExport
 exports["DeditecRelais8"] = USBDeditecRelaisExport
 exports["HIDRelay"] = USBHIDRelayExport
 exports["USBFlashableDevice"] = USBFlashableExport
+exports["LXAUSBMux"] = USBGenericExport
 
 
 @attr.s

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -323,6 +323,14 @@ class NetworkLXAIOBusPIO(NetworkLXAIOBusNode):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkLXAUSBMux(RemoteUSBResource):
+    """The NetworkLXAUSBMux describes a remotely accessible USBMux device"""
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkUSBFlashableDevice(RemoteUSBResource):
     devnode = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(str)))
     def __attrs_post_init__(self):

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -18,6 +18,7 @@ from .udev import (
     USBEthernetInterface,
     SiSPMPowerPort,
     USBAudioInput,
+    LXAUSBMux,
 )
 from ..util import dump
 
@@ -46,6 +47,7 @@ class Suggester:
         self.resources.append(USBEthernetInterface(**args))
         self.resources.append(SiSPMPowerPort(**args))
         self.resources.append(USBAudioInput(**args))
+        self.resources.append(LXAUSBMux(**args))
 
     def suggest_callback(self, resource, meta, suggestions):
         cls = type(resource).__name__

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -643,3 +643,15 @@ class USBFlashableDevice(USBResource):
         if self.device is not None:
             return self.device.device_node
         return None
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class LXAUSBMux(USBResource):
+    """The LXAUSBMux describes an attached USBMux device,
+    it is identified via USB using udev.
+    """
+
+    def __attrs_post_init__(self):
+        self.match['ID_VENDOR_ID'] = '33f7'
+        self.match['ID_MODEL_ID'] = '0001'
+        super().__attrs_post_init__()


### PR DESCRIPTION
This devices allows switching a USB device between the host and the DUT.

**Description**

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested