### PR TITLE
remote: common: list public objects explicitly

### DIFF
--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -10,6 +10,16 @@ from fnmatch import fnmatchcase
 
 import attr
 
+__all__ = [
+    'TAG_KEY',
+    'TAG_VAL',
+    'ResourceEntry',
+    'ResourceMatch',
+    'Place',
+    'ReservationState',
+    'Reservation',
+    'enable_tcp_nodelay',
+]
 
 TAG_KEY = re.compile(r"[a-z][a-z0-9_]+")
 TAG_VAL = re.compile(r"[a-z0-9_]?")


### PR DESCRIPTION
**Description**
`labgrid.remote.client` and `labgrid.remote.coordinator` import `*` from `labgrid.remote.common`. This leads to various modules being imported implicitly. Polluting the namespace like this could overwrite previous local imports or variables.

Better specify explicitly what should be imported on `*`.

**Checklist**
- [ ] PR has been tested