### PR TITLE
client/usbsdmuxdriver: drop deprecated command line switch, add mode query

### DIFF
--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -35,7 +35,6 @@ class USBSDMuxDriver(Driver):
             raise ExecutionError("Setting mode '%s' not supported by USBSDMuxDriver" % mode)
         cmd = self.mux.command_prefix + [
             self.tool,
-            "-c",
             self.mux.control_path,
             mode.lower()
         ]

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-member
+import subprocess
+
 import attr
 
 from .common import Driver
@@ -39,3 +41,18 @@ class USBSDMuxDriver(Driver):
             mode.lower()
         ]
         processwrapper.check_output(cmd)
+
+    @Driver.check_active
+    @step(title='sdmux_get')
+    def get_mode(self):
+        cmd = self.mux.command_prefix + [
+            self.tool,
+            self.mux.control_path,
+            "get"
+        ]
+        proc = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            check=True
+        )
+        return proc.stdout.strip().decode()

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1018,9 +1018,13 @@ class ClientSession(ApplicationSession):
         if not drv:
             raise UserError("target has no compatible resource available")
         target.activate(drv)
-        if isinstance(drv, USBSDWireDriver) and action in ['off', 'client']:
-            raise UserError("sd-wire does only support 'dut' and 'host' modes")
-        drv.set_mode(action)
+        if isinstance(drv, USBSDWireDriver) and action in ['off', 'client', 'get']:
+            raise UserError("sd-wire does only supports setting 'dut' and 'host' modes")
+
+        if action == 'get':
+            print(drv.get_mode())
+        else:
+            drv.set_mode(action)
 
     def _get_ip(self, place):
         target = self._get_target(place)
@@ -1601,8 +1605,8 @@ def main():
     subparser.set_defaults(func=ClientSession.bootstrap)
 
     subparser = subparsers.add_parser('sd-mux',
-                                      help="switch USB SD Muxer")
-    subparser.add_argument('action', choices=['dut', 'host', 'off', 'client'])
+                                      help="switch USB SD Muxer or get current mode")
+    subparser.add_argument('action', choices=['dut', 'host', 'off', 'client', 'get'])
     subparser.set_defaults(func=ClientSession.sd_mux)
 
     subparser = subparsers.add_parser('ssh',


### PR DESCRIPTION
**Description**
The usbsdmux tool dropped the service/client split with https://github.com/linux-automation/usbsdmux/commit/656e3d5ca46f6e7a707925707dc9504dcd18fb33, so stop passing `-c` (client mode). 

https://github.com/linux-automation/usbsdmux/commit/628303606c4fdb15a65f85a804900d05de8994dd added support to query the currently selected mode. Add support for that to the `USBSDMuxDriver` as well as to the client (allowing `labgrid-client sd-mux get`).

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] CHANGES.rst has been updated
- [x] PR has been tested