### PR TITLE
driver: add missing LXAUSBMuxDriver in __init__.py

### DIFF
--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -29,6 +29,7 @@ from .serialdigitaloutput import SerialPortDigitalOutputDriver
 from .xenadriver import XenaDriver
 from .dockerdriver import DockerDriver
 from .lxaiobusdriver import LXAIOBusPIODriver
+from .lxausbmuxdriver import LXAUSBMuxDriver
 from .pyvisadriver import PyVISADriver
 from .usbhidrelay import HIDRelayDriver
 from .flashscriptdriver import FlashScriptDriver


### PR DESCRIPTION
**Description**
This leads to

```
labgrid.exceptions.InvalidConfigError: unknown driver class LXAUSBMuxDriver
```

when used with an environment config. So fix it.


**Checklist**
- [x] PR has been tested

Fixes #766