### PR TITLE
client: Add named resource arg to SSH subparser

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ New Features in 0.5.0
 - Support for Eaton ePDU added, and can be used as a NetworkPowerPort.
 - Consider a combination of multiple "lg_feature" markers instead of
   considering only the closest marker.
+- The labgrid client SSH command is now able to instantiate the SSHDriver when
+  there are multiple NetworkService resources available.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1069,18 +1069,19 @@ class ClientSession(ApplicationSession):
 
         from ..resource import NetworkService
         try:
-            target.get_resource(NetworkService)
+            resource = target.get_resource(NetworkService, name=self.args.name)
         except NoResourceFoundError:
             ip = self._get_ip(place)
             if not ip:
                 return
-            NetworkService(target, address=str(ip), username='root')
+            resource = NetworkService(target, address=str(ip), username='root')
 
         from ..driver.sshdriver import SSHDriver
         try:
             drv = target.get_driver(SSHDriver)
         except NoDriverFoundError:
-            drv = SSHDriver(target, name=None)
+            target.set_binding_map({"networkservice": resource.name})
+            drv = SSHDriver(target, name=resource.name)
         target.activate(drv)
         return drv
 
@@ -1690,6 +1691,7 @@ def main():
 
     subparser = subparsers.add_parser('ssh',
                                       help="connect via ssh (with optional arguments)")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.ssh)
 
     subparser = subparsers.add_parser('scp',


### PR DESCRIPTION
Sometimes a remote place might have multiple NetworkService resources,
for example a single device running multiple operating systems.  In this
case, we must specify which NetworkService resource to use for the local
SSHDriver instance.

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>

Testing:
```
(labgrid-venv) $ labgrid-client ssh --help
usage: labgrid-client ssh [-h] [name]

positional arguments:
  name        optional resource name

optional arguments:
  -h, --help  show this help message and exit

(labgrid-venv) $ labgrid-client -p codethink-office-guest-gw ssh guest-os-network
guest-os#

(labgrid-venv) $ labgrid-client -p codethink-office-guest-gw ssh host-os-network
host-os# 
```

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature (in the subparser --help docs, I don't think this needs a man page)
- N/A Tests for the feature (I don't think there are labgrid-client tests, and also the SSHDriver binding is already tested)
<!---
If you add a driver/resource or modifiy one:
--->
- N/A The arguments and description in doc/configuration.rst have been updated (not relevant)
<!---
If you add a feature other drivers/resources can benefit from:
--->
- N/A Add a section on how to use the feature to doc/usage.rst (not relevant)
<!---
A library feature which other developers can use:
--->
- N/A Add a section on how to use the feature to doc/development.rst (not relevant)
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- N/A Man pages have been regenerated (nope, it doesn't touch the man pages)

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
