### PR TITLE
exporter: Check /usr/sbin for ser2net

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ New Features in 0.4.0
   make them easier distinguishable from pytest's "PASSED" output.
 - Network controlled relay providing GET/PUT based REST API
 - Improved LG_PROXY documentation in docs/usage.rst.
+- Exporter now checks /usr/sbin/ser2net for SerialPortExport
 
 Bug fixes in 0.4.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 import sys
 import os
+import os.path
 import time
 import traceback
 import shutil
@@ -191,8 +192,12 @@ class SerialPortExport(ResourceExport):
         self.port = None
         self.ser2net_bin = shutil.which("ser2net")
         if self.ser2net_bin is None:
-            warnings.warn("ser2net binary not found, falling back to /usr/bin/ser2net")
-            self.ser2net_bin = "/usr/bin/ser2net"
+            if os.path.isfile("/usr/sbin/ser2net"):
+                self.ser2net_bin = "/usr/sbin/ser2net"
+
+            if self.ser2net_bin is None:
+                warnings.warn("ser2net binary not found, falling back to /usr/bin/ser2net")
+                self.ser2net_bin = "/usr/bin/ser2net"
 
     def __del__(self):
         if self.child is not None:


### PR DESCRIPTION
On Debian, the ser2net binary is installed at /usr/sbin/ser2net and it
can be run by any user. Since this isn't on the users PATH, we should
attempt to use it when failing to find a ser2net binary, before falling
back to /usr/bin/ser2net.

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>

You can quickly see this like so:
```
$ podman run -it debian:bullseye
# apt update && apt install ser2net
# ls -l /usr/sbin/ser2net
-rwxr-xr-x. 1 root root 136696 Aug 24  2018 /usr/sbin/ser2net
```
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- N/A Documentation for the feature (not necessary, just searches in an additional place)
- N/A Tests for the feature (not necessary)
<!---
If you add a driver/resource or modifiy one:
--->
- N/A The arguments and description in doc/configuration.rst have been updated (not relevant)
<!---
If you add a feature other drivers/resources can benefit from:
--->
- N/A Add a section on how to use the feature to doc/usage.rst (not relevant)
<!---
A library feature which other developers can use:
--->
- N/A Add a section on how to use the feature to doc/development.rst (not relevant)
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- N/A Man pages have been regenerated (not relevant)

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
