### PR TITLE
exporter: Add --ser2net-port argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ New Features in 0.4.0
   The 256-color schemes now use purple instead of green for the ``run`` lines to
   make them easier distinguishable from pytest's "PASSED" output.
 - Network controlled relay providing GET/PUT based REST API
+- Add exporter argument --ser2net-port.
 
 Bug fixes in 0.4.0
 ~~~~~~~~~~~~~~~~~~

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -59,6 +59,9 @@ the public name of the exporter
 .B \-\-hostname
 hostname (or IP) published for accessing resources
 .TP
+.B \-\-ser2net\-port
+ser2net port published for accessing resources (defaults to any free port)
+.TP
 .B \-d\fP,\fB  \-\-debug
 enable debug mode
 .UNINDENT
@@ -83,6 +86,12 @@ exporter needs to provide a host name to set the exported value of the "host"
 key.
 If the system hostname is not resolvable via DNS, this option can be used to
 override this default with another name (or an IP address).
+.SS \-\-ser2net\-port
+.sp
+For the SerialPortExport resource the exporter needs to provide a port number
+to ser2net for it to expose the serial console on. Use this argument if you
+need a fixed port, for example if running the exporter in a container.  If the
+ser2net port is not set, it will default to any open port.
 .SH CONFIGURATION
 .sp
 The exporter uses a YAML configuration file which defines groups of related

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -46,6 +46,8 @@ OPTIONS
     the public name of the exporter
 --hostname
     hostname (or IP) published for accessing resources
+--ser2net-port
+    ser2net port published for accessing resources (defaults to any free port)
 -d, --debug
     enable debug mode
 
@@ -72,6 +74,13 @@ exporter needs to provide a host name to set the exported value of the "host"
 key.
 If the system hostname is not resolvable via DNS, this option can be used to
 override this default with another name (or an IP address).
+
+--ser2net-port
+~~~~~~~~~~~~~~
+For the SerialPortExport resource the exporter needs to provide a port number
+to ser2net for it to expose the serial console on. Use this argument if you
+need a fixed port, for example if running the exporter in a container.  If the
+ser2net port is not set, it will default to any open port.
 
 CONFIGURATION
 -------------


### PR DESCRIPTION
Add an exporter argument to set the ser2net port. This is useful when
running the exporter in a container because you have to expose a known
port in the configuration.

The ser2net port defaults to any free port.

Signed-off-by: Thomas Preston <thomas.preston@codethink.co.uk>

Running the exporter:
```
$ labgrid-exporter --ser2net-port=54321 exporter-conf/exporter.yaml
[snip]
2021-04-13T20:39:28 started ser2net for /dev/ttyUSB1 on port 54321
[snip]
```
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- N/A Tests for the feature
<!---
If you add a driver/resource or modifiy one:
--->
- N/A The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- N/A Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- N/A Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
