### PR TITLE
shelldriver: Handle intermingled output on login

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1185,6 +1185,9 @@ Arguments:
     to pass before sending a newline to device.
   - console_ready (regex): optional, pattern used by the kernel to inform
     the user that a console can be activated by pressing enter.
+  - post_login_settle_time (int): optional, seconds of silence after logging in
+    before check for a prompt. Useful when the console is interleaved with boot
+    output which may interrupt prompt detection
 
 .. _conf-sshdriver:
 

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -15,7 +15,7 @@ import xmodem
 from ..factory import target_factory
 from ..protocol import CommandProtocol, ConsoleProtocol, FileTransferProtocol
 from ..step import step
-from ..util import gen_marker
+from ..util import gen_marker, Timeout
 from .commandmixin import CommandMixin
 from .common import Driver
 from .exception import ExecutionError
@@ -37,6 +37,9 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         password (str): password to login with
         keyfile (str): keyfile to bind mount over users authorized keys
         login_timeout (int): optional, timeout for login prompt detection
+        post_login_settle_time (int): optional, seconds of silence after logging in
+            before check for a prompt. Useful when the console is interleaved with boot
+            output which may interrupt prompt detection
     """
     bindings = {"console": ConsoleProtocol, }
     prompt = attr.ib(validator=attr.validators.instance_of(str))
@@ -47,6 +50,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     login_timeout = attr.ib(default=60, validator=attr.validators.instance_of(int))
     console_ready = attr.ib(default="", validator=attr.validators.instance_of(str))
     await_login_timeout = attr.ib(default=2, validator=attr.validators.instance_of(int))
+    post_login_settle_time = attr.ib(default=0, validator=attr.validators.instance_of(int))
 
 
     def __attrs_post_init__(self):
@@ -114,7 +118,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def _await_login(self):
         """Awaits the login prompt and logs the user in"""
 
-        start = time.time()
+        timeout = Timeout(float(self.login_timeout))
 
         expectations = [self.prompt, self.login_prompt, TIMEOUT]
         if self.console_ready != "":
@@ -146,10 +150,13 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                 if index == 1:
                     if self.password:
                         self.console.sendline(self.password)
-                        remaining_time = (start + self.login_timeout) - time.time()
-                        self.console.expect(self.prompt, timeout=remaining_time)
+                        self.console.expect(self.prompt, timeout=timeout.remaining)
                     else:
                         raise Exception("Password entry needed but no password set")
+
+                if self.post_login_settle_time > 0:
+                    self.console.settle(self.post_login_settle_time, timeout=timeout.remaining)
+
                 self._check_prompt()
                 break
 
@@ -170,7 +177,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
             last_before = before
 
-            if time.time() > start + self.login_timeout:
+            if timeout.expired:
                 raise TIMEOUT("Timeout of {} seconds exceeded during waiting for login".format(self.login_timeout))  # pylint: disable=line-too-long
 
     @step()


### PR DESCRIPTION
Some devices may have chatty consoles during login;
specifically, if a user logs into the root serial console of a target
using systemd that has not finished booting, boot messages will begin to
appear after login. These messages can interrupt prompt detection and
cause test timeouts. To allow proper detection of the prompt:
1. Add an API to wait for the device to "settle", e.g.
   no output is seen on the console for a specified number of seconds and
   add an option for the shelldriver to utilize it
2. Move the password and post-login prompt detection into the same main
   main loop as the other prompt detection. This allows the same login and retry
   logic to be used which make it more robust against noise.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
