### PR TITLE
driver/power/digipower: Make driver work

### DIFF
--- a/labgrid/driver/power/digipower.py
+++ b/labgrid/driver/power/digipower.py
@@ -12,18 +12,8 @@ def power_set(host, port, index, value):
         cgi = "offs.cgi"
 
     suffixstring = "0000000000000000"
-    portstring = {
-        1: "10000000",
-        2: "01000000",
-        3: "00100000",
-        4: "00010000",
-        5: "00001000",
-        6: "00000100",
-        7: "00000010",
-        8: "00000001",
-    }
     r = requests.get(
-        "http://{}:{}/{}?led={}".format(host, port, cgi, portstring[index] + suffixstring),
+        f"http://{host}:{port}/{cgi}?led={1 << 8 - index:08b}{suffixstring}",
         auth=("snmp", "1234"),
     )
     r.raise_for_status()
@@ -33,18 +23,11 @@ def power_get(host, port, index):
     index = int(index)
     assert 1 <= index <= 8
 
-    # get the contents of the status page
-    r = requests.get("http://{}:{}/status.xml".format(host, port), auth=("snmp", "1234"))
+    r = requests.get(
+        f"http://{host}:{port}/status.xml",
+        auth=("snmp", "1234"),
+    )
     r.raise_for_status()
-    states = {"0": False, "1": True}
-    ports = {
-        1: 10,
-        2: 11,
-        3: 12,
-        4: 13,
-        5: 14,
-        6: 15,
-        7: 16,
-        8: 17
-    }
-    return states[r.text.split(',')[ports[index]]]
+
+    state = r.text.split(',')[9 + index]
+    return bool(int(state, 2))

--- a/labgrid/driver/power/digipower.py
+++ b/labgrid/driver/power/digipower.py
@@ -13,14 +13,14 @@ def power_set(host, port, index, value):
 
     suffixstring = "0000000000000000"
     portstring = {
-        "1": "10000000",
-        "2": "01000000",
-        "3": "00100000",
-        "4": "00010000",
-        "5": "00001000",
-        "6": "00000100",
-        "7": "00000010",
-        "8": "00000001",
+        1: "10000000",
+        2: "01000000",
+        3: "00100000",
+        4: "00010000",
+        5: "00001000",
+        6: "00000100",
+        7: "00000010",
+        8: "00000001",
     }
     r = requests.get(
         "http://{}:{}/{}?led={}".format(host, port, cgi, portstring[index] + suffixstring),
@@ -38,13 +38,13 @@ def power_get(host, port, index):
     r.raise_for_status()
     states = {"0": False, "1": True}
     ports = {
-        "1": 10,
-        "2": 11,
-        "3": 12,
-        "4": 13,
-        "5": 14,
-        "6": 15,
-        "7": 16,
-        "8": 17
+        1: 10,
+        2: 11,
+        3: 12,
+        4: 13,
+        5: 14,
+        6: 15,
+        7: 16,
+        8: 17
     }
-    return states[r.content.split(',')[ports[index]]]
+    return states[r.text.split(',')[ports[index]]]


### PR DESCRIPTION
**Description**

This changes basically make this driver work. I am not sure if it ever worked at all:
* Indexing of the `portstring` and `ports` -dicts has probably never worked
  the way it was done: `index` is explicitly casted to `int` but indices
  have been `str`.
* `response.content` is the bytes-response from the server.
  The way it was used before probably never worked the way it was done:
  A byte-array can not be splitted using a string.
  When using `response.text` decoding is done by `requests` what is
  probably the best idea here.

This problems showed up when I wanted to bring up a new lab in our infrastructure that is equipped with a Digipower power-switch.
I successfully tested the `get` and `set` methods against our device.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
