### PR TITLE
add support for USB JTAG debuggers

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -553,6 +553,22 @@ Used by:
   - `OpenOCDDriver`_
   - `QuartusHPSDriver`_
 
+USBDebugger
+~~~~~~~~~~~
+An USBDebugger resource describes a JTAG USB adapter (for example an FTDI
+FT2232H).
+
+.. code-block:: yaml
+
+   USBDebugger:
+     match:
+       ID_PATH: 'pci-0000:00:10.0-usb-0:1.4'
+
+- match (dict): key and value for a udev match, see `udev Matching`_
+
+Used by:
+  - `OpenOCDDriver`_
+
 SNMPEthernetPort
 ~~~~~~~~~~~~~~~~
 A SNMPEthernetPort resource describes a port on an Ethernet switch, which is
@@ -1347,8 +1363,7 @@ OpenOCDDriver
 An OpenOCDDriver controls OpenOCD to bootstrap a target with a bootloader.
 
 Note that OpenOCD supports specifying USB paths since
-`a1b308ab <https://sourceforge.net/p/openocd/code/ci/a1b308ab/>`_ which is not
-part of a release yet.
+`a1b308ab <https://sourceforge.net/p/openocd/code/ci/a1b308ab/>`_ which was released with v0.11.
 The OpenOCDDriver passes the resource's USB path.
 Depending on which OpenOCD version is installed it is either used correctly or
 a warning is displayed and the first resource seen is used, which might be the
@@ -1358,14 +1373,30 @@ Consider updating your OpenOCD version when using multiple USB Blasters.
 Binds to:
   interface:
     - `AlteraUSBBlaster`_
+    - `USBDebugger`_
 
 Implements:
   - :any:`BootstrapProtocol`
 
+.. code-block:: yaml
+
+   OpenOCDDriver:
+     config: local-settings.cfg
+     image: bitstream
+     interface_config: ftdi/lambdaconcept_ecpix-5.cfg
+     board_config: lambdaconcept_ecpix-5.cfg
+     load_commands:
+     - "init"
+     - "svf -quiet {filename}"
+     - "exit"
+
 Arguments:
-  - config (str): OpenOCD configuration file
-  - search (str): include search path for scripts
-  - image (str): filename of image to bootstrap onto the device
+  - config (str/list): optional, OpenOCD configuration file(s)
+  - search (str): optional, include search path for scripts
+  - image (str): optional, name of the image to bootstrap onto the device
+  - interface_config (str): optional, interface config in the ``openocd/scripts/interface/`` directory
+  - board_config (str): optional, board config in the ``openocd/scripts/board/`` directory
+  - load_commands (list of str): optional, load commands to use instead of ``init``, ``bootstrap {filename}``, ``shutdown``
 
 QuartusHPSDriver
 ~~~~~~~~~~~~~~~~

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -97,7 +97,10 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
             cmd.append(mconfig.get_remote_path())
 
         cmd += chain.from_iterable(("--command", "'{}'".format(command)) for command in commands)
-        processwrapper.check_output(cmd)
+        processwrapper.check_output(
+            cmd,
+            print_on_silent_log=True
+        )
 
     @Driver.check_active
     @step(args=['filename'])

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -21,7 +21,10 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         },
     }
 
-    config = attr.ib(validator=attr.validators.instance_of((str, list)))
+    config = attr.ib(
+        default=[],
+        validator=attr.validators.optional(attr.validators.instance_of((str, list)))
+    )
     search = attr.ib(
         default=[],
         validator=attr.validators.optional(attr.validators.instance_of((str, list)))

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -15,7 +15,10 @@ from .common import Driver
 @attr.s(eq=False)
 class OpenOCDDriver(Driver, BootstrapProtocol):
     bindings = {
-        "interface": {"AlteraUSBBlaster", "NetworkAlteraUSBBlaster"},
+        "interface": {
+            "AlteraUSBBlaster", "NetworkAlteraUSBBlaster",
+            "USBDebugger", "NetworkUSBDebugger",
+        },
     }
 
     config = attr.ib(validator=attr.validators.instance_of((str, list)))

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -38,6 +38,10 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
+    load_commands = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(list))
+    )
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -100,11 +104,15 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         mf = ManagedFile(filename, self.interface)
         mf.sync_to_resource()
 
-        commands = [
-            "init",
-            "bootstrap {}".format(mf.get_remote_path()),
-            "shutdown",
-        ]
+        if self.load_commands is None:
+            commands = [
+                "init",
+                "bootstrap {}".format(mf.get_remote_path()),
+                "shutdown",
+            ]
+        else:
+            commands = [c.format(filename=mf.get_remote_path()) for c in self.load_commands]
+
         self._run_commands(commands)
 
     @Driver.check_active

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -66,7 +66,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         # OpenOCD supports "adapter usb location" since a1b308ab, if the command is not known
         # notice user and continue
         message = ("Your OpenOCD version does not support specifying USB paths.\n"
-                   "Consider updating to OpenOCD master when using multiple USB Blasters.")
+                   "Consider updating to OpenOCD v0.11 when using multiple USB Blasters.")
         return [
             "--command",
             "'if {{ [catch {{adapter usb location \"{usbpath}\"}}] }} {{ puts stderr \"{msg}\" }}'"

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -30,6 +30,14 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
+    interface_config = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    board_config = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -68,6 +76,14 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
             mconfig = ManagedFile(config, self.interface)
             mconfig.sync_to_resource()
             managed_configs.append(mconfig)
+
+        if self.interface_config:
+            cmd.append("--file")
+            cmd.append("interface/{}".format(self.interface_config))
+
+        if self.board_config:
+            cmd.append("--file")
+            cmd.append("board/{}".format(self.board_config))
 
         for mconfig in managed_configs:
             cmd.append("--file")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -497,6 +497,7 @@ exports["SigrokUSBDevice"] = USBSigrokExport
 exports["SigrokUSBSerialDevice"] = USBSigrokExport
 exports["USBSDMuxDevice"] = USBSDMuxExport
 exports["USBSDWireDevice"] = USBSDWireExport
+exports["USBDebugger"] = USBGenericExport
 
 exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -273,6 +273,15 @@ class NetworkUSBTMC(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkUSBDebugger(RemoteUSBResource):
+    """The NetworkUSBDebugger describes a remotely accessible USB JTAG/Debugger device"""
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkDeditecRelais8(RemoteUSBResource):
     """The NetworkDeditecRelais8 describes a remotely accessible USB relais port"""
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -20,6 +20,7 @@ from .udev import (
     USBAudioInput,
     LXAUSBMux,
     HIDRelay,
+    USBDebugger,
 )
 from ..util import dump
 
@@ -50,6 +51,7 @@ class Suggester:
         self.resources.append(USBAudioInput(**args))
         self.resources.append(LXAUSBMux(**args))
         self.resources.append(HIDRelay(**args))
+        self.resources.append(USBDebugger(**args))
 
     def suggest_callback(self, resource, meta, suggestions):
         cls = type(resource).__name__

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -655,3 +655,15 @@ class LXAUSBMux(USBResource):
         self.match['ID_VENDOR_ID'] = '33f7'
         self.match['ID_MODEL_ID'] = '0001'
         super().__attrs_post_init__()
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class USBDebugger(USBResource):
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [("0403", "6010"),
+                         ]:
+            return False
+
+        return super().filter_match(device)


### PR DESCRIPTION
**Description**
This cleans up the OpenOCD driver and adds support for using FTDI-based JTAG interfaces. I've used this to load bitstreams on a [ECPIX-5 FPGA devboard](http://docs.lambdaconcept.com/ecpix-5/features/debug.html).

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested