### PR TITLE
driver/power/gude8031 overhaul

### DIFF
--- a/labgrid/driver/power/gude8031.py
+++ b/labgrid/driver/power/gude8031.py
@@ -13,7 +13,7 @@ def power_set(host, port, index, value):
     # access the web interface...
     value = 1 if value else 0
     r = requests.get(
-        "http://{}:{}//status.json?components=769&cmd=1&p={}&s={}".format(host, port, index, value)
+        "http://{}:{}/status.json?components=769&cmd=1&p={}&s={}".format(host, port, index, value)
     )
     r.raise_for_status()
 

--- a/labgrid/driver/power/gude8031.py
+++ b/labgrid/driver/power/gude8031.py
@@ -3,7 +3,14 @@ import requests
 # Driver has been tested with:
 # Gude Expert Power Control 8031()
 
-# Components Parameter is static, defines how to interact whith power controller
+# HTTP-GET API is defined in the Gude EPC-HTTP-Interface specification:
+# http://wiki.gude.info/EPC_HTTP_Interface
+#
+# The `components=<N>` parameter defines which status information are
+# included into the returned JSON.
+# * `components=0` happily returns an empty response but still switches the
+#   outputs as requestd.
+# * `components=1` only includes the output's state into the JSON.
 
 PORT = 80
 
@@ -13,7 +20,7 @@ def power_set(host, port, index, value):
     # access the web interface...
     value = 1 if value else 0
     r = requests.get(
-        "http://{}:{}/status.json?components=769&cmd=1&p={}&s={}".format(host, port, index, value)
+        "http://{}:{}/status.json?components=0&cmd=1&p={}&s={}".format(host, port, index, value)
     )
     r.raise_for_status()
 
@@ -22,7 +29,7 @@ def power_get(host, port, index):
     assert 1 <= index <= 8
 
     # get the component status
-    r = requests.get("http://{}:{}/status.json?components=575235".format(host, port))
+    r = requests.get("http://{}:{}/status.json?components=1".format(host, port))
     r.raise_for_status()
 
     state = r.json()['outputs'][index - 1]['state']


### PR DESCRIPTION

**Description**
This PR overhauls the Gude 8031 driver:
At least with the most recent firmare (V1.1.2) the URL used to set a port state returns a HTTP404 error. 
With this change an existing URL is used.

And while making changes to the driver anyway this PR reduces the amount of unused information requested from the device on every access making every interaction a little less expensive. We now only request as much status as needed.

**Checklist**


- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
