### PR TITLE
setup.py: add README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,20 @@
 #!/usr/bin/env python3
 
+from os import path
+
 from setuptools import setup
 
 import fastentrypoints  # noqa: F401 # pylint: disable=unused-import
 
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.rst'), encoding='utf-8') as f:
+        long_description = f.read()
 
 setup(
     name='labgrid',
     description='labgrid: lab hardware and software control layer',
+    long_description=long_description,
+    long_description_content_type='text/x-rst',
     author='Rouven Czerwinski and Jan Luebbe',
     author_email='entwicklung@pengutronix.de',
     license='LGPL-2.1',


### PR DESCRIPTION
**Description**
Include the README.rst as the long_description, so we get a properly
rendered README.rst on Pypi.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

See https://packaging.python.org/guides/making-a-pypi-friendly-readme/

Preview available at: https://test.pypi.org/project/labgrid-EMANTOR/
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested
<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
