### PR TITLE
HIDRelay: Add serial number filtering

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -361,9 +361,11 @@ It currently supports the widely used "dcttech USBRelay".
    HIDRelay:
      index: 2
      invert: False
+     serial: 6QMBS
 
 - index (int): number of the relay to use (defaults to 1)
 - invert (bool): whether to invert the relay
+- serial (str): relay serial number (defaults to "")
 
 Used by:
   - `HIDRelayDriver`_

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -115,6 +115,7 @@ RUN set -e ;\
     apt install -q=2 --yes --no-install-recommends \
         libyaml-0-2 \
         libsctp1 \
+        libusb-1.0-0 \
     ; \
     apt clean ;\
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Adds support for checking the HID Relay serial number when scanning
devices. The serial number is fetched from the devices HID report.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
