### PR TITLE
contrib/sync-places: Fix missing matches on tag on new places

### DIFF
--- a/contrib/sync-places.py
+++ b/contrib/sync-places.py
@@ -61,17 +61,20 @@ def main():
                     await session.call("org.labgrid.coordinator.add_place", name)
                 changed = True
 
-        for name in seen_places:
-            place = session.places[name]
+        for name in config["places"]:
             matches = config["places"][name].get("matches", [])
             seen_matches = set()
             remove_matches = set()
-            for m in place.matches:
-                m = repr(m)
-                if m in matches:
-                    seen_matches.add(m)
-                else:
-                    remove_matches.add(m)
+            place_tags = {}
+            if name in seen_places:
+                place = session.places[name]
+                for m in place.matches:
+                    m = repr(m)
+                    if m in matches:
+                        seen_matches.add(m)
+                    else:
+                        remove_matches.add(m)
+                place_tags = place.tags
 
             for m in remove_matches:
                 print("Deleting match '%s' for place %s" % (m, name))
@@ -91,7 +94,7 @@ def main():
                     changed = True
 
             tags = config["places"][name].get("tags", {}).copy()
-            if place.tags != tags:
+            if place_tags != tags:
                 print(
                     "Setting tags for place %s to %s"
                     % (
@@ -103,7 +106,7 @@ def main():
                 )
 
                 # Set the empty string for tags that should be removed
-                for k in place.tags:
+                for k in place_tags:
                     if k not in tags:
                         tags[k] = ""
 


### PR DESCRIPTION
The code was only adding matches and tags for places that were seen
while processing adding/removing places. This meant that brand-new
places did not get the matches and tags set. Fix this to set tags and
matches for all places specified in the config file, but only query the
existing places and tags for places that were seen (which prevents
dry-run from breaking)

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
