### PR TITLE
driver/fastbootdriver: remove vendor_id matching

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -32,7 +32,6 @@ class AndroidFastbootDriver(Driver):
     def _get_fastboot_prefix(self):
         prefix = self.fastboot.command_prefix+[
             self.tool,
-            "-i", hex(self.fastboot.vendor_id),
             "-s", "usb:{}".format(self.fastboot.path),
         ]
 


### PR DESCRIPTION
Remove passing of -i option to fastboot, since it has been removed
upstream by commit f3192bd05 ("Remove -i vendor id matching.").

Signed-off-by: Thorsten Scherer <t.scherer@eckelmann.de>


**Description**

Debians (bullseye) fastboot 1:10.0.0+r36-7 removes the option for vendor id matching. Which breaks our labgrid fastboot setup. This commit aims at fixing this issue.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [ ] PR has been tested
- [ ] Man pages have been regenerated