### PR TITLE
driver/power: Add backend driver for EG PMS2 LAN/WLAN

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ New Features in 0.5.0
   considering only the closest marker.
 - The labgrid client SSH command is now able to instantiate the SSHDriver when
   there are multiple NetworkService resources available.
+- eg_pms2_network power port driver supports controlling the Energenie power
+  management series with devices like the EG_PMS2_LAN & EG_PMS2_WLAN
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -208,6 +208,12 @@ Currently available are:
   Controls TP-Link power strips via `python-kasa
   <https://github.com/python-kasa/python-kasa>`_.
 
+``eg_pms2_network``
+  Controls the EG_PMS2_LAN & EG_PMS2_WLAN devices, through simple HTTP POST and
+  GET requests.  The device requires a password for logging into the control
+  interface, this module deliberately uses the standard password '1' and is
+  not compatible with a different password.
+
 Used by:
   - `NetworkPowerDriver`_
 

--- a/labgrid/driver/power/eg_pms2_network.py
+++ b/labgrid/driver/power/eg_pms2_network.py
@@ -1,0 +1,77 @@
+import re
+import requests
+
+from ..exception import ExecutionError
+
+# This driver implementes a power port for the EG_PMS2_LAN & EG_PMS2_WLAN
+# devices, it works through a simple HTTP interface, that requires a login.
+# Driver has been tested with:
+# * EG_PMS2_LAN
+
+# The default HTTP port for usage via the SSH proxy.
+PORT = 80
+
+# The login was successful when we can locate a Log out button
+LOGIN_SUCCESS_REGEX = r'<div class="boxmenuitem"><a href="login\.html">Log Out</a></div>'
+# Search for a string similar to: "var sockstates = [1,1,1,1];" and create
+# a match group out of the numbers within the square brackets.
+SOCKSTATES_REGEX = r"var\s+sockstates\s+=\s+\[([01]),([01]),([01]),([01])\];"
+
+
+def login(base_url: str) -> None:
+    """
+    Use the default password 1, because labgrid doesn't support password
+    encryption, modifying the password doesn't secure the device as the
+    password would be stored as plain-text.
+    """
+    login_url = f"{base_url}/login.html"
+    try:
+        response = requests.post(login_url, data={'pw': 1})
+    except requests.exceptions.ConnectionError as err:
+        raise ExecutionError(
+            f"Device not found at {base_url} or the network interface of the "
+            "device is not active (press the reset button on the device)"
+        ) from err
+    if response.status_code != 200 or not re.search(LOGIN_SUCCESS_REGEX,
+                                                    response.text):
+        raise ExecutionError("Login to Energenie web interface failed")
+
+
+def logout(base_url: str) -> None:
+    """
+    After a successful login, the session is reserved for the IP address.
+    Logout explicitly to allow accessing the device from different hosts.
+    """
+    response = requests.get(f"{base_url}/login.html")
+    if response.status_code != 200:
+        raise ExecutionError("Logout from Energenie web interface failed")
+
+
+def power_set(host, port, index, value):
+    base_url = f"http://{host}:{port}"
+    index = int(index)
+    assert 1 <= index <= 4
+
+    value = 1 if value else 0
+    login(base_url=base_url)
+    response = requests.post(base_url, data={f'cte{index}': value})
+    response.raise_for_status()
+    logout(base_url=base_url)
+    if not response.status_code == 200:
+        raise ExecutionError(f"Switching socket at index {index} "
+                             f"{'on' if value else 'off'} failed")
+
+
+def power_get(host, port, index):
+    base_url = f"http://{host}:{port}"
+    index = int(index)
+    assert 1 <= index <= 4
+
+    # Fetch status
+    login(base_url=base_url)
+    response = requests.get(f"{base_url}/energenie.html")
+    response.raise_for_status()
+    logout(base_url=base_url)
+    match_group = re.search(SOCKSTATES_REGEX, response.text)
+    sockstates = [int(match_group.group(x)) for x in range(1, 5)]
+    return sockstates[index - 1] == 1

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -171,6 +171,7 @@ class TestNetworkPowerDriver:
         import labgrid.driver.power.netio_kshell
         import labgrid.driver.power.rest
         import labgrid.driver.power.sentry
+        import labgrid.driver.power.eg_pms2_network
 
     def test_import_backend_siglent(self):
         pytest.importorskip("vxi11")


### PR DESCRIPTION
This driver adds support for the Energenie PMS2 LAN & WLAN programmable
power sockets. They are accessed over a web interface and require a
login before accessing the status of the socket or switching them on or off.
A password is required for the login in POST request and this driver
deliberately uses the default password, as the current state of labgrid
doesn't support password encryption, meaning the password would be
stored in plain text.

Signed-off-by: Sebastian Fricke <sebastian.fricke@posteo.net>

Small note about passwords:
From my discussion in this [issue](https://github.com/labgrid-project/labgrid/issues/794) I have gotten the notion, that security in labgrid is performed on the network level, therefore I have decided to keep this module as simple as possible by demanding the default password. If we want to allow the user to change the password, then I believe this patch will become a lot more complex as the NetworkPowerDriver does not support such an attribute and therefore there might be the need for an alternative approach.
I would like to hear your thoughts about this.

What do you use the feature for?
To work with my Energenie programmable power sockets within my personal lab.

How does labgrid benefit as a testing library from the feature?
A wider range of supported devices increases the usefulness of the library for a bigger audience. 

How did you verify the feature works?
I have tested it in my personal lab with the EG_PMS2_LAN device.

If hardware is needed for the feature, which hardware is supported, and which hardware did you test with?
Currently, I know that the device should work for both the EG_PMS2_LAN and EG_PMS2_WLAN devices as both are from the same series, but I only tested with EG_PMS2_LAN. The driver might also work for the EG_PM2 series but I have not tested it (the only difference between the PMS2 and PM2 seems to be surge protection).

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst (should not be required for such a simple module)
- [ ] Add a section on how to use the feature to doc/development.rst (should not be required for such a simple module)
- [x] CHANGES.rst has been updated
- [x] PR has been tested
