### PR TITLE
WIP: yaml include

### DIFF
--- a/examples/yamlinclude/README.md
+++ b/examples/yamlinclude/README.md
@@ -1,0 +1,99 @@
+# Splitting configuration into multiple yaml files
+
+**TODO**:*write a coherent prose*
+
+
+Essentially the files listed in `includes` are copy pasted into the "base" yaml with all the limitation it will cause.
+
+Limitations:
+
+* It is not allow to have multiple blocks with the same name. See the section 'Same block in multiple files'.
+* Anchors must be defined before they are referenced. See the section 'Defining anchors'
+
+## Same block in multiple files
+
+This is not possible due to limitation in YAML. In the following example the `defaults` block from `first.yaml` will be overwritten with the `defaults` block from `second.yaml`
+
+```yaml
+# filename: first.yaml
+defaults:
+    foo: "hello"
+
+includes:
+    - "second.yaml"
+```
+
+```yaml
+# filename: second.yaml
+defaults:
+    bar: "world"
+```
+
+The output produced by the **TODO***:name of this include functionality* will be
+
+```yaml
+# filename: first.yaml
+defaults:
+    foo: "hello"
+
+# filename: second.yaml
+defaults:
+    bar: "world"
+```
+
+... which by YAML will be evaluated just as 
+
+```yaml
+defaults:
+    bar: "world"
+```
+
+## Defining anchors
+
+**TODO**: *actually this could be partly solved if the included files in dropped in where the include block in defined, and not just at the end of the base file*
+
+Yaml dictates that anchors must be defines before they are referenced **TOD**:*insert reference*
+
+```yaml
+# filename: base.yaml
+defines:
+    target_ip: &target_ip
+        "1.2.3.4"
+
+includes:
+    - "target.yaml"
+```
+
+```yaml
+# filename: target.yaml
+target:
+    main:
+        resources:
+            - NetworkService:
+                name: 'ssh'
+                address: *target_ip
+```
+
+### How not to do it
+
+This will not work because the included file is inserted at the bottom of `base.yaml`
+
+```yaml
+# filename: base.yaml
+includes:
+    - "hosts.yaml"
+
+targe:
+    main:
+        resources:
+            - NetworkService:
+                name: 'ssh'
+                address: *target_ip
+```
+
+```yaml
+# filename: hosts.yaml
+defines:
+    target_ip: &target_ip
+        "1.2.3.4"
+```

--- a/examples/yamlinclude/common.yaml
+++ b/examples/yamlinclude/common.yaml
@@ -1,0 +1,36 @@
+abstracts:
+  resources:
+    - MyPDU: &pdu_resource
+        model: "apc"
+        host: *pdu_ip
+
+targets:
+  main:
+    resources:
+    - NetworkService:
+        name: 'ssh-root'
+        address: *target_ip
+        username: "root"
+        password: "root"
+    - NetworkPowerPort:
+        name: "target_resource"
+        <<: *pdu_resource
+        index: 2
+    - NetworkPowerPort:
+        name: "network_power_resource"
+        <<: *pdu_resource
+        index: 1
+    drivers:
+    - SSHDriver:
+        name: "ssh-root-driver"
+        bindings:
+          networkservice: "ssh-root"
+        keyfile: ""
+    - NetworkPowerDriver:
+        name: "target"
+        bindings:
+          port: "target_resource"
+    - NetworkPowerDriver:
+        name: "network_power"
+        bindings:
+          port: "network_power_resource"

--- a/examples/yamlinclude/my-target-env.yaml
+++ b/examples/yamlinclude/my-target-env.yaml
@@ -1,0 +1,8 @@
+defines:
+  pdu_ip: &pdu_ip
+    "1.2.3.4"
+  m_system_ip: &target_ip
+    "1.2.3.5"
+
+includes:
+  - "common.yaml"

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -19,7 +19,7 @@ class Config:
         self.base = os.path.dirname(os.path.abspath(self.filename))
         try:
             with open(self.filename) as file:
-                self.data = load(file)
+                self.data = load(file, self.base)
         except FileNotFoundError:
             raise NoConfigFoundError(
                 "configuration file '{}' could not be found".format(self.filename)

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -75,7 +75,7 @@ def test_drivers():
 
 
 def test_convert_dict(foo_yaml):
-    data = load(foo_yaml)
+    data = load(foo_yaml, '.')
     l = target_factory._convert_to_named_list(data)
     assert l == [
         {
@@ -90,7 +90,7 @@ def test_convert_dict(foo_yaml):
 
 
 def test_convert_simple_list(foo_yaml):
-    data = load(foo_yaml)
+    data = load(foo_yaml, '.')
     l = target_factory._convert_to_named_list(data)
     assert l == [
         {
@@ -105,7 +105,7 @@ def test_convert_simple_list(foo_yaml):
 
 
 def test_convert_explicit_list(list_yaml):
-    data = load(list_yaml)
+    data = load(list_yaml, '.')
     l = target_factory._convert_to_named_list(data)
     assert l == [
         {
@@ -123,14 +123,14 @@ def test_convert_error():
     with pytest.raises(InvalidConfigError) as excinfo:
         data = load(io.StringIO("""
                 - {}
-                """))
+                """), '.')
         target_factory._convert_to_named_list(data)
     assert "invalid empty dict as list item" in excinfo.value.msg
 
     with pytest.raises(InvalidConfigError) as excinfo:
         data = load(io.StringIO("""
                 - "error"
-                """))
+                """), '.')
         target_factory._convert_to_named_list(data)
     assert "invalid list item type <class 'str'> (should be dict)" in excinfo.value.msg
 
@@ -138,7 +138,7 @@ def test_convert_error():
         data = load(io.StringIO("""
                 - name: "bar"
                   extra: "baz"
-                """))
+                """), '.')
         target_factory._convert_to_named_list(data)
     assert "missing 'cls' key in " in excinfo.value.msg
 
@@ -146,7 +146,7 @@ def test_convert_error():
         data = load(io.StringIO("""
                 - one:
                 - two: {}
-                """))
+                """), '.')
         target_factory._convert_to_named_list(data)
     assert "invalid list item, add empty dict for no arguments" in excinfo.value.msg
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -2,6 +2,7 @@ from collections import OrderedDict, UserString
 
 import pytest
 import yaml
+import io
 
 from labgrid.util.yaml import *
 
@@ -35,9 +36,11 @@ def test_labgrid_loader():
       line
     bar: False
     """
-    data = load(doc)
-    assert type(data) == OrderedDict
-    assert type(data["foo"]) == UserString
+    stream = io.StringIO(doc)
+    data = load(stream)
+
+    assert isinstance(data, dict)
+    assert isinstance(data['foo'], UserString)
     assert data["foo"].start_mark.line == 1
     assert data["foo"].end_mark.line == 4
 

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -37,7 +37,7 @@ def test_labgrid_loader():
     bar: False
     """
     stream = io.StringIO(doc)
-    data = load(stream)
+    data = load(stream, '.')
 
     assert isinstance(data, dict)
     assert isinstance(data['foo'], UserString)


### PR DESCRIPTION
This is still early days for the functionality, but I would like to get feed back if the concept holds and should be part of labgrid in the future. 

**Description**

The functionality added it to allow to split the lg-env yaml into multiple files. The rationale for this is that we have multiple test sites that essential are the same with very minor differences, e.g. different ip addresses of resources. With this change it is possible to have a `common.yaml` (or any other name) that describes that describes all that is common and then implement the individual sites/envs in separate file that will include the common stuff.

Special attention: 

* I had to change the unittests for some of the existing tests. See ecd3f08e462f6e5b44d6b574c65f8b8d5677f8f9
* There is an issue in the current implementation of the yaml.py::load() method. The custom loader implemented does not work with anchors and references in the yaml. This is not originated to the include-feature, but becomes an issue for it. I do not know how to fix that problem correct, but this PR contains a work around. If the feature in this PR is welcomed into the master, I will create an issue on this. See the comments in `labgrid/util/yaml.py` in 2c0a9fce18ccbe7a1bb2218d365a092421ce7bfa
 
**Alternative solution**

The functionality covered in this PR can also be achieved with scripts that can "stitch" specialized yaml files. This solution would allow much more complex use cases that covered by this PR, e.g. storing sites and configuration in a database and be able to auto generate specific yaml files. However, it is assumed that the issue in this PR will cover far the most examples.

**Checklist**

- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x ] PR has been tested
