### PR TITLE
driver: add modbus rtu driver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ Release 0.5.0 (unreleased)
 
 New Features in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~
+- ModbusRTU driver for instruments
 - Support for Eaton ePDU and TP-Link power strips added, either can be used as a NetworkPowerPort.
 - Consider a combination of multiple "lg_feature" markers instead of
   considering only the closest marker.

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,6 +9,7 @@ psutil==5.8.0
 -r crossbar-requirements.txt
 -r onewire-requirements.txt
 -r modbus-requirements.txt
+-r modbusrtu-requirements.txt
 -r snmp-requirements.txt
 -r xena-requirements.txt
 -r graph-requirements.txt

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -64,6 +64,42 @@ port 53867 and use a baud rate of 115200 with the RFC2217 protocol.
 Used by:
   - `SerialDriver`_
 
+ModbusRTU
++++++++++
+Describes the resource required to use the ModbusRTU driver.
+`Modbus RTU <https://en.wikipedia.org/wiki/Modbus>`_ is a communication
+protocol used to control many different kinds of electronic systems, such as
+thermostats, power plants, etc.
+Modbus is normally implemented on top of RS-485, though this is not strictly
+necessary, as long as the Modbus network only has one master (and up to 256
+slaves).
+
+The labgrid driver is implemented using the minimalmodbus Python library.
+The implementation only supports that labgrid will be the master on the Modbus
+network.
+For more information, see `minimalmodbus
+<https://minimalmodbus.readthedocs.io/en/stable/>`_.
+
+This resource and driver only supports local usage and will not work with an
+exporter.
+
+.. code-block:: yaml
+
+    ModbusRTU:
+      port: "/dev/ttyUSB0"
+      address: 16
+      speed: 115200
+      timeout: 0.25
+
+Arguments:
+  - port (str): tty the instrument is connected to, e.g. '/dev/ttyUSB0'
+  - address (int): slave address on the modbus, e.g. 16
+  - baudrate (bool): optional, default is 115200
+  - timeout (bool): optional, timeout in seconds. Default is 0.25 s
+
+Used by:
+  - `ModbusRTUDriver`_
+
 USBSerialPort
 +++++++++++++
 A USBSerialPort describes a serial port which is connected via USB and is
@@ -1225,6 +1261,19 @@ Arguments:
   - txdelay (float, default=0.0): time in seconds to wait before sending each byte
   - timeout (float, default=3.0): time in seconds to wait for a network serial port before
     an error occurs
+
+ModbusRTUDriver
+~~~~~~~~~~~~~~~
+A ModbusRTUDriver connects to a ModbusRTU resource. This driver only supports
+local usage and will not work with an exporter.
+
+.. code-block:: yaml
+
+    ModbusRTUDriver: {}
+
+Binds to:
+  port:
+    - `ModbusRTU`_
 
 ShellDriver
 ~~~~~~~~~~~

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -100,6 +100,10 @@ Modbus
 Modbus support requires an additional package `pyModbusTCP`. It is included in
 the `modbus-requirements.txt` file.
 
+ModbusRTU
++++++++++
+Modbus support requires an additional package `minimalmodbus`. It is included in
+the `modbusrtu-requirements.txt` file.
 
 Running Your First Test
 -----------------------

--- a/examples/modbusrtu/conftest.py
+++ b/examples/modbusrtu/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(scope='session')
+def instrument(target):
+    _modbus = target.get_driver('ModbusRTUDriver')
+    return _modbus

--- a/examples/modbusrtu/env.yaml
+++ b/examples/modbusrtu/env.yaml
@@ -1,0 +1,10 @@
+targets:
+  main:
+    resources:
+      ModbusRTU:
+        port: "/dev/ttyUSB0"
+        address: 16
+        speed: 115200
+        timeout: 0.25
+    drivers:
+      ModbusRTUDriver: {}

--- a/examples/modbusrtu/test_modbusrtu_example.py
+++ b/examples/modbusrtu/test_modbusrtu_example.py
@@ -1,0 +1,13 @@
+def test_modbusrtu_example(instrument):
+    """
+    The interface for the modbus RTU driver is a thin adapter, having same
+    interface as provided by the minimalmodbus package. Therefore, for more
+    infromation on how to use the labgrid modbus RTU driver, please refer to
+    the minimalmodbus documentation.
+    """
+
+    uptime_register_addr = 0x107
+    instrument.write_register(uptime_register_addr, 0, functioncode=6)
+    value = instrument.read_register(uptime_register_addr)
+
+    assert value <= 1

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -20,6 +20,7 @@ from .usbsdwiredriver import USBSDWireDriver
 from .common import Driver
 from .qemudriver import QEMUDriver
 from .modbusdriver import ModbusCoilDriver
+from .modbusrtudriver import ModbusRTUDriver
 from .sigrokdriver import SigrokDriver
 from .usbstoragedriver import USBStorageDriver, NetworkUSBStorageDriver, Mode
 from .resetdriver import DigitalOutputResetDriver

--- a/labgrid/driver/modbusrtudriver.py
+++ b/labgrid/driver/modbusrtudriver.py
@@ -1,0 +1,54 @@
+from importlib import import_module
+import attr
+
+from ..factory import target_factory
+from .common import Driver
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class ModbusRTUDriver(Driver):
+    bindings = {"resource": "ModbusRTU"}
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self._modbus = import_module('minimalmodbus')
+        self.instrument = None
+
+    def on_activate(self):
+        self.instrument = self._modbus.Instrument(
+            self.resource.port,
+            self.resource.address,
+            debug=False)
+        self.instrument.serial.baudrate = self.resource.speed
+        self.instrument.serial.timeout = self.resource.timeout
+
+        self.instrument.mode = self._modbus.MODE_RTU
+        self.instrument.clear_buffers_before_each_transaction = True
+
+    def on_deactivate(self):
+        self.instrument = None
+
+    def read_register(self, *args, **kwargs):
+        return self.instrument.read_register(*args, **kwargs)
+
+    def write_register(self, *args, **kwargs):
+        return self.instrument.write_register(*args, **kwargs)
+
+    def read_registers(self, *args, **kwargs):
+        return self.instrument.read_registers(*args, **kwargs)
+
+    def write_registers(self, *args, **kwargs):
+        return self.instrument.write_registers(*args, **kwargs)
+
+    def read_bit(self, *args, **kwargs):
+        return self.instrument.read_bit(*args, **kwargs)
+
+    def write_bit(self, *args, **kwargs):
+        return self.instrument.write_bit(*args, **kwargs)
+
+    def read_string(self, *args, **kwargs):
+        return self.instrument.read_string(*args, **kwargs)
+
+    def write_string(self, *args, **kwargs):
+        return self.instrument.write_string(*args, **kwargs)

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -2,6 +2,7 @@ from .base import SerialPort, NetworkInterface, EthernetPort
 from .ethernetport import SNMPEthernetPort
 from .serialport import RawSerialPort, NetworkSerialPort
 from .modbus import ModbusTCPCoil
+from .modbusrtu import ModbusRTU
 from .networkservice import NetworkService
 from .onewireport import OneWirePIO
 from .power import NetworkPowerPort

--- a/labgrid/resource/modbusrtu.py
+++ b/labgrid/resource/modbusrtu.py
@@ -1,0 +1,29 @@
+import attr
+
+from ..factory import target_factory
+from .common import Resource
+from .base import SerialPort
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class ModbusRTU(SerialPort, Resource):
+    """This resource describes Modbus RTU instrument.
+
+    Args:
+        port (str): tty the instrument is connected to, e.g. '/dev/ttyUSB0'
+        speed (bool): optional, default is 115200
+        address (int): slave address on the modbus, e.g. 16
+        timeout (bool): optional, timeout in seconds. Default is 0.25 s
+    """
+
+    address = attr.ib(default=None, validator=attr.validators.instance_of(int))
+    timeout = attr.ib(default=0.25,
+                      validator=attr.validators.instance_of(float))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        if self.port is None:
+            raise ValueError("ModbusRTU must be configured with a port")
+        if self.address is None:
+            raise ValueError("ModbusRTU must be configured with an slave address")

--- a/modbusrtu-requirements.txt
+++ b/modbusrtu-requirements.txt
@@ -1,0 +1,1 @@
+minimalmodbus==1.0.2

--- a/tests/test_modbusrtudriver.py
+++ b/tests/test_modbusrtudriver.py
@@ -1,0 +1,36 @@
+from labgrid.resource.modbusrtu import ModbusRTU
+from labgrid.driver.modbusrtudriver import ModbusRTUDriver
+
+import pytest
+
+
+def test_resource_with_minimum_argument(target):
+    dut = ModbusRTU(target, name=None, port="/dev/tty1", address=10)
+
+    assert dut.port == "/dev/tty1"
+    assert dut.address == 10
+    assert dut.speed == 115200
+    assert dut.timeout == 0.25
+
+
+def test_resource_with_non_default_argument(target):
+    dut = ModbusRTU(target, name=None, port="/dev/tty1", address=10,
+                    speed=9600, timeout=0.5)
+
+    assert dut.port == "/dev/tty1"
+    assert dut.address == 10
+    assert dut.speed == 9600
+    assert dut.timeout == 0.5
+
+
+def test_driver(target, mocker):
+    ModbusRTU(target, name=None, port="/dev/tty0", address=10)
+    driver = ModbusRTUDriver(target, name=None)
+
+    # Ensure pyserial will not try to open the port
+    driver.resource.port = None
+
+    target.activate(driver)
+
+    assert driver.instrument.serial.baudrate == 115200
+    assert driver.instrument.serial.timeout == 0.25


### PR DESCRIPTION
**Description**

Added a Modbus RTU driver to allow for labgrid tests to control modbus devices.

**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature 
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] CHANGES.rst has been updated
- [X] PR has been tested
