### PR TITLE
target: Quieten message when resource is unavailable

### DIFF
--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -51,8 +51,15 @@ class Target:
         for resource in self.resources:
             resource.poll()
             if not resource.avail and resource.state is BindingState.active:
-                self.log.info("deactivating unavailable resource %s", resource.display_name)  # pylint: disable=line-too-long
-                self.deactivate(resource)
+                deactivated = self.deactivate(resource)
+                deactivated.remove(resource)
+                if deactivated:
+                    self.log.info("deactivating unavailable resource %s used by %s",
+                        resource.display_name,
+                        ", ".join(d.display_name for d in deactivated)
+                    )
+                else:
+                    self.log.debug("deactivating unavailable resource %s (unused)", resource.display_name)  # pylint: disable=line-too-long
 
     def await_resources(self, resources, timeout=None, avail=True):
         """
@@ -438,6 +445,8 @@ class Target:
         Recursively deactivate the client's clients and itself.
 
         This is needed to ensure that no client has an inactive supplier.
+
+        Returns the list of all objects that were deactivated
         """
         if isinstance(client, str):
             cls = target_factory.class_from_string(client)
@@ -446,7 +455,7 @@ class Target:
         assert client is not None
 
         if client.state is BindingState.bound:
-            return  # nothing to do
+            return [] # nothing to do
 
         if client.state is not BindingState.active:
             raise BindingError(
@@ -456,12 +465,15 @@ class Target:
         # consistency check
         assert client in self.resources or client in self.drivers
 
+        deactivated = [client]
+
         for cli in client.clients:
-            self.deactivate(cli)
+            deactivated.extend(self.deactivate(cli))
 
         # update state
         client.on_deactivate()
         client.state = BindingState.bound
+        return deactivated
 
     def deactivate_all_drivers(self):
         """Deactivates all drivers in reversed order they were activated"""


### PR DESCRIPTION
Having this message at info() level means it shows up on stdout when a
resource disappears during a test. This is unnecessary as any driver
using the resource will fail when an attempt is made to use it.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
