### PR TITLE
drivers/manualswitchoutput: Add Driver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1717,6 +1717,23 @@ Implements:
 Arguments:
   - None
 
+ManualSwitchDriver
+~~~~~~~~~~~~~~~~~~
+A ManualSwitchDriver requires the user to control a switch or jumper on the
+target. This can be used if a driver binds to a :any:`DigitalOutputProtocol`,
+but no automatic control is available.
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   ManualSwitchDriver:
+     description: 'Jumper 5'
+
+Arguments:
+  - description (str): optional description of the switch or jumper on the target
+
 MXSUSBDriver
 ~~~~~~~~~~~~
 A MXUSBDriver is used to upload an image into a device in the mxs USB loader

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -37,3 +37,4 @@ from .usbaudiodriver import USBAudioInputDriver
 from .networkinterfacedriver import NetworkInterfaceDriver
 from .provider import TFTPProviderDriver
 from .mqtt import TasmotaPowerDriver
+from .manualswitchdriver import ManualSwitchDriver

--- a/labgrid/driver/manualswitchdriver.py
+++ b/labgrid/driver/manualswitchdriver.py
@@ -1,0 +1,41 @@
+import attr
+
+from ..factory import target_factory
+from ..protocol import DigitalOutputProtocol
+from ..step import step
+from .common import Driver
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class ManualSwitchDriver(Driver, DigitalOutputProtocol):
+    description = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str)),
+    )
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.status = False
+
+    @Driver.check_active
+    @step(args=["status"])
+    def set(self, status):
+        if self.description is not None:
+            description = self.description
+        else:
+            description = self.name
+
+        self.target.interact(
+            "Set {description} for target {name} to {status} and press enter".format(
+                description=description,
+                name=self.target.name,
+                status="ON" if status else "OFF",
+            )
+        )
+        self.status = status
+
+    @Driver.check_active
+    @step(result=True)
+    def get(self):
+        return self.status

--- a/tests/test_manualswitchdriver.py
+++ b/tests/test_manualswitchdriver.py
@@ -1,0 +1,43 @@
+import pytest
+
+from labgrid.driver.manualswitchdriver import ManualSwitchDriver
+
+
+class TestManualSwitchDriver:
+    def test_create(self, target):
+        d = ManualSwitchDriver(target, "foo-switch")
+        assert isinstance(d, ManualSwitchDriver)
+
+    def test_set_on(self, target, mocker):
+        m = mocker.patch("builtins.input")
+
+        d = ManualSwitchDriver(target, "foo-switch")
+        target.activate(d)
+        d.set(True)
+
+        m.assert_called_once_with(
+            "Set foo-switch for target Test to ON and press enter"
+        )
+
+    def test_set_off(self, target, mocker):
+        m = mocker.patch("builtins.input")
+
+        d = ManualSwitchDriver(target, "foo-switch")
+        target.activate(d)
+        d.set(False)
+
+        m.assert_called_once_with(
+            "Set foo-switch for target Test to OFF and press enter"
+        )
+
+    def test_get(self, target, mocker):
+        m = mocker.patch("builtins.input")
+
+        d = ManualSwitchDriver(target, "foo-switch")
+        target.activate(d)
+
+        d.set(True)
+        assert d.get() is True
+
+        d.set(False)
+        assert d.get() is False


### PR DESCRIPTION
Adds a Manual Switch Driver which can be used to prompt the user to set
a jumper or switch when testing locally

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
