### PR TITLE
strategy: wait for systemd operational state in shell states

### DIFF
--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -56,6 +56,7 @@ class BareboxStrategy(Strategy):
             self.barebox.boot("")
             self.barebox.await_boot()
             self.target.activate(self.shell)
+            self.shell.run("systemctl is-system-running --wait")
         else:
             raise StrategyError(
                 "no transition found from {} to {}".

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -46,6 +46,7 @@ class ShellStrategy(Strategy):
             self.target.activate(self.console)
             self.power.cycle()
             self.target.activate(self.shell)
+            self.shell.run("systemctl is-system-running --wait")
         else:
             raise StrategyError(
                 "no transition found from {} to {}".

--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -53,6 +53,7 @@ class UBootStrategy(Strategy):
             self.uboot.boot("")
             self.uboot.await_boot()
             self.target.activate(self.shell)
+            self.shell.run("systemctl is-system-running --wait")
         else:
             raise StrategyError("no transition found from {} to {}".format(self.status, status))
         self.status = status


### PR DESCRIPTION
**Description**
The system might not be in operational state once the login prompt is shown. Try to wait until the system is up and running for systemd-based systems. Use run() instead of run_check() for non-systemd based systems or if degraded/maintenance/stopping system states are reached.

This covers wider use-cases for the shipped strategies.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [.] PR has been tested