### PR TITLE
remote/client: add write-image-like write-file command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,8 @@ New Features in 0.4.0
 - Network controlled relay providing GET/PUT based REST API
 - Improved LG_PROXY documentation in docs/usage.rst.
 - Exporter now checks /usr/sbin/ser2net for SerialPortExport
+- labgrid-client ``write-file`` subcommand: labgrid client now has a
+  ``write-file`` command to mount block devices and write a single file.
 
 Bug fixes in 0.4.0
 ~~~~~~~~~~~~~~~~~~

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: labgrid
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python3, ${misc:Pre-Depends}
 Depends: ${python3:Depends}, ${misc:Depends}, ${shlibs:Depends}
-Recommends: openssh-client, microcom, socat, sshfs, rsync
+Recommends: openssh-client, microcom, socat, sshfs, rsync, pmount
 Description: embedded board control python library
  Labgrid is a embedded board control python library with a focus on testing,
  development and general automation. It includes a remote control layer to

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -426,7 +426,7 @@ Used by:
   - `USBStorageDriver`_
 
 The NetworkUSBMassStorage can be used in test cases by calling the
-`write_image()`, and `get_size()` functions.
+`write_image()`, `write_file()` and `get_size()` functions.
 
 SigrokDevice
 ~~~~~~~~~~~~

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -26,7 +26,7 @@ RUN set -e ;\
     pip3 install --no-cache-dir -r requirements.txt ;\
     SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" python3 setup.py install ;\
     apt update -q=2 ;\
-    apt install -q=2 --yes --no-install-recommends microcom openssh-client rsync jq qemu-system; \
+    apt install -q=2 --yes --no-install-recommends microcom openssh-client rsync pmount jq qemu-system; \
     apt clean ;\
     rm -rf /var/lib/apt/lists/*
 

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -186,6 +186,8 @@ matches anything.
 .sp
 \fBwrite\-image\fP                 Write images onto block devices (USBSDMux, USB Sticks, …)
 .sp
+\fBwrite\-file\fP                  Write file onto a file system on a block device (USBSDMux, USB Sticks, …)
+.sp
 \fBreserve\fP filter              Create a reservation
 .sp
 \fBcancel\-reservation\fP token    Cancel a pending reservation

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -180,6 +180,8 @@ LABGRID-CLIENT COMMANDS
 
 ``write-image``                 Write images onto block devices (USBSDMux, USB Sticks, …)
 
+``write-file``                  Write file onto a file system on a block device (USBSDMux, USB Sticks, …)
+
 ``reserve`` filter              Create a reservation
 
 ``cancel-reservation`` token    Cancel a pending reservation


### PR DESCRIPTION
**Description**

- what do you use the feature for?

Interactive use with `labgrid-client`. It's useful for bootloader development for processors with bootroms that load code from file systems (e.g. EFI system partition, OMAP, AT91, Zynq, Raspberry ... etc.)

- how does labgrid benefit as a testing library from the feature?

I guess a unit test could place e.g. a broken configuration file and see how it behaves?

- how did you verify the feature works?

Remote usbsdmux that I usually use with `write-image`. Tried writing non-existing files and overwriting existing files with `write-file`. Works well.

- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

Anything exposing a `USBStorageDriver`. I tested with a usbsdmux.


**Checklist**
- [x] Documentation for the feature
- [-] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [-] Add a section on how to use the feature to doc/usage.rst
- [-] Add a section on how to use the feature to doc/development.rst
- [x] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated