### PR TITLE
resource/udev: handle multiple resources on single device correctly

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -32,7 +32,7 @@ class UdevManager(ResourceManager):
         devices.match_subsystem(resource.match['SUBSYSTEM'])
         for device in devices:
             if resource.try_match(device):
-                break
+                self.log.debug(" matched successfully against %s", resource.device)
 
     def _insert_into_queue(self, device):
         self.queue.put(device)
@@ -46,9 +46,8 @@ class UdevManager(ResourceManager):
                 break
             self.log.debug("%s: %s", device.action, device)
             for resource in self.resources:
-                self.log.debug(" %s", resource)
                 if resource.try_match(device):
-                    break
+                    self.log.debug(" matched successfully")
 
 @attr.s(eq=False)
 class USBResource(ManagedResource):


### PR DESCRIPTION
**Description**
Imagine multiple USBResources match the same device, e.g.:

```
{% for idx, sysfs in [
  (1,   'pci-0000:00:14.0-usb-0:2.3'),
  (2,   'pci-0000:00:14.0-usb-0:2.4'),
  (3,   'pci-0000:00:14.0-usb-0:2.1'),
  (4,   'pci-0000:00:14.0-usb-0:2.2')] %}

  usbhub-b-{{idx}}:
    location: 'on my desk'
    USBSerialPort:
      match:
        '@ID_PATH': '{{sysfs}}'

  {% for port in range(1, 5) %}
  usbhub-b-{{idx}}-outlet{{port}}:
    SiSPMPowerPort:
      match:
        'ID_PATH': '{{sysfs}}'
      index: {{port}}
  {% endfor %}
{% endfor %}
```

This describes a 4 port USB hub. On each port USBSerialPort as well as SiSPMPowerPort resources should be exported. Note that the 4 power sockets of the _SiS-PM_ power outlet are exported separately.

This works if the SiS-PM is plugged before the exporter is started. In case it is then unplugged, not all resources are marked as unavailable. If it is replugged again, not all resources are marked as available.

The reason for this behavior is the premature break in `UdevManager.on_resource_added()` and `UdevManager.poll()` once the first matching device is found. All remaining resources are
ignored. This breaks the concept of allowing multiple resources on a single device.

Fix that by dropping the premature break, so all resources are tried to match against the device.

There is no need to log each and every resource while iterating over them. The `try_match()` method logs the matched USBResource already, so log only whether matching was successful.
Also log the matched device in `on_resource_added()` since we do not log that here before.


**Note:** I am unsure if this breaks assumptions made elsewhere or if the matching all resources impacts the udev processing in negative ways.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] CHANGES.rst has been updated
- [x] PR has been tested

Fixes fa5ed01 ("resource: implement ManagedResources and a USBSerialPort")

