### PR TITLE
driver: flashscriptdriver/openocddriver: avoid using mutable objects as defaults

### DIFF
--- a/labgrid/driver/flashscriptdriver.py
+++ b/labgrid/driver/flashscriptdriver.py
@@ -24,7 +24,7 @@ class FlashScriptDriver(Driver):
         validator=attr.validators.optional(attr.validators.instance_of(str)),
     )
     args = attr.ib(
-        default=[],
+        default=attr.Factory(list),
         validator=attr.validators.optional(attr.validators.instance_of(list)),
     )
 

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -22,11 +22,11 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
     }
 
     config = attr.ib(
-        default=[],
+        default=attr.Factory(list),
         validator=attr.validators.optional(attr.validators.instance_of((str, list)))
     )
     search = attr.ib(
-        default=[],
+        default=attr.Factory(list),
         validator=attr.validators.optional(attr.validators.instance_of((str, list)))
     )
     image = attr.ib(


### PR DESCRIPTION
**Description**
If the config/search/attrs attributes are changed in one object instance, they appear changed in all the others since they are in fact shared. This could happen when multiple OpenOCDDrivers/FlashScriptDrivers are instanciated on different resources.

Fix that by using a factory instead.

**Checklist**
- [ ] PR has been tested

Fixes #746 
Fixes #781
Fixes #270