### PR TITLE
pytestplugin: fixtures: redirect stderr of git commands to /dev/null

### DIFF
--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -80,7 +80,7 @@ def env(request, record_testsuite_property):
         record_testsuite_property('PATH_{}'.format(name.upper()), path)
         try:
             sha = subprocess.check_output(
-                "git rev-parse HEAD".split(), cwd=path)
+                "git rev-parse HEAD".split(), cwd=path, stderr=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             continue
         except FileNotFoundError:
@@ -94,7 +94,8 @@ def env(request, record_testsuite_property):
             'IMAGE_{}'.format(name.upper()), image)
         try:
             sha = subprocess.check_output(
-                "git rev-parse HEAD".split(), cwd=os.path.dirname(image))
+                "git rev-parse HEAD".split(), cwd=os.path.dirname(image),
+                stderr=subprocess.DEVNULL)
         except subprocess.CalledProcessError:
             continue
         except FileNotFoundError:


### PR DESCRIPTION
**Description**
labgrid's `env` fixture calls `git rev-parse HEAD` in each path configured in the environments "paths" and "images" keys to record their corresponding commit-ishes.

Because of that, errors like these are quite common:

```
fatal: not a git repository (or any parent up to mount point /)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).
```

This happens if the paths do not contain a git repository. Redirect these errors to `/dev/null` instead of printing them without context, confusing the users of the pytest plugin.

**Checklist**
- [x] PR has been tested