### PR TITLE
doc: configuration: add missing keys "paths"/"features" to env config skeleton

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2664,6 +2664,9 @@ The skeleton for an environment consists of:
    options:
      <option-1 name>: <value for option-1>
      <more options>
+   paths:
+     <path-1 name>: <absolute or relative path for path-1>
+     <more paths>
    images:
      <image-1 name>: <absolute or relative path for image-1>
      <more images>

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2652,6 +2652,8 @@ The skeleton for an environment consists of:
          <driver-1>:
            <driver-1 parameters>
          <driver-2>: {} # no parameters for driver-2
+       features:
+         - <target-feature-1>
      <target-2>:
        resources:
          <resources>
@@ -2664,6 +2666,8 @@ The skeleton for an environment consists of:
    options:
      <option-1 name>: <value for option-1>
      <more options>
+   features:
+     - <global-feature-1>
    paths:
      <path-1 name>: <absolute or relative path for path-1>
      <more paths>


### PR DESCRIPTION
**Description**
The "paths" key was missing in the config skeleton. It is referenced in the documentation of the QEMUDriver. See also Config's `get_path()` and `get_paths()` methods.

The "features" key is documented in its own section in `doc/usage.rst`, but it was missing in the config skeleton.

**Checklist**
- [x] Documentation for the feature