### PR TITLE
remote/config: support jinja2 includes

### DIFF
--- a/labgrid/remote/config.py
+++ b/labgrid/remote/config.py
@@ -15,6 +15,7 @@ class ResourceConfig:
 
     def __attrs_post_init__(self):
         env = jinja2.Environment(
+            loader=jinja2.FileSystemLoader(os.path.dirname(self.filename)),
             line_statement_prefix='#',
             line_comment_prefix='##',
         )


### PR DESCRIPTION
This allows using `{% include 'other.yaml' %}` to include further
configuration fragments.

**Checklist**
- [x] PR has been tested