### PR TITLE
remote/client: allow already locked resources

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -615,6 +615,8 @@ class ClientSession(ApplicationSession):
                     name = resource_name
                     if match.rename:
                         name = match.rename
+                    if resource.acquired == place.name:
+                        continue
                     print("Matching resource '{}' ({}/{}/{}/{}) already acquired by place '{}'"
                           .format(name, exporter, group_name, resource.cls, resource_name,
                                   resource.acquired))


### PR DESCRIPTION
**Description**

Allow a place to still be locked if one of the resources is acquired but
was previously acquired by the same place.

Signed-off-by: Rouven Czerwinski <r.czerwinski@pengutronix.de>

Not really sure how to test this.

**Checklist**
- [ ] CHANGES.rst has been updated
- [ ] PR has been tested

Fixes https://github.com/labgrid-project/labgrid/issues/748