### PR TITLE
tests/test_docker: skip unavailable docker module

### DIFF
--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -10,6 +10,8 @@ from labgrid.driver import DockerDriver
 from labgrid.resource.docker import DockerConstants
 from labgrid.exceptions import NoResourceFoundError
 
+pytest.importorskip("docker")
+
 
 def check_external_progs_present():
     """Determine if host machine has a usable docker daemon"""


### PR DESCRIPTION
**Description**
Recent pytest versions print out a collection error if the module is not
skipped:
```
____________________ ERROR collecting tests/test_docker.py _____________________
ImportError while importing test module '/build/source/tests/test_docker.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/nix/store/1g54cwl6m78rgrqsnn1pp29dbvldpvsd-python3-3.9.6/lib/python3.9/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_docker.py:89: in <module>
    ???
tests/test_docker.py:17: in check_external_progs_present
    import docker
E   ModuleNotFoundError: No module named 'docker'
=========================== short test summary info ============================
ERROR tests/test_docker.py
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```
add an importorskip for the docker module.

**Checklist**
- [x] PR has been tested