### PR TITLE
test/flashscript: skip tests if binaries missing

### DIFF
--- a/tests/test_flashscript.py
+++ b/tests/test_flashscript.py
@@ -2,6 +2,7 @@ import pytest
 import subprocess
 import tempfile
 import attr
+from pathlib import Path
 from labgrid.driver.flashscriptdriver import FlashScriptDriver
 from labgrid.resource.common import ManagedResource
 from labgrid import target_factory
@@ -50,10 +51,12 @@ def capture_argument_expansion(d, var):
         return f.read().decode("utf-8")
 
 
+@pytest.mark.skipif(not Path("/bin/true").exists(), reason="true not available")
 def test_script_success(target, driver):
     driver.flash("/bin/true")
 
 
+@pytest.mark.skipif(not Path('/bin/false').exists(), reason="false not available")
 def test_script_failure(target, driver):
     with pytest.raises(subprocess.CalledProcessError):
         driver.flash("/bin/false")


### PR DESCRIPTION
**Description**
The true and false binaries may not be available within the execution
environment of the tests (i.e. on Nixos), skip the tests if the binaries
are not available.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested