### PR TITLE
util/ssh: fix control master check

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -395,7 +395,7 @@ class SSHConnection:
         if check == 0:
             self._logger.debug("Found existing control socket")
             return True
-        if b"No such file or directory" or b"No ControlPath specified" in stdout:
+        if b"No such file or directory" in stdout or b"No ControlPath specified" in stdout:
             self._logger.debug("No existing control socket found")
             return False
 


### PR DESCRIPTION
**Description**
The first part of the condition always evaluates to True, so the output of the SSH check command is never considered.

Fortunately, this only results in wrong messages being logged in the worst case.

Fix that by actually checking if `stdout` contains `b"No such file or directory"`.

**Checklist**
- [ ] PR has been tested

Fixes: #687