### PR TITLE
support exporting resource/driver information

### DIFF
--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -97,6 +97,22 @@ class BindingMixin:
 
         return wrapper
 
+    @classmethod
+    def check_bound(cls, func):
+        @wraps(func)
+        def wrapper(self, *_args, **_kwargs):
+            if self.state is BindingState.active:
+                raise StateError(
+                    f'{self} is active, but must be deactivated to call {func.__qualname__}'  # pylint: disable=line-too-long
+                )
+            elif self.state is not BindingState.bound:
+                raise StateError(
+                    f'{self} has not been bound, {func.__qualname__} cannot be called in state "{self.state.name}"'  # pylint: disable=line-too-long
+                )
+            return func(self, *_args, **_kwargs)
+
+        return wrapper
+
     class NamedBinding:
         """
         Marks a binding (or binding set) as requiring an explicit name.

--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -45,6 +45,19 @@ class Driver(BindingMixin):
 
         return 0
 
+    def get_export_name(self):
+        """Get the name to be used for exported variables.
+
+        Falls back to the class name if the driver has no name.
+        """
+        if self.name:
+            return self.name
+        return self.__class__.__name__
+
+    def get_export_vars(self):
+        """Get a dictionary of variables to be exported."""
+        return {}
+
 
 def check_file(filename, *, command_prefix=[]):
     if subprocess.call(command_prefix + ['test', '-r', filename]) != 0:

--- a/labgrid/driver/networkinterfacedriver.py
+++ b/labgrid/driver/networkinterfacedriver.py
@@ -35,6 +35,13 @@ class NetworkInterfaceDriver(Driver):
             self.wrapper = None
             self.proxy = None
 
+    @Driver.check_bound
+    def get_export_vars(self):
+        return {
+            "host": self.iface.host,
+            "ifname": self.iface.ifname or "",
+        }
+
     # basic
     @Driver.check_active
     @step()

--- a/labgrid/driver/provider.py
+++ b/labgrid/driver/provider.py
@@ -14,6 +14,14 @@ class BaseProviderDriver(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @Driver.check_bound
+    def get_export_vars(self):
+        return {
+            "host": self.provider.host,
+            "internal": self.provider.internal,
+            "external": self.provider.external,
+        }
+
     @Driver.check_active
     @step(args=['filename'], result=True)
     def stage(self, filename):

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -69,6 +69,20 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     def on_deactivate(self):
         self.close()
 
+    @Driver.check_bound
+    def get_export_vars(self):
+        vars = {
+            "speed": str(self.port.speed)
+        }
+        if isinstance(self.port, SerialPort):
+            vars["port"] = self.port.port
+        else:
+            host, port = proxymanager.get_host_and_port(self.port)
+            vars["host"] = host
+            vars["port"] = str(port)
+            vars["protocol"] = self.port.protocol
+        return vars
+
     def _read(self, size: int = 1, timeout: float = 0.0):
         """
         Reads 'size' or more bytes from the serialport

--- a/labgrid/exceptions.py
+++ b/labgrid/exceptions.py
@@ -31,5 +31,10 @@ class NoResourceFoundError(NoSupplierFoundError):
 
 
 @attr.s(eq=False)
+class NoStrategyFoundError(NoSupplierFoundError):
+    pass
+
+
+@attr.s(eq=False)
 class RegistrationError(Exception):
     msg = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/strategy/common.py
+++ b/labgrid/strategy/common.py
@@ -48,3 +48,10 @@ class Strategy(Driver):  # reuse driver handling
 
     def force(self, status):
         raise NotImplementedError(f"Strategy.force() is not implemented for {self.__class__.__name__}")
+
+    def prepare_export(self):
+        """By default, export all drivers bound by the strategy."""
+        name_map = {}
+        for name in self.bindings.keys():
+            name_map[getattr(self, name)] = name
+        return name_map

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -7,7 +7,7 @@ import attr
 
 from .binding import BindingError, BindingState
 from .driver import Driver
-from .exceptions import NoSupplierFoundError, NoDriverFoundError, NoResourceFoundError
+from .exceptions import NoSupplierFoundError, NoDriverFoundError, NoResourceFoundError, NoStrategyFoundError
 from .resource import Resource
 from .strategy import Strategy
 from .util import Timeout
@@ -211,6 +211,24 @@ class Target:
         activate -- activate the driver (default True)
         """
         return self._get_driver(cls, name=name, activate=activate)
+
+    def get_strategy(self):
+        """
+        Helper function to get the strategy of the target.
+
+        Returns the Strategy, if exactly one exists and raises a
+        NoStrategyFoundError otherwise.
+        """
+        found = []
+        for drv in self.drivers:
+            if not isinstance(drv, Strategy):
+                continue
+            found.append(drv)
+        if not found:
+            raise NoStrategyFoundError(f"no Strategy found in {self}")
+        elif len(found) > 1:
+            raise NoStrategyFoundError(f"multiple Strategies found in {self}")
+        return found[0]
 
     def __getitem__(self, key):
         """

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,7 +1,8 @@
 import pytest
 
 from labgrid.resource import Resource, NetworkSerialPort
-from labgrid.driver import Driver, SerialDriver
+from labgrid.resource.remote import RemoteNetworkInterface
+from labgrid.driver import Driver, SerialDriver, NetworkInterfaceDriver
 from labgrid.strategy import Strategy
 from labgrid.binding import StateError
 
@@ -73,4 +74,15 @@ def test_export_network_serial(target):
         'LG__SERIALDRIVER_PORT': '12345',
         'LG__SERIALDRIVER_PROTOCOL': 'rfc2217',
         'LG__SERIALDRIVER_SPEED': '115200'
+    }
+
+
+def test_export_remote_network_interface(target):
+    RemoteNetworkInterface(target, None, host='testhost', ifname='wlan0')
+    NetworkInterfaceDriver(target, "netif")
+
+    exported = target.export()
+    assert exported == {
+        'LG__NETIF_HOST': 'testhost',
+        'LG__NETIF_IFNAME': 'wlan0'
     }

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,7 +1,7 @@
 import pytest
 
-from labgrid.resource import Resource
-from labgrid.driver import Driver
+from labgrid.resource import Resource, NetworkSerialPort
+from labgrid.driver import Driver, SerialDriver
 from labgrid.strategy import Strategy
 from labgrid.binding import StateError
 
@@ -60,4 +60,17 @@ def test_export_custom(target):
     exported = target.export()
     assert exported == {
         "LG__CUSTOM_NAME_A": "b",
+    }
+
+
+def test_export_network_serial(target):
+    NetworkSerialPort(target, None, host='testhost', port=12345, speed=115200)
+    SerialDriver(target, None)
+
+    exported = target.export()
+    assert exported == {
+        'LG__SERIALDRIVER_HOST': 'testhost',
+        'LG__SERIALDRIVER_PORT': '12345',
+        'LG__SERIALDRIVER_PROTOCOL': 'rfc2217',
+        'LG__SERIALDRIVER_SPEED': '115200'
     }

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,8 +1,8 @@
 import pytest
 
 from labgrid.resource import Resource, NetworkSerialPort
-from labgrid.resource.remote import RemoteNetworkInterface
-from labgrid.driver import Driver, SerialDriver, NetworkInterfaceDriver
+from labgrid.resource.remote import RemoteNetworkInterface, RemoteTFTPProvider
+from labgrid.driver import Driver, SerialDriver, NetworkInterfaceDriver, TFTPProviderDriver
 from labgrid.strategy import Strategy
 from labgrid.binding import StateError
 
@@ -85,4 +85,16 @@ def test_export_remote_network_interface(target):
     assert exported == {
         'LG__NETIF_HOST': 'testhost',
         'LG__NETIF_IFNAME': 'wlan0'
+    }
+
+
+def test_export_remote_tftp_provider(target):
+    RemoteTFTPProvider(target, None, host='testhost', internal='/srv/tftp/testboard/', external='testboard/')
+    TFTPProviderDriver(target, "tftp")
+
+    exported = target.export()
+    assert exported == {
+        'LG__TFTP_HOST': 'testhost',
+        'LG__TFTP_INTERNAL': '/srv/tftp/testboard/',
+        'LG__TFTP_EXTERNAL': 'testboard/',
     }

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,0 +1,63 @@
+import pytest
+
+from labgrid.resource import Resource
+from labgrid.driver import Driver
+from labgrid.strategy import Strategy
+from labgrid.binding import StateError
+
+
+class ResourceA(Resource):
+    pass
+
+
+class DriverA(Driver):
+    bindings = {"res": ResourceA}
+
+    @Driver.check_bound
+    def get_export_vars(self):
+        return {
+            "a": "b",
+        }
+
+
+class StrategyA(Strategy):
+    bindings = {
+        "drv": DriverA,
+    }
+
+
+def test_export(target):
+    ra = ResourceA(target, "resource")
+    d = DriverA(target, "driver")
+    s = StrategyA(target, "strategy")
+
+    exported = target.export()
+    assert exported == {
+        "LG__DRV_A": "b",
+    }
+
+    target.activate(d)
+    with pytest.raises(StateError):
+        d.get_export_vars()
+
+
+class StrategyB(Strategy):
+    bindings = {
+        "drv": DriverA,
+    }
+
+    def prepare_export(self):
+        return {
+            self.drv: "custom_name",
+        }
+
+
+def test_export_custom(target):
+    ra = ResourceA(target, "resource")
+    d = DriverA(target, "driver")
+    s = StrategyB(target, "strategy")
+
+    exported = target.export()
+    assert exported == {
+        "LG__CUSTOM_NAME_A": "b",
+    }

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -9,7 +9,7 @@ from labgrid.binding import BindingError
 from labgrid.resource import Resource
 from labgrid.driver import Driver
 from labgrid.strategy import Strategy
-from labgrid.exceptions import NoSupplierFoundError, NoDriverFoundError, NoResourceFoundError
+from labgrid.exceptions import NoSupplierFoundError, NoDriverFoundError, NoResourceFoundError, NoStrategyFoundError
 
 
 # test basic construction
@@ -250,6 +250,27 @@ def test_suppliers_optional_named_a_missing(target):
     d = DriverWithOptionalNamedA(target, "driver")
     assert d.res is None
 
+
+
+class StrategyA(Strategy):
+    bindings = {
+        "drv": DriverWithA,
+    }
+
+
+def test_get_strategy(target):
+    ra = ResourceA(target, "resource")
+    d = DriverWithA(target, "driver")
+
+    with pytest.raises(NoStrategyFoundError):
+        target.get_strategy()
+
+    s1 = StrategyA(target, "s1")
+    assert target.get_strategy() is s1
+
+    s2 = StrategyA(target, "s2")
+    with pytest.raises(NoStrategyFoundError):
+        target.get_strategy()
 
 
 # test nested resource creation


### PR DESCRIPTION
**Description**
 This adds support to export the low-level information used by the drivers to
 external programs. To use this, you need to run labgrid-client with an
 environment configuration (-c):
    
       $ labgrid-client -c foo.yaml export -
       Selected role main and place foo from configuration file
       export LG__CLIENT_PID=373996
       export LG__CONSOLE_HOST=rlaba-srv
       export LG__CONSOLE_PORT=52855
       export LG__CONSOLE_PROTOCOL=rfc2217
       export LG__CONSOLE_SPEED=115200
       export LG__ETH_HOST=raspberrypi
       export LG__ETH_IFNAME=''
       export LG__TFTP_EXTERNAL=foo/
       export LG__TFTP_HOST=raspberrypi
       export LG__TFTP_INTERNAL=/srv/tftp/foo/
       export LG__WIFI_HOST=raspberrypi
       export LG__WIFI_IFNAME=wlp1s0u1u3
       Waiting for CTRL+C or SIGTERM...
    
 Writing to a file is supported as well:
    
       $ labgrid-client -c foo.yaml export test.env
       Selected role main and place foo from configuration file
       Exported to test.env
       Waiting for CTRL+C or SIGTERM...
    
 When using this from a script, you will need to poll until the file is created
 and the source the shell variables from it. The script can later stop
 labgrid-client by sending using kill $LG__CLIENT_PID.



**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated