### PR TITLE
remote/exporter: pass proxy information to ResourceEntry

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -777,6 +777,10 @@ class ExporterSession(ApplicationSession):
             group[resource_name] = export_cls(config, host=self.hostname, proxy=getfqdn(),
                                               proxy_required=proxy_req)
         else:
+            config['params']['extra'] = {
+                'proxy': getfqdn(),
+                'proxy_required': proxy_req,
+            }
             group[resource_name] = export_cls(config)
         await self.update_resource(group_name, resource_name)
 


### PR DESCRIPTION
**Description**
`ResourceEntry` objects do not have proxy attributes (contrary to `ResourceExports`). Resources such as `NetworkPowerPorts` or `ModbusTCPCoils` are `ResourceEntry` objects, but need this information in case its exporter is run in isolated mode (`-i, --isolated`). In this case a SSH port forwarding is needed to access the device via the exporter.

Allow that by passing the proxy information as part of the `ResourceEntry`'s data.


**Checklist**
- [.] PR has been tested

Fixes #803