### PR TITLE
agents/sysfsgpio: Do not clear state in init

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ New Features in 0.5.0
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~
 
+- Fixed a bug where using ``labgrid-client io get`` always returned ``low``
+  when reading a ``sysfsgpio``.
+
 Breaking changes in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/labgrid/util/agents/sysfsgpio.py
+++ b/labgrid/util/agents/sysfsgpio.py
@@ -26,10 +26,15 @@ class GpioDigitalOutput:
         GpioDigitalOutput._assert_gpio_line_is_exported(index)
         gpio_sysfs_path = os.path.join(GpioDigitalOutput._gpio_sysfs_path_prefix,
                                        f'gpio{index}')
+
         gpio_sysfs_direction_path = os.path.join(gpio_sysfs_path, 'direction')
-        self._logger.debug("Configuring GPIO %d as output.", index)
-        with open(gpio_sysfs_direction_path, 'wb') as direction_fd:
-            direction_fd.write(b'out')
+        with open(gpio_sysfs_direction_path, 'rb') as direction_fd:
+            literal_value = direction_fd.read(3)
+        if literal_value != b"out":
+            self._logger.debug("Configuring GPIO %d as output.", index)
+            with open(gpio_sysfs_direction_path, 'wb') as direction_fd:
+                direction_fd.write(b'out')
+
         gpio_sysfs_value_path = os.path.join(gpio_sysfs_path, 'value')
         self.gpio_sysfs_value_fd = os.open(gpio_sysfs_value_path, flags=(os.O_RDWR | os.O_SYNC))
 


### PR DESCRIPTION
**Description**

Always writing the 'direction' of a GPIO to 'out' leads to the value being reset.
This is not a problem when values are only set.
But: Getting a value will always return 'low'.

This fix checks if the GPIO is already set to 'out' and skips the
re-initialisation in this case.
This way the value of the GPIO is kept and can be read.

I have tested this feature using my local labgrid setup with a coordinator+client and an exporter on the network.

**Checklist**
- [-] Documentation for the feature
- [-] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [-] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [-] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [-] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [-] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
