### PR TITLE
remote/client: exit with 1 on KeyboardInterrupt

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Bug fixes in 0.5.0
 
 - Fixed a bug where using ``labgrid-client io get`` always returned ``low``
   when reading a ``sysfsgpio``.
+- Fix labgrid-client exit code on keyboard interrupt.
 
 Breaking changes in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1904,7 +1904,7 @@ def main():
                 print(f"{parser.prog}: error: {e}", file=sys.stderr)
             exitcode = 1
         except KeyboardInterrupt:
-            exitcode = 0
+            exitcode = 1
         except Exception:  # pylint: disable=broad-except
             traceback.print_exc()
             exitcode = 2


### PR DESCRIPTION
**Description**
When concatenating commands with `&&` or using `set -e`, a keyboard interrupt should lead to no further commands being executed.

To allow this, rather exit with `1` than `0` on keyboard interrupt.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #155
