### PR TITLE
driver/power: add network power driver for TP-Link power strips

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,7 +3,7 @@ Release 0.5.0 (unreleased)
 
 New Features in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~
-- Support for Eaton ePDU added, and can be used as a NetworkPowerPort.
+- Support for Eaton ePDU and TP-Link power strips added, either can be used as a NetworkPowerPort.
 - Consider a combination of multiple "lg_feature" markers instead of
   considering only the closest marker.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,3 +16,4 @@ psutil==5.8.0
 -r pyvisa-requirements.txt
 -r vxi11-requirements.txt
 -r mqtt-requirements.txt
+-r kasa-requirements.txt

--- a/kasa-requirements.txt
+++ b/kasa-requirements.txt
@@ -1,0 +1,1 @@
+python-kasa==0.4.0

--- a/labgrid/driver/power/tplink.py
+++ b/labgrid/driver/power/tplink.py
@@ -1,0 +1,34 @@
+""" Tested with TP Link KP303, and should be compatible with any strip supported by kasa """
+
+import asyncio
+from kasa import SmartStrip
+
+
+async def _power_set(host, port, index, value):
+    """We embed the coroutines in an `async` function to minimise calls to `asyncio.run`"""
+    assert port is None
+    index = int(index)
+    strip = SmartStrip(host)
+    await strip.update()
+    assert (
+        len(strip.children) > index
+    ), "Trying to access non-existant plug socket on strip"
+    if value is True:
+        await strip.children[index].turn_on()
+    elif value is False:
+        await strip.children[index].turn_off()
+
+
+def power_set(host, port, index, value):
+    asyncio.run(_power_set(host, port, index, value))
+
+
+def power_get(host, port, index):
+    assert port is None
+    index = int(index)
+    strip = SmartStrip(host)
+    asyncio.run(strip.update())
+    assert (
+        len(strip.children) > index
+    ), "Trying to access non-existant plug socket on strip"
+    return strip.children[index].is_on

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -166,6 +166,7 @@ class TestNetworkPowerDriver:
         import labgrid.driver.power.digipower
         import labgrid.driver.power.gude
         import labgrid.driver.power.gude24
+        import labgrid.driver.power.tplink
         import labgrid.driver.power.netio
         import labgrid.driver.power.netio_kshell
         import labgrid.driver.power.rest


### PR DESCRIPTION
Implemented using the python-kasa library. This driver functions in the same way as other network power drivers, e.g.  eaton

Tested on a KP303 power strip.

Signed-off-by: kiran ostrolenk <kiran.ostrolenk@codethink.co.uk>

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Tests for the feature 
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
