### PR TITLE
Add Support for "HD 2MP WEBCAM" to USBVideoDriver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2239,9 +2239,12 @@ Arguments:
 Although the driver can be used from Python code by calling the `stream()`
 method, it is currently mainly useful for the ``video`` subcommand of
 ``labgrid-client``.
-It supports the `Logitech HD Pro Webcam C920` with the USB ID 046d:082d, but
-other cameras can be added to `get_qualities()` in
+It supports the `Logitech HD Pro Webcam C920` with the USB ID 046d:082d and a
+few others.
+More cameras can be added to `get_qualities()` and `get_pipeline()` in
 ``labgrid/driver/usbvideodriver.py``.
+Appropriate configuration parameters can be determined by using the GStreamer
+``gst-device-monitor-1.0`` command line utility.
 
 USBAudioInputDriver
 ~~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -40,6 +40,12 @@ class USBVideoDriver(Driver, VideoProtocol):
                 ("mid", "image/jpeg,width=1280,height=720,framerate=10/1"),
                 ("high", "image/jpeg,width=1920,height=1080,framerate=10/1"),
                 ])
+        if match == (0x1d6c, 0x0103): # HD 2MP WEBCAM
+            return ("mid", [
+                ("low", "video/x-h264,width=640,height=480,framerate=25/1"),
+                ("mid", "video/x-h264,width=1280,height=720,framerate=25/1"),
+                ("high", "video/x-h264,width=1920,height=1080,framerate=25/1"),
+                ])
         raise InvalidConfigError("Unknown USB video device {:04x}:{:04x}".format(*match))
 
     def select_caps(self, hint=None):
@@ -65,6 +71,9 @@ class USBVideoDriver(Driver, VideoProtocol):
             inner = None
         elif match == (0x534d, 0x2109):
             inner = None  # just forward the jpeg frames
+        elif match == (0x1d6c, 0x0103):
+            controls = controls or "focus_auto=1"
+            inner = "h264parse"
         else:
             raise InvalidConfigError("Unknown USB video device {:04x}:{:04x}".format(*match))
 


### PR DESCRIPTION
Adds support for another USB camera model and updates documentation a bit.

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested
