### PR TITLE
__init__: add ConsoleLoggingReporter

### DIFF
--- a/labgrid/__init__.py
+++ b/labgrid/__init__.py
@@ -5,3 +5,4 @@ from .exceptions import NoConfigFoundError
 from .factory import target_factory
 from .step import step, steps
 from .stepreporter import StepReporter
+from .consoleloggingreporter import ConsoleLoggingReporter


### PR DESCRIPTION
**Description**
When using labgrid as a library, instanciating the `ConsoleLoggingReporter` to retrieve console log is a common case.

Allow `from labgrid import ConsoleLoggingReporter`, similar to the `StepReporter`.


**Checklist**
- [x] PR has been tested