### PR TITLE
ubootdriver: add configurable sleep before sending interrupt chars

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ New Features in 0.5.0
   considering only the closest marker.
 - The labgrid client SSH command is now able to instantiate the SSHDriver when
   there are multiple NetworkService resources available.
+- The UBootDriver acquired the new parameter ``preinterruptsleep`` which
+  configures the number of seconds to sleep after matching the ``autoboot``
+  prompt but before sending the ``interrupt`` characters.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1313,6 +1313,8 @@ Implements:
 Arguments:
   - prompt (regex, default=""): U-Boot prompt to match
   - autoboot (regex, default="stop autoboot"): autoboot message to match
+  - preinterruptsleep (float, default=0.0): optional, time to sleep after
+    matching the autoboot pattern before sending the interrupt character
   - password (str): optional, U-Boot unlock password
   - interrupt (str, default="\\n"): string to interrupt autoboot (use "\\x03" for CTRL-C)
   - init_commands (tuple): optional, tuple of commands to execute after matching the

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 import attr
+import time
 from pexpect import TIMEOUT
 
 from ..factory import target_factory
@@ -25,6 +26,8 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         password (str): optional, password to unlock U-Boot
         init_commands (tuple): optional, tuple of commands to run after unlock
         autoboot (str): optional, string to search for to interrupt autoboot
+        preinterruptsleep (float): optional, time to sleep after matching the
+            autoboot pattern before sending the interrupt character
         interrupt (str): optional, character to interrupt autoboot and go to prompt
         password_prompt (str): optional, string to detect the password prompt
         boot_expression (str): optional, string to search for on U-Boot start
@@ -37,6 +40,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     bindings = {"console": ConsoleProtocol, }
     prompt = attr.ib(default="", validator=attr.validators.instance_of(str))
     autoboot = attr.ib(default="stop autoboot", validator=attr.validators.instance_of(str))
+    preinterruptsleep = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
     password = attr.ib(default="", validator=attr.validators.instance_of(str))
     interrupt = attr.ib(default="\n", validator=attr.validators.instance_of(str))
     init_commands = attr.ib(default=attr.Factory(tuple), converter=tuple)
@@ -156,6 +160,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
                 break
 
             elif index == 1:
+                time.sleep(self.preinterruptsleep)
                 self.console.write(self.interrupt.encode('ASCII'))
 
             elif index == 2:

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -24,7 +24,8 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         prompt (str): optional, U-Boot prompt
         password (str): optional, password to unlock U-Boot
         init_commands (tuple): optional, tuple of commands to run after unlock
-        interrupt(str): optional, interrupt character to use to go to prompt
+        autoboot (str): optional, string to search for to interrupt autoboot
+        interrupt (str): optional, character to interrupt autoboot and go to prompt
         password_prompt (str): optional, string to detect the password prompt
         boot_expression (str): optional, string to search for on U-Boot start
         bootstring (str): optional, string that indicates that the Kernel is booting


### PR DESCRIPTION
Some U-Boots are configured not to print the "press any key to stop autoboot" message, but still allow interrupting the boot flow with key press. In those cases, another string must be matched (maybe even the U-Boot version string usually intended to be matched by `boot_expression`), which might be printed by U-Boot at a time when the interrupt prompt is not active yet. This PR adds a configurable sleep interval after matching the pattern before sending the interrupt to catch those use cases.

**Checklist**
- [x] Documentation for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested