### PR TITLE
util/expect: Improve __init__ method for wrapper

### DIFF
--- a/labgrid/util/expect.py
+++ b/labgrid/util/expect.py
@@ -9,14 +9,10 @@ class PtxExpect(pexpect.spawn):
     """
 
     def __init__(self, driver):
-        "Initializes a pexpect spawn instanse with required configuration"
+        "Initializes a pexpect spawn instance with the required configuration"
         self.driver = driver
         self.linesep = b"\n"
-        pexpect.spawn.__init__(
-            self,
-            None,
-            maxread=1,
-        )
+        pexpect.spawn.__init__(self, None, maxread=1)
 
     def send(self, s):
         "Write to underlying transport, return number of bytes written"


### PR DESCRIPTION
Fix a typo, improve the sentence and remove unneeded newlines. The
newlines seem to be leftover from a previous state.

Fixes: 5204c4a0 update sphinx to 1.8.1
Fixes: 56d5947a configure and run yapf

Signed-off-by: Sebastian Fricke <sebastian.fricke@posteo.net>