### PR TITLE
pyproject.toml: specify build-system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "setuptools_scm"]


### PR DESCRIPTION
Using pyproject.toml to specify build system requirements is now the
preferred way. From the setuptools documentation[1]:

"This used to be accomplished with the setup_requires keyword but is now
considered deprecated in favor of the PEP 517 style described above."

I didn't remove the 'setup_requires' from setup.py because some users
who are using older versions of setuptools might still rely on it if
their version of setuptools has no support for pyproject.toml.

Without this pyproject.toml, the following command fails on a local
network without internet access:

[edit: correct command as explained below in the comments]
  `pip install --index-url <local index> -e .`

because setuptools does not take the index into account when fetching
the 'setup_requires' dependencies defined in setup.py.

However, with the correct pyproject.toml available, the build system
requirements are fetched first, using the correct index, and then later
at the point where setuptools tries to install the 'setup_requires'
dependencies, they are already installed so no need to fetch anything
anymore.

[1]: https://setuptools.pypa.io/en/latest/userguide/dependency_management.html

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
