### PR TITLE
driver/usbstoragedriver: Accept `dd` options as `write_image()` arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ New Features in 0.5.0
   considering only the closest marker.
 - The labgrid client SSH command is now able to instantiate the SSHDriver when
   there are multiple NetworkService resources available.
+- Allow to pass dd arguments to USBMassStorage.write_image() function
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Allow to set currently used arguments (conv, status, oflag, bs, skip,
seek) through kwargs instead of hardcoding the defaults. This allows
to set them to custom values while allowing to keep the defaults
for consistent and backwards-compatible behavior.
This also makes place for adding more arguments if needed.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Describe what your pull request does:
Adds a possiblity to set currently hardcoded dd arguments to USBMassStorage.write_image() function

Reasons behind the change:
When using other dd implementation (BusyBox) currently hardcoded arguments were not supported.
This change will allow to avoid such cases and also set custom arguments if needed.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
 Adjust function docstring
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
No need for update here
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
Verify whether dd arguments are properly set by printing the list with different input arguments. Use feature to write_image to sd card with different arguments.
