### PR TITLE
driver: import missing drivers in __init__.py

### DIFF
--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -39,3 +39,5 @@ from .networkinterfacedriver import NetworkInterfaceDriver
 from .provider import TFTPProviderDriver
 from .mqtt import TasmotaPowerDriver
 from .manualswitchdriver import ManualSwitchDriver
+from .usbtmcdriver import USBTMCDriver
+from .deditecrelaisdriver import DeditecRelaisDriver


### PR DESCRIPTION
**Description**
It should be possible to specify the DeditecRelaisDriver and USBTMCDriver in a labgrid environment config. Allow that.

**Checklist**
- [x] PR has been tested