### PR TITLE
Documentation fixes and improvements

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,7 +101,7 @@ New Features in 0.3.0
 ~~~~~~~~~~~~~~~~~~~~~
 
 - All `CommandProtocol` drivers support the poll_until_success method.
-- The new `FileDigitalOutputDriver` respresents a digital signal with a file.
+- The new `FileDigitalOutputDriver` represents a digital signal with a file.
 - The new `GpioDigitalOutputDriver` controls the state of a GPIO via the sysfs interface.
 - Crossbar and autobahn have been updated to 19.3.3 and 19.3.5 respectively.
 - The InfoDriver was removed. The functions have been integrated into the
@@ -117,7 +117,7 @@ New Features in 0.3.0
   file just like the images are.
 - The ShellDriver's keyfile attribute is now specified relative to the config
   file just like the images are.
-- ``labgrid-client -P <PROXY>`` and the ``LG_PROXY`` enviroment variable can be
+- ``labgrid-client -P <PROXY>`` and the ``LG_PROXY`` environment variable can be
   used to access the coordinator and network resources via that SSH proxy host.
   Drivers which run commands via SSH to the exporter still connect directly,
   allowing custom configuration in the user's ``.ssh/config`` as needed.
@@ -131,7 +131,7 @@ New Features in 0.3.0
 - AndroidFastbootDriver now supports 'getvar' and 'oem getenv' subcommands.
 - The coordinator now updates the resource acquired state at the exporter.
   Accordingly, the exporter now starts ser2net only when a resources is
-  aquired. Furthermore, resource conflicts between places are now detected.
+  acquired. Furthermore, resource conflicts between places are now detected.
 - Labgrid now uses the `ProcessWrapper` for externally called processes. This
   should include output from these calls better inside the test runs.
 - The binding dictionary can now supports type name strings in addition to the

--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ and is currently in active use and development.
 Quickstart
 ----------
 See the `Installation section
-<http://labgrid.readthedocs.io/en/latest/getting_started.html#Installation>`_
+<http://labgrid.readthedocs.io/en/latest/getting_started.html#installation>`_
 for more details.
 
 Clone the git repository:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -95,6 +95,7 @@ Arguments:
   - port (str): tty the instrument is connected to, e.g. '/dev/ttyUSB0'
   - address (int): slave address on the modbus, e.g. 16
   - baudrate (bool): optional, default is 115200
+  - speed (int, default=115200): baud rate of the serial port
   - timeout (bool): optional, timeout in seconds. Default is 0.25 s
 
 Used by:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2557,8 +2557,11 @@ to transition to the shell state:
 
 ::
 
-   t = get_target("main")
-   s = BareboxStrategy(t)
+   from labgrid import Environment
+
+   e = Environment("local.yaml")
+   t = e.get_target("main")
+   s = t.get_driver("BareboxStrategy")
    s.transition("shell")
 
 
@@ -2578,8 +2581,11 @@ to transition to the shell state:
 
 ::
 
-   t = get_target("main")
-   s = ShellStrategy(t)
+   from labgrid import Environment
+
+   e = Environment("local.yaml")
+   t = e.get_target("main")
+   s = t.get_driver("ShellStrategy")
    s.transition("shell")
 
 
@@ -2600,8 +2606,11 @@ to transition to the shell state:
 
 ::
 
-   t = get_target("main")
-   s = UBootStrategy(t)
+   from labgrid import Environment
+
+   e = Environment("local.yaml")
+   t = e.get_target("main")
+   s = t.get_driver("UBootStrategy")
    s.transition("shell")
 
 
@@ -2621,8 +2630,11 @@ To transition to the shell state:
 
 ::
 
-   t = get_target("main")
-   s = DockerShellStrategy(t)
+   from labgrid import Environment
+
+   e = Environment("local.yaml")
+   t = e.get_target("main")
+   s = t.get_driver("DockerShellStrategy")
    s.transition("shell")
 
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -174,13 +174,13 @@ Currently available are:
   Controls a NETIO 4C PDU via a Telnet interface.
 
 ``rest``
-  This is a generic backend for PDU implementations which can be controled via
+  This is a generic backend for PDU implementations which can be controlled via
   HTTP PUT and GET requests.
   See the `docstring in the module
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/rest.py>`__
   for details.
 
-``senty``
+``sentry``
   Controls a Sentry PDU via SNMP using Sentry3-MIB.
   It was tested on CW-24VDD and 4805-XLS-16.
 
@@ -189,7 +189,7 @@ Currently available are:
   <https://pypi.org/project/python-vxi11/>`_.
 
 ``simplerest``
-  This is a generic backend for PDU implementations which can be controled via
+  This is a generic backend for PDU implementations which can be controlled via
   HTTP GET requests (both set and get).
   See the `docstring in the module
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
@@ -294,7 +294,7 @@ Used by:
 
 TasmotaPowerPort
 ++++++++++++++++
-A :any:`TasmotaPowerPort` resource describes a switchable Tasmora power outlet
+A :any:`TasmotaPowerPort` resource describes a switchable Tasmota power outlet
 accessed over MQTT.
 
 .. code-block:: yaml
@@ -309,8 +309,8 @@ The example uses a mosquitto server at "this.is.an.example.host.com" and has the
 topics setup for a tasmota power port that has the ID 575A2B.
 
 - host (str): hostname of the MQTT server
-- status_topic (str): topic that signals the current status as "ON" of "OFF"
-- power_topic (str): topic that allows switchting the status between "ON" and
+- status_topic (str): topic that signals the current status as "ON" or "OFF"
+- power_topic (str): topic that allows switching the status between "ON" and
   "OFF"
 - avail_topic (str): topic that signals the availability of the Tasmota power
   outlet
@@ -427,7 +427,7 @@ Used by:
 
 NetworkHIDRelay
 +++++++++++++++
-A NetworkHIDRelay descibes an `HIDRelay`_ exported over the network.
+A NetworkHIDRelay describes an `HIDRelay`_ exported over the network.
 
 NetworkService
 ~~~~~~~~~~~~~~
@@ -694,7 +694,7 @@ of a USB serial port instead of being a USB device itself (see
        '@ID_SERIAL_SHORT': P-00-02389
 
 - driver (str): name of the sigrok driver to use
-- channels (str): optional, channel mapping as desribed in the sigrok-cli man page
+- channels (str): optional, channel mapping as described in the sigrok-cli man page
 
 Used by:
   - `SigrokPowerDriver`_
@@ -867,7 +867,7 @@ It is assumed that flashrom is installed on the host and the executable is confi
   tools:
     flashrom: '/usr/sbin/flashrom'
 
-- programmer (str): programmer device as desribed in `-p, --programmer` in `man 8 flashrom`
+- programmer (str): programmer device as described in `-p, --programmer` in `man 8 flashrom`
 
 The resource must configure which programmer to use and the parameters to the programmer.
 The programmer parameter is passed directly to the flashrom bin hence man(8) flashrom
@@ -1616,7 +1616,7 @@ A PDUDaemonDriver controls a `PDUDaemonPort`, allowing control of the target
 power state without user interaction.
 
 .. note::
-  PDUDaemon processess commands in the background, so the actual state change
+  PDUDaemon processes commands in the background, so the actual state change
   may happen several seconds after calls to PDUDaemonDriver return.
 
 Binds to:
@@ -1714,7 +1714,7 @@ Arguments:
 
 TasmotaPowerDriver
 ~~~~~~~~~~~~~~~~~~
-A TasmotaPowerDriver contols a `TasmotaPowerPort`, allowing the outlet to be
+A TasmotaPowerDriver controls a `TasmotaPowerPort`, allowing the outlet to be
 switched on and off.
 
 Binds to:
@@ -1770,7 +1770,7 @@ Implements:
 
 Arguments:
   - signal (str): control signal to use: "dtr" or "rts"
-  - bindings (dict): A named ressource of the type SerialDriver to
+  - bindings (dict): A named resource of the type SerialDriver to
     bind against. This is only needed if you have multiple
     SerialDriver in your environment (what is likely to be the case
     if you are using this driver).
@@ -2579,7 +2579,7 @@ to transition to the shell state:
 
 
 this command would transition from the bootloader into a Linux shell and
-activate the shelldriver.
+activate the ShellDriver.
 
 ShellStrategy
 ~~~~~~~~~~~~~
@@ -2600,7 +2600,7 @@ to transition to the shell state:
 
 
 this command would transition directly into a Linux shell and
-activate the shelldriver.
+activate the ShellDriver.
 
 UBootStrategy
 ~~~~~~~~~~~~~
@@ -2622,7 +2622,7 @@ to transition to the shell state:
 
 
 this command would transition from the bootloader into a Linux shell and
-activate the shelldriver.
+activate the ShellDriver.
 
 DockerShellStrategy
 ~~~~~~~~~~~~~~~~~~~
@@ -2792,7 +2792,7 @@ becomes:
   - SerialDriver: {}
   - SerialDriver: {}
 
-This configuration doesn't specifiy which :any:`RawSerialPort` to use for each
+This configuration doesn't specify which :any:`RawSerialPort` to use for each
 :any:`SerialDriver`, so it will cause an exception when instantiating the
 :any:`Target`.
 To bind the correct driver to the correct resource, explicit ``name`` and

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1466,13 +1466,13 @@ Implements:
 .. code-block:: yaml
 
    AndroidFastbootDriver:
-     image: mylocal.image
+     boot_image: mylocal.image
      sparse_size: 100M
 
 Arguments:
-  - boot_image (str): image key referring to the image to boot
-  - flash_images (dict): partition to image key mapping referring to images to
-    flash to the device
+  - boot_image (str): optional, image key referring to the image to boot
+  - flash_images (dict): optional, partition to image key mapping referring to
+    images to flash to the device
   - sparse_size (str): optional, sparse files greater than given size (see
     fastboot manpage -S option for allowed size suffixes). The default is the
     same as the fastboot default, which is computed after querying the target's

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -492,12 +492,12 @@ from all connected supported devices use the `SigrokUSBDevice`_.
 
 .. code-block:: yaml
 
-   SigrokUSBDevice:
+   SigrokDevice:
      driver: fx2lafw
-     channel: "D0=CLK,D1=DATA"
+     channels: "D0=CLK,D1=DATA"
 
 - driver (str): name of the sigrok driver to use
-- channel (str): optional, channel mapping as described in the sigrok-cli man page
+- channels (str): optional, channel mapping as described in the sigrok-cli man page
 
 Used by:
   - `SigrokDriver`_
@@ -648,12 +648,12 @@ A SigrokUSBDevice resource describes a sigrok USB device.
 
    SigrokUSBDevice:
      driver: fx2lafw
-     channel: "D0=CLK,D1=DATA"
+     channels: "D0=CLK,D1=DATA"
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
 - driver (str): name of the sigrok driver to use
-- channel (str): optional, channel mapping as described in the sigrok-cli man page
+- channels (str): optional, channel mapping as described in the sigrok-cli man page
 - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
@@ -663,22 +663,6 @@ NetworkSigrokUSBDevice
 ~~~~~~~~~~~~~~~~~~~~~~
 A NetworkSigrokUSBDevice resource describes a sigrok USB device connected to a
 host which is exported over the network. The SigrokDriver will access it via SSH.
-
-.. code-block:: yaml
-
-   NetworkSigrokUSBDevice:
-     driver: fx2lafw
-     channel: "D0=CLK,D1=DATA"
-     match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
-     host: remote.example.computer
-
-- driver (str): name of the sigrok driver to use
-- channel (str): optional, channel mapping as described in the sigrok-cli man page
-- match (str): key and value for a udev match, see `udev Matching`_
-
-Used by:
-  - `SigrokDriver`_
 
 SigrokUSBSerialDevice
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2656,7 +2656,7 @@ The StepReporter outputs individual labgrid steps to `STDOUT`.
 
 ::
 
-    from labgrid.stepreporter import StepReporter
+    from labgrid import StepReporter
 
     StepReporter.start()
 
@@ -2664,7 +2664,7 @@ The Reporter can be stopped with a call to the stop function:
 
 ::
 
-    from labgrid.stepreporter import StepReporter
+    from labgrid import StepReporter
 
     StepReporter.stop()
 
@@ -2683,7 +2683,7 @@ files. It takes the path as a parameter.
 
 ::
 
-    from labgrid.consoleloggingreporter import ConsoleLoggingReporter
+    from labgrid import ConsoleLoggingReporter
 
     ConsoleLoggingReporter.start(".")
 
@@ -2691,7 +2691,7 @@ The Reporter can be stopped with a call to the stop function:
 
 ::
 
-    from labgrid.consoleloggingreporter import ConsoleLoggingReporter
+    from labgrid import ConsoleLoggingReporter
 
     ConsoleLoggingReporter.stop()
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1769,11 +1769,11 @@ Implements:
 
 Arguments:
   - signal (str): control signal to use: "dtr" or "rts"
-  - bindings (dict): A named resource of the type SerialDriver to
+  - invert (bool): whether to invert the signal
+  - bindings (dict): optional, a named resource of the type SerialDriver to
     bind against. This is only needed if you have multiple
     SerialDriver in your environment (what is likely to be the case
     if you are using this driver).
-  - invert (bool): whether to invert the signal
 
 FileDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2384,6 +2384,9 @@ a device.
      script: 'foo'
      args:
        - '{device.devnode}'
+
+.. code-block:: yaml
+
    images:
      foo: ../images/flash_device.sh
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -35,8 +35,9 @@ enumeration order.
 The example would access the serial port /dev/ttyUSB0 on the local computer with
 a baud rate of 115200.
 
-- port (str): path to the serial device
-- speed (int, default=115200): desired baud rate
+Arguments:
+  - port (str): path to the serial device
+  - speed (int, default=115200): desired baud rate
 
 Used by:
   - `SerialDriver`_
@@ -56,10 +57,12 @@ usually using RFC2217 or raw tcp.
 The example would access the serial port on computer remote.example.computer via
 port 53867 and use a baud rate of 115200 with the RFC2217 protocol.
 
-- host (str): hostname of the remote host
-- port (str): TCP port on the remote host to connect to
-- speed (int, default=115200): baud rate of the serial port
-- protocol (str, default="rfc2217"): protocol used for connection: raw or rfc2217
+Arguments:
+  - host (str): hostname of the remote host
+  - port (str): TCP port on the remote host to connect to
+  - speed (int, default=115200): baud rate of the serial port
+  - protocol (str, default="rfc2217"): protocol used for connection: raw or
+    rfc2217
 
 Used by:
   - `SerialDriver`_
@@ -119,8 +122,9 @@ The example would search for a USB serial converter with the key
 of 115200.
 The `ID_SERIAL_SHORT` property is set by the usb_id builtin helper program.
 
-- match (str): key and value for a udev match, see `udev Matching`_
-- speed (int, default=115200): baud rate of the serial port
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
+  - speed (int, default=115200): baud rate of the serial port
 
 Used by:
   - `SerialDriver`_
@@ -142,9 +146,10 @@ A NetworkPowerPort describes a remotely switchable power port.
 The example describes port 0 on the remote power switch
 `powerswitch.example.computer`, which is a `gude` model.
 
-- model (str): model of the power switch
-- host (str): hostname of the power switch
-- index (int): number of the port to switch
+Arguments:
+  - model (str): model of the power switch
+  - host (str): hostname of the power switch
+  - index (int): number of the port to switch
 
 The `model` property selects one of several `backend implementations
 <https://github.com/labgrid-project/labgrid/tree/master/labgrid/driver/power>`_.
@@ -223,9 +228,10 @@ PDUDaemon configuration file needs to be specified.
 The example describes port 1 on the PDU configured as `apc-snmpv3-noauth`, with
 PDUDaemon running on the host `pduserver`.
 
-- host (str): name of the host running the PDUDaemon
-- pdu (str): name of the PDU in the configuration file
-- index (int): index of the power port on the PDU
+Arguments:
+  - host (str): name of the host running the PDUDaemon
+  - pdu (str): name of the PDU in the configuration file
+  - index (int): index of the power port on the PDU
 
 Used by:
   - `PDUDaemonDriver`_
@@ -244,8 +250,9 @@ The example describes port 1 on the YKUSH USB hub with the
 serial "YK12345".
 (use "pykush -l" to get your serial...)
 
-- serial (str): serial number of the YKUSH hub
-- index (int): number of the port to switch
+Arguments:
+  - serial (str): serial number of the YKUSH hub
+  - index (int): number of the port to switch
 
 Used by:
   - `YKUSHPowerDriver`_
@@ -266,8 +273,9 @@ The example describes port 1 on the hub with the ID_PATH
 "pci-0000:00:14.0-usb-0:2:1.0".
 (use ``udevadm info /sys/bus/usb/devices/...`` to find the ID_PATH value)
 
-- index (int): number of the port to switch
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - index (int): number of the port to switch
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `USBPowerDriver`_
@@ -294,8 +302,9 @@ A SiSPMPowerPort describes a GEMBIRD SiS-PM as supported by
 The example describes port 1 on the hub with the ID_PATH
 "platform-1c1a400.usb-usb-0:2".
 
-- index (int): number of the port to switch
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - index (int): number of the port to switch
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `SiSPMPowerDriver`_
@@ -316,12 +325,13 @@ accessed over MQTT.
 The example uses a mosquitto server at "this.is.an.example.host.com" and has the
 topics setup for a tasmota power port that has the ID 575A2B.
 
-- host (str): hostname of the MQTT server
-- status_topic (str): topic that signals the current status as "ON" or "OFF"
-- power_topic (str): topic that allows switching the status between "ON" and
-  "OFF"
-- avail_topic (str): topic that signals the availability of the Tasmota power
-  outlet
+Arguments:
+  - host (str): hostname of the MQTT server
+  - status_topic (str): topic that signals the current status as "ON" or "OFF"
+  - power_topic (str): topic that allows switching the status between "ON" and
+    "OFF"
+  - avail_topic (str): topic that signals the availability of the Tasmota power
+    outlet
 
 Used by:
   - `TasmotaPowerDriver`_
@@ -342,9 +352,11 @@ A ModbusTCPCoil describes a coil accessible via ModbusTCP.
 The example describes the coil with the address 1 on the ModbusTCP device
 `192.168.23.42`.
 
-- host (str): hostname of the Modbus TCP server e.g. "192.168.23.42:502"
-- coil (int): index of the coil e.g. 3
-- invert (bool, default=False): whether the logic level is inverted (active-low)
+Arguments:
+  - host (str): hostname of the Modbus TCP server e.g. "192.168.23.42:502"
+  - coil (int): index of the coil e.g. 3
+  - invert (bool, default=False): whether the logic level is inverted
+    (active-low)
 
 Used by:
   - `ModbusCoilDriver`_
@@ -361,9 +373,11 @@ A DeditecRelais8 describes a Deditec USB GPO module with 8 relays.
      match:
        ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
 
-- index (int): number of the relay to use
-- invert (bool, default=False): whether the logic level is inverted (active-low)
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - index (int): number of the relay to use
+  - invert (bool, default=False): whether the logic level is inverted
+    (active-low)
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `DeditecRelaisDriver`_
@@ -382,9 +396,11 @@ A OneWirePIO describes a onewire programmable I/O pin.
 The example describes a `PIO.0` at device address `29.7D6913000000` via the onewire
 server on `example.computer`.
 
-- host (str): hostname of the remote system running the onewire server
-- path (str): path on the server to the programmable I/O pin
-- invert (bool, default=False): whether the logic level is inverted (active-low)
+Arguments:
+  - host (str): hostname of the remote system running the onewire server
+  - path (str): path on the server to the programmable I/O pin
+  - invert (bool, default=False): whether the logic level is inverted
+    (active-low)
 
 Used by:
   - `OneWirePIODriver`_
@@ -404,10 +420,11 @@ An :any:`LXAIOBusPIO` resource describes a single PIO pin on an LXAIOBusNode.
 The example uses an lxa-iobus-server running on localhost:8080, with node
 IOMux-00000003 and pin OUT0.
 
-- host (str): hostname with port of the lxa-io-bus server
-- node (str): name of the node to use
-- pin (str): name of the pin to use
-- invert (bool, default=False): whether to invert the pin
+Arguments:
+  - host (str): hostname with port of the lxa-io-bus server
+  - node (str): name of the node to use
+  - pin (str): name of the pin to use
+  - invert (bool, default=False): whether to invert the pin
 
 Used by:
   - `LXAIOBusPIODriver`_
@@ -430,9 +447,10 @@ It currently supports the widely used "dcttech USBRelay".
      match:
        ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
 
-- index (int, default=1): number of the relay to use
-- invert (bool, default=False): whether to invert the relay
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - index (int, default=1): number of the relay to use
+  - invert (bool, default=False): whether to invert the relay
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `HIDRelayDriver`_
@@ -463,10 +481,11 @@ In that case, the SSH connection will be proxied via the exporter, using
 ``socat`` and the ``labgrid-bound-connect`` sudo helper.
 These and the sudo configuration needs to be prepared by the administrator.
 
-- address (str): hostname of the remote system
-- username (str): username used by SSH
-- password (str, default=""): password used by SSH
-- port (int, default=22): port used by SSH
+Arguments:
+  - address (str): hostname of the remote system
+  - username (str): username used by SSH
+  - password (str, default=""): password used by SSH
+  - port (int, default=22): port used by SSH
 
 Used by:
   - `SSHDriver`_
@@ -481,7 +500,8 @@ A USBMassStorage resource describes a USB memory stick or similar device.
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0-scsi-0:0:0:3
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `USBStorageDriver`_
@@ -508,8 +528,10 @@ from all connected supported devices use the `SigrokUSBDevice`_.
      driver: fx2lafw
      channels: "D0=CLK,D1=DATA"
 
-- driver (str): name of the sigrok driver to use
-- channels (str): optional, channel mapping as described in the sigrok-cli man page
+Arguments:
+  - driver (str): name of the sigrok driver to use
+  - channels (str): optional, channel mapping as described in the sigrok-cli
+    man page
 
 Used by:
   - `SigrokDriver`_
@@ -524,7 +546,8 @@ An IMXUSBLoader resource describes a USB device in the imx loader state.
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `IMXUSBDriver`_
@@ -540,7 +563,8 @@ An MXSUSBLoader resource describes a USB device in the mxs loader state.
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `MXSUSBDriver`_
@@ -556,7 +580,8 @@ An RKUSBLoader resource describes a USB device in the rockchip loader state.
      match:
        sys_name: '1-3'
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `RKUSBDriver`_
@@ -583,7 +608,8 @@ An AndroidFastboot resource describes a USB device in the fastboot state.
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `AndroidFastbootDriver`_
@@ -599,7 +625,8 @@ Ethernet or WiFi)
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 RemoteNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -616,7 +643,8 @@ An AlteraUSBBlaster resource describes an Altera USB blaster.
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
-- match (dict): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (dict): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `OpenOCDDriver`_
@@ -633,7 +661,8 @@ FT2232H).
      match:
        ID_PATH: pci-0000:00:10.0-usb-0:1.4
 
-- match (dict): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (dict): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `OpenOCDDriver`_
@@ -649,8 +678,9 @@ accessible via SNMP.
      switch: "switch-012"
      interface: "17"
 
-- switch (str): host name of the Ethernet switch
-- interface (str): interface name
+Arguments:
+  - switch (str): host name of the Ethernet switch
+  - interface (str): interface name
 
 SigrokUSBDevice
 ~~~~~~~~~~~~~~~
@@ -664,9 +694,11 @@ A SigrokUSBDevice resource describes a sigrok USB device.
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
-- driver (str): name of the sigrok driver to use
-- channels (str): optional, channel mapping as described in the sigrok-cli man page
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - driver (str): name of the sigrok driver to use
+  - channels (str): optional, channel mapping as described in the sigrok-cli
+    man page
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `SigrokDriver`_
@@ -689,9 +721,11 @@ of a USB serial port instead of being a USB device itself (see
      match:
        '@ID_SERIAL_SHORT': P-00-02389
 
-- driver (str): name of the sigrok driver to use
-- channels (str): optional, channel mapping as described in the sigrok-cli man page
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - driver (str): name of the sigrok driver to use
+  - channels (str): optional, channel mapping as described in the sigrok-cli
+    man page
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `SigrokPowerDriver`_
@@ -708,7 +742,8 @@ device.
      match:
        '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `USBSDMUXDriver`_
@@ -729,7 +764,8 @@ A :any:`LXAUSBMux` resource describes a Linux Automation GmbH USB-Mux device.
      match:
        '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `LXAUSBMuxDriver`_
@@ -752,7 +788,8 @@ device.
      match:
        '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `USBSDWireDriver`_
@@ -775,7 +812,8 @@ Video4Linux2 kernel driver.
      match:
        '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `USBVideoDriver`_
@@ -790,7 +828,8 @@ A :any:`SysfsGPIO` resource describes a GPIO line.
    SysfsGPIO:
      index: 12
 
-- index (int): index of the GPIO line
+Arguments:
+  - index (int): index of the GPIO line
 
 Used by:
   - `GpioDigitalOutputDriver`_
@@ -813,8 +852,10 @@ by an ALSA kernel driver.
      match:
        '@sys_name': '1-4'
 
-- index (int, default=0): ALSA PCM device number (as in `hw:CARD=<card>,DEV=<index>`)
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - index (int, default=0): ALSA PCM device number (as in
+    `hw:CARD=<card>,DEV=<index>`)
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `USBAudioInputDriver`_
@@ -839,7 +880,8 @@ The low-level communication is handled by the ``usbtmc`` kernel driver.
      match:
        '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
 
-- match (str): key and value for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value for a udev match, see `udev Matching`_
 
 A udev rules file may be needed to allow access for non-root users:
 
@@ -866,7 +908,9 @@ It is assumed that flashrom is installed on the host and the executable is confi
   tools:
     flashrom: '/usr/sbin/flashrom'
 
-- programmer (str): programmer device as described in `-p, --programmer` in `man 8 flashrom`
+Arguments:
+  - programmer (str): programmer device as described in `-p, --programmer` in
+    `man 8 flashrom`
 
 The resource must configure which programmer to use and the parameters to the programmer.
 The programmer parameter is passed directly to the flashrom bin hence man(8) flashrom
@@ -902,7 +946,8 @@ running a flashing program with `FlashScriptDriver`_.
        SUBSYSTEM: usb
        ID_SERIAL: '1234'
 
-- match (str): key and value pairs for a udev match, see `udev Matching`_
+Arguments:
+  - match (str): key and value pairs for a udev match, see `udev Matching`_
 
 Used by:
   - `FlashScriptDriver`_
@@ -925,7 +970,8 @@ A XenaManager resource describes a Xena Manager instance which is the instance t
    XenaManager:
      hostname: "example.computer"
 
-- hostname (str): hostname or IP of the management address of the Xena tester
+Arguments:
+  - hostname (str): hostname or IP of the management address of the Xena tester
 
 Used by:
   - `XenaDriver`_
@@ -941,8 +987,11 @@ Such device could be a signal generator.
      type: "TCPIP"
      url: "192.168.110.11"
 
-- type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
-- url (str): device identifier on selected resource, e.g. <ip> for TCPIP resource
+Arguments:
+  - type (str): device resource type following the pyVISA resource syntax, e.g.
+    ASRL, TCPIP...
+  - url (str): device identifier on selected resource, e.g. <ip> for TCPIP
+    resource
 
 Used by:
   - `PyVISADriver`_
@@ -957,7 +1006,8 @@ A :any:`HTTPVideoStream` resource describes a IP video stream over HTTP or HTTPS
    HTTPVideoStream:
      url: http://192.168.110.11/0.ts
 
-- url (str): URI of the IP video stream
+Arguments:
+  - url (str): URI of the IP video stream
 
 Used by:
   - `HTTPVideoDriver`_
@@ -995,8 +1045,9 @@ TFTPProvider / NFSProvider / HTTPProvider
      internal: "/srv/www/board-23/"
      external: "http://192.168.1.1/board-23/"
 
-- internal (str): path prefix to the local directory accessible by the target
-- external (str): corresponding path prefix for use by the target
+Arguments:
+  - internal (str): path prefix to the local directory accessible by the target
+  - external (str): corresponding path prefix for use by the target
 
 Used by:
   - `TFTPProviderDriver`_
@@ -1030,7 +1081,8 @@ The example describes the remote place `example-place`. It will connect to the
 labgrid remote coordinator, wait until the resources become available and expose
 them to the internal environment.
 
-- name (str): name or pattern of the remote place
+Arguments:
+  - name (str): name or pattern of the remote place
 
 Used by:
   - potentially all drivers
@@ -1061,7 +1113,8 @@ cleans up the created docker container; programming errors, keyboard
 interrupts or unix kill signals may lead to hanging containers, however;
 therefore auto-cleanup is important.
 
-- docker_daemon_url (str): The url of the daemon to use for this target.
+Arguments:
+  - docker_daemon_url (str): The url of the daemon to use for this target
 
 Used by:
   - `DockerDriver`_

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2399,8 +2399,8 @@ Implements:
   - None (yet)
 
 Arguments:
-  - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
-    of an image to bootstrap onto the target
+  - script (str): optional, key in :ref:`images <labgrid-device-config-images>`
+    containing the script to execute for writing of the flashable device
   - args (list): optional, list of arguments for flash script execution
 
 The FlashScriptDriver allows running arbitrary programs to flash a device.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -790,6 +790,8 @@ A :any:`SysfsGPIO` resource describes a GPIO line.
    SysfsGPIO:
      index: 12
 
+- index (int): index of the GPIO line
+
 Used by:
   - `GpioDigitalOutputDriver`_
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2332,7 +2332,7 @@ The :any:`FlashromDriver` is used to flash a rom, using the flashrom utility.
 .. code-block:: yaml
 
    FlashromDriver:
-        image: 'foo'
+     image: 'foo'
    images:
      foo: ../images/image_to_load.raw
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -358,6 +358,8 @@ A DeditecRelais8 describes a Deditec USB GPO module with 8 relays.
    DeditecRelais8:
      index: 1
      invert: false
+     match:
+       ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
 
 - index (int): number of the relay to use
 - invert (bool, default=False): whether the logic level is inverted (active-low)
@@ -425,6 +427,8 @@ It currently supports the widely used "dcttech USBRelay".
    HIDRelay:
      index: 2
      invert: False
+     match:
+       ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
 
 - index (int, default=1): number of the relay to use
 - invert (bool, default=False): whether to invert the relay

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -156,6 +156,9 @@ Currently available are:
 ``digipower``
   Controls a DigiPower PDU via a simple HTTP API.
 
+``eaton``
+  Controls Eaton ePDUs via SNMP.
+
 ``gude``
   Controls a Gude PDU via a simple HTTP API.
 
@@ -195,6 +198,10 @@ Currently available are:
   See the `docstring in the module
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
   for details.
+
+``tplink``
+  Controls TP-Link power strips via `python-kasa
+  <https://github.com/python-kasa/python-kasa>`_.
 
 Used by:
   - `NetworkPowerDriver`_

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -691,6 +691,7 @@ of a USB serial port instead of being a USB device itself (see
 
 - driver (str): name of the sigrok driver to use
 - channels (str): optional, channel mapping as described in the sigrok-cli man page
+- match (str): key and value for a udev match, see `udev Matching`_
 
 Used by:
   - `SigrokPowerDriver`_

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2628,12 +2628,11 @@ to transition to the shell state:
 
 ::
 
-   from labgrid import Environment
-
-   e = Environment("local.yaml")
-   t = e.get_target("main")
-   s = t.get_driver("BareboxStrategy")
-   s.transition("shell")
+   >>> from labgrid import Environment
+   >>> e = Environment("local.yaml")
+   >>> t = e.get_target("main")
+   >>> s = t.get_driver("BareboxStrategy")
+   >>> s.transition("shell")
 
 
 this command would transition from the bootloader into a Linux shell and
@@ -2652,12 +2651,11 @@ to transition to the shell state:
 
 ::
 
-   from labgrid import Environment
-
-   e = Environment("local.yaml")
-   t = e.get_target("main")
-   s = t.get_driver("ShellStrategy")
-   s.transition("shell")
+   >>> from labgrid import Environment
+   >>> e = Environment("local.yaml")
+   >>> t = e.get_target("main")
+   >>> s = t.get_driver("ShellStrategy")
+   >>> s.transition("shell")
 
 
 this command would transition directly into a Linux shell and
@@ -2677,12 +2675,11 @@ to transition to the shell state:
 
 ::
 
-   from labgrid import Environment
-
-   e = Environment("local.yaml")
-   t = e.get_target("main")
-   s = t.get_driver("UBootStrategy")
-   s.transition("shell")
+   >>> from labgrid import Environment
+   >>> e = Environment("local.yaml")
+   >>> t = e.get_target("main")
+   >>> s = t.get_driver("UBootStrategy")
+   >>> s.transition("shell")
 
 
 this command would transition from the bootloader into a Linux shell and
@@ -2701,12 +2698,11 @@ To transition to the shell state:
 
 ::
 
-   from labgrid import Environment
-
-   e = Environment("local.yaml")
-   t = e.get_target("main")
-   s = t.get_driver("DockerShellStrategy")
-   s.transition("shell")
+   >>> from labgrid import Environment
+   >>> e = Environment("local.yaml")
+   >>> t = e.get_target("main")
+   >>> s = t.get_driver("DockerShellStrategy")
+   >>> s.transition("shell")
 
 
 These commands would activate the docker driver which creates and starts
@@ -2727,17 +2723,15 @@ The StepReporter outputs individual labgrid steps to `STDOUT`.
 
 ::
 
-    from labgrid import StepReporter
-
-    StepReporter.start()
+    >>> from labgrid import StepReporter
+    >>> StepReporter.start()
 
 The Reporter can be stopped with a call to the stop function:
 
 ::
 
-    from labgrid import StepReporter
-
-    StepReporter.stop()
+    >>> from labgrid import StepReporter
+    >>> StepReporter.stop()
 
 Stopping the StepReporter if it has not been started will raise an
 AssertionError, as will starting an already started StepReporter.
@@ -2754,17 +2748,15 @@ files. It takes the path as a parameter.
 
 ::
 
-    from labgrid import ConsoleLoggingReporter
-
-    ConsoleLoggingReporter.start(".")
+    >>> from labgrid import ConsoleLoggingReporter
+    >>> ConsoleLoggingReporter.start(".")
 
 The Reporter can be stopped with a call to the stop function:
 
 ::
 
-    from labgrid import ConsoleLoggingReporter
-
-    ConsoleLoggingReporter.stop()
+    >>> from labgrid import ConsoleLoggingReporter
+    >>> ConsoleLoggingReporter.stop()
 
 
 Stopping the ConsoleLoggingReporter if it has not been started will raise an

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -94,7 +94,7 @@ be added into multiple drivers.
     from labgrid.protocol import ConsoleProtocol
 
     @attr.s(eq=False)
-    class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol)
+    class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         pass
 
 Additionally the driver needs to be registered with the :any:`target_factory`
@@ -112,9 +112,8 @@ dependencies on other drivers or resources.
 
     @target_factory.reg_driver
     @attr.s(eq=False)
-    class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol)
-        bindings = { "port": SerialPort }
-        pass
+    class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
+        bindings = { "port": "SerialPort" }
 
 The listed resource :code:`SerialPort` will be bound to :code:`self.port`,
 making it usable in the class.
@@ -124,11 +123,11 @@ otherwise an error will be raised.
 If your driver can support alternative resources, you can use a set of classes
 instead of a single class::
 
-    bindings = { "port": {SerialPort, NetworkSerialPort}}
+    bindings = { "port": {"SerialPort", "NetworkSerialPort"} }
 
 Optional bindings can be declared by including ``None`` in the set::
 
-    bindings = { "port": {SerialPort, NetworkSerialPort, None}}
+    bindings = { "port": {"SerialPort", "NetworkSerialPort", None} }
 
 If you need to do something during instantiation, you need to add a
 :code:`__attrs_post_init__` method (instead of the usual :code:`__init__` used
@@ -146,8 +145,8 @@ The minimum requirement is a call to :code:`super().__attrs_post_init__()`.
 
     @target_factory.reg_driver
     @attr.s(eq=False)
-    class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol)
-        bindings = { "port": SerialPort }
+    class ExampleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
+        bindings = { "port": "SerialPort" }
 
         def __attrs_post_init__(self):
             super().__attrs_post_init__()
@@ -166,7 +165,7 @@ Additionally we need the :any:`target_factory` and the common ``Resource`` class
     import attr
 
     from labgrid.factory import target_factory
-    from labgrid.driver.common import Resource
+    from labgrid.resource import Resource
 
 Next we add our own resource with the :code:`Resource` parent class and
 register it with the :any:`target_factory`.
@@ -176,7 +175,7 @@ register it with the :any:`target_factory`.
     import attr
 
     from labgrid.factory import target_factory
-    from labgrid.driver.common import Resource
+    from labgrid.resource import Resource
 
     @target_factory.reg_resource
     @attr.s(eq=False)
@@ -191,7 +190,7 @@ variables.
     import attr
 
     from labgrid.factory import target_factory
-    from labgrid.driver.common import Resource
+    from labgrid.resource import Resource
 
     @target_factory.reg_resource
     @attr.s(eq=False)
@@ -216,7 +215,7 @@ Start by creating a strategy skeleton:
     import attr
 
     from labgrid.step import step
-    from labgrid.driver import Strategy, StrategyError
+    from labgrid.strategy import Strategy, StrategyError
     from labgrid.factory import target_factory
 
     class Status(enum.Enum):
@@ -521,9 +520,9 @@ you can now request or remove port forwardings:
 
    from labgrid.util.ssh import sshmanager
 
-   localport = sshmanager.request_forward('somehost', 3000)
+   localport = sshmanager.request_forward('localhost', 'somehost', 3000)
 
-   sshmanager.remove_forward('somehost', 3000)
+   sshmanager.remove_forward('localhost', 'somehost', 3000)
 
 or get and put files:
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -303,7 +303,7 @@ Live-Reading Console Output
 When starting labgrid with ``--lg-log`` option, it will dump the input from the
 serial driver to a file in specified directory::
 
-  $ pytest .. --lg-log=logdir test-dir/
+  $ pytest [OPTIONS] --lg-log=logdir test-dir/
 
 This can help understanding what happened and why it happened.
 However, when debugging tests, it might be more helpful to get a live

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -515,25 +515,22 @@ To use the SSHManager in your code, import it from :any:`labgrid.util.ssh`:
 
 .. code-block:: python
 
-   from labgrid.util import sshmanager
+   >>> from labgrid.util import sshmanager
 
 you can now request or remove port forwardings:
 
 .. code-block:: python
 
-   from labgrid.util import sshmanager
-
-   localport = sshmanager.request_forward('localhost', 'somehost', 3000)
-
-   sshmanager.remove_forward('localhost', 'somehost', 3000)
+   >>> from labgrid.util import sshmanager
+   >>> localport = sshmanager.request_forward('localhost', 'somehost', 3000)
+   >>> sshmanager.remove_forward('localhost', 'somehost', 3000)
 
 or get and put files:
 
 .. code-block:: python
 
-   from labgrid.util import sshmanager
-
-   sshmanager.put_file('somehost', '/path/to/local/file', '/path/to/remote/file')
+   >>> from labgrid.util import sshmanager
+   >>> sshmanager.put_file('somehost', '/path/to/local/file', '/path/to/remote/file')
 
 .. note::
   The SSHManager will reuse existing Control Sockets and set up a keepalive loop
@@ -556,11 +553,10 @@ To use it in conjunction with a `Resource` and a file:
 
 .. code-block:: python
 
-   from labgrid.util.managedfile import ManagedFile
-
-   mf = ManagedFile(<your-file>, <your-resource>)
-   mf.sync_to_resource()
-   path = mf.get_remote_path()
+   >>> from labgrid.util.managedfile import ManagedFile
+   >>> mf = ManagedFile(<your-file>, <your-resource>)
+   >>> mf.sync_to_resource()
+   >>> path = mf.get_remote_path()
 
 Unless constructed with `ManagedFile(..., detect_nfs=False)`, ManagedFile
 employs the following heuristic to check if a file is stored on a NFS share
@@ -585,9 +581,8 @@ Usage:
 
 .. code-block:: python
 
-   from labgrid.util.proxy import proxymanager
-
-   proxymanager.get_host_and_port(<resource>)
+   >>> from labgrid.util.proxy import proxymanager
+   >>> proxymanager.get_host_and_port(<resource>)
 
 
 .. _contributing:

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -384,10 +384,12 @@ Example
 ~~~~~~~
 
 .. code-block:: python
-   :caption: conftest.py
+   :caption: teststrategy.py
 
    from labgrid.strategy import GraphStrategy
+   from labgrid.factory import target_factory
 
+   @target_factory.reg_driver
    class TestStrategy(GraphStrategy):
        def state_unknown(self):
            pass
@@ -416,25 +418,26 @@ The class can also render a graph as PNG (using GraphViz):
    targets:
      main:
        resources: {}
-       drivers: {}
+       drivers:
+         TestStrategy: {}
 
-.. code-block:: python
-   :caption: render_teststrategy.py
+   imports:
+   - teststrategy.py
 
-   from labgrid.environment import Environment
-   from conftest import TestStrategy
-   env = Environment('test.yaml')
-   strategy = TestStrategy(env.get_target(), "strategy name")
 
-   strategy.transition('barebox', via=['boot_via_nfs'])
-   # returned: ['unknown', 'boot_via_nfs', 'barebox']
-   strategy.graph.render("teststrategy-via-nfs")
-   # returned: 'teststrategy-via-nfs.png'
+::
 
-   strategy.transition('barebox', via=['boot_via_nand'])
-   # returned: ['unknown', 'boot_via_nand', 'barebox']
-   strategy.graph.render("teststrategy-via-nand")
-   # returned: 'teststrategy-via-nand.png'
+   >>> from labgrid.environment import Environment
+   >>> env = Environment('test.yaml')
+   >>> strategy = env.get_target().get_driver('Strategy')
+   >>> strategy.transition('barebox', via=['boot_via_nfs'])
+   ['unknown', 'boot_via_nfs', 'barebox']
+   >>> strategy.graph.render("teststrategy-via-nfs")
+   'teststrategy-via-nfs.png'
+   >>> strategy.transition('barebox', via=['boot_via_nand'])
+   ['unknown', 'boot_via_nand', 'barebox']
+   >>> strategy.graph.render("teststrategy-via-nand")
+   'teststrategy-via-nand.png'
 
 .. figure:: res/graphstrategy-via-nfs.png
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -240,7 +240,7 @@ Start by creating a strategy skeleton:
                 return  # nothing to do
             else:
                 raise StrategyError(
-                    f"no transition found from {self.status,} to {status}"
+                    f"no transition found from {self.status} to {status}"
                 )
             self.status = status
 
@@ -266,7 +266,7 @@ The Status enum for the BareboxStrategy:
        barebox = 2
        shell = 3
 
-defines 3 custom states and the `unknown` state as the start point.
+defines three custom states and the `unknown` state as the start point.
 These three states are handled in the transition function:
 
 ::
@@ -283,15 +283,16 @@ These three states are handled in the transition function:
         # interrupt barebox
         self.target.activate(self.barebox)
     elif status == Status.shell:
-        # tansition to barebox
+        # transition to barebox
         self.transition(Status.barebox)
         self.barebox.boot("")
         self.barebox.await_boot()
         self.target.activate(self.shell)
 
-Here the `barebox` state simply cycles the board and activates the driver, while
-the `shell` state uses the barebox state to cycle the board and than boot the
-linux kernel. The `off` states switch the power off.
+Here, the `barebox` state simply cycles the board and activates the driver,
+while the `shell` state uses the barebox state to cycle the board and then boot
+the linux kernel.
+The `off` state switches the power off.
 
 
 Tips for Writing and Debugging Tests
@@ -309,7 +310,7 @@ This can help understanding what happened and why it happened.
 However, when debugging tests, it might be more helpful to get a live
 impression of what is going on.
 For this, you can use ``tail -F`` to read the content written to the log file
-as if you would be connected to the devices serial console (except that it is
+as if you would be connected to the device's serial console (except that it is
 read-only)::
 
   $ tail -F logdir/console_main # for the 'main' target
@@ -514,7 +515,7 @@ To use the SSHManager in your code, import it from :any:`labgrid.util.ssh`:
 
    from labgrid.util.ssh import sshmanager
 
-you can now request or remove forwards:
+you can now request or remove port forwardings:
 
 .. code-block:: python
 

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -60,7 +60,7 @@ into your new driver file.
 
     import attr
 
-    from labgrid.driver.common import Driver
+    from labgrid.driver import Driver
     from labgrid.protocol import ConsoleProtocol
 
 Next, define your new class and list the protocols as subclasses of the new
@@ -72,7 +72,7 @@ provided by connecting drivers and resources on a given target at runtime.
 
     import attr
 
-    from labgrid.driver.common import Driver
+    from labgrid.driver import Driver
     from labgrid.protocol import ConsoleProtocol
 
     @attr.s(eq=False)
@@ -89,7 +89,7 @@ be added into multiple drivers.
 
     import attr
 
-    from labgrid.driver.common import Driver
+    from labgrid.driver import Driver
     from labgrid.driver.consoleexpectmixin import ConsoleExpectMixin
     from labgrid.protocol import ConsoleProtocol
 
@@ -106,7 +106,7 @@ dependencies on other drivers or resources.
     import attr
 
     from labgrid.factory import target_factory
-    from labgrid.driver.common import Driver
+    from labgrid.driver import Driver
     from labgrid.driver.consoleexpectmixin import ConsoleExpectMixin
     from labgrid.protocol import ConsoleProtocol
 
@@ -139,7 +139,7 @@ The minimum requirement is a call to :code:`super().__attrs_post_init__()`.
     import attr
 
     from labgrid.factory import target_factory
-    from labgrid.driver.common import Driver
+    from labgrid.driver import Driver
     from labgrid.driver.consoleexpectmixin import ConsoleExpectMixin
     from labgrid.protocol import ConsoleProtocol
 
@@ -512,13 +512,13 @@ To use the SSHManager in your code, import it from :any:`labgrid.util.ssh`:
 
 .. code-block:: python
 
-   from labgrid.util.ssh import sshmanager
+   from labgrid.util import sshmanager
 
 you can now request or remove port forwardings:
 
 .. code-block:: python
 
-   from labgrid.util.ssh import sshmanager
+   from labgrid.util import sshmanager
 
    localport = sshmanager.request_forward('localhost', 'somehost', 3000)
 
@@ -528,7 +528,7 @@ or get and put files:
 
 .. code-block:: python
 
-   from labgrid.util.ssh import sshmanager
+   from labgrid.util import sshmanager
 
    sshmanager.put_file('somehost', '/path/to/local/file', '/path/to/remote/file')
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -213,7 +213,8 @@ For example, to export a ``USBSerialPort`` with ``ID_SERIAL_SHORT`` of
    example-group:
      location: example-location
      USBSerialPort:
-       ID_SERIAL_SHORT: ID23421JLK
+       match:
+         ID_SERIAL_SHORT: ID23421JLK
 
 .. note:: Use ``labgrid-suggest`` to generate the YAML snippets for most
 	  exportable resources.
@@ -240,7 +241,8 @@ Additional groups and resources can be added:
        index: 3
    example-group-2:
      USBSerialPort:
-       ID_SERIAL_SHORT: KSLAH2341J
+       match:
+         ID_SERIAL_SHORT: KSLAH2341J
 
 Restart the exporter to activate the new configuration.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -336,7 +336,7 @@ Follow these instructions to install the systemd files on your machine(s):
 #. Adapt the ``ExecStart`` paths of the service files to the respective Python
    virtual environments of the coordinator and exporter.
 #. Create the coordinator configuration file referenced in the ``ExecStart``
-   option of the :file:`systemd-coordinator.service` file by using
+   option of the :file:`labgrid-coordinator.service` file by using
    :file:`.crossbar/config.yaml` as a starting point. You most likely want to
    make sure that the ``workdir`` option matches the path given via the
    ``--cbdir`` option in the service file; see
@@ -373,7 +373,7 @@ Follow these instructions to install the systemd files on your machine(s):
       # systemctl start labgrid-coordinator
 
 #. After creating the exporter configuration file referenced in the
-   ``ExecStart`` option of the :file:`systemd-exporter.service` file, start the
+   ``ExecStart`` option of the :file:`labgrid-exporter.service` file, start the
    exporter:
 
    .. code-block:: console
@@ -394,7 +394,7 @@ udev Matching
 
 labgrid allows the exporter (or the client-side environment) to match resources
 via udev rules.
-The udev resources become available to the test/exporter as soon es they are
+The udev resources become available to the test/exporter as soon as they are
 plugged into the computer, e.g. allowing an exporter to export all USB ports on
 a specific hub and making a ``NetworkSerialPort`` available as soon as it is
 plugged into one of the hub's ports.

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -466,6 +466,9 @@ retrieve it in your test and call the ``transition(status)`` function.
 
 .. code-block:: python
 
+   >>> from labgrid import Environment
+   >>> env = Environment("env.yaml")
+   >>> target = env.get_target("main")
    >>> strategy = target.get_driver("Strategy")
    >>> strategy.transition("barebox")
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -127,6 +127,10 @@ Each driver and resource can have an optional name. This parameter is required
 for all manual creations of drivers and resources. To manually bind to a
 specific driver set a binding mapping before creating the driver:
 
+  >>> from labgrid import Target
+  >>> from labgrid.resource import SerialPort
+  >>> from labgrid.driver import SerialDriver
+  >>>
   >>> t = Target("Test")
   >>> SerialPort(t, "First")
   SerialPort(target=Target(name='Test', env=None), name='First', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
@@ -135,7 +139,7 @@ specific driver set a binding mapping before creating the driver:
   >>> t.set_binding_map({"port": "Second"})
   >>> sd = SerialDriver(t, "Driver")
   >>> sd
-  SerialDriver(target=Target(name='Test', env=None), name='Driver', state=<BindingState.bound: 1>, txdelay=0.0)
+  SerialDriver(target=Target(name='Test', env=None), name='Driver', state=<BindingState.bound: 1>, txdelay=0.0, timeout=3.0)
   >>> sd.port
   SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
 
@@ -164,9 +168,13 @@ name `priorities`, e.g.
 
 .. code-block:: python
 
+   import attr
+   from labgrid.driver import Driver
+   from labgrid.protocol import PowerProtocol, ResetProtocol
+
    @attr.s
    class NetworkPowerDriver(Driver, PowerProtocol, ResetProtocol):
-       priorities: {PowerProtocol: -10}
+       priorities = {PowerProtocol: -10}
 
 Strategies
 ~~~~~~~~~~

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -219,7 +219,7 @@ These components communicate over the `WAMP <http://wamp-proto.org/>`_
 implementation `Autobahn <http://autobahn.ws/>`_ and the `Crossbar
 <http://crossbar.io/>`_ WAMP router.
 
-The following sections describe the resposibilities of each component. See
+The following sections describe the responsibilities of each component. See
 :ref:`remote-usage` for usage information.
 
 .. _overview-coordinator:
@@ -364,7 +364,7 @@ connections to remote resources made available by this exporter need to be
 tunneled using a SSH connection.
 
 On the other hand, clients may need to access the remote coordinator
-infrastrucure using a SSH tunnel. In this case the :code:`LG_PROXY` environment
+infrastructure using a SSH tunnel. In this case the :code:`LG_PROXY` environment
 variable needs to be set to the remote host which should tunnel the connection
 to the coordinator. The client then forwards all network traffic -
 client-to-coordinator and client-to-exporter - through SSH, via their

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -497,7 +497,7 @@ useful to define a function scope fixture per state in ``conftest.py``::
   import pytest
 
   @pytest.fixture(scope='function')
-  def switch_off(target, strategy, capsys):
+  def switch_off(strategy, capsys):
       with capsys.disabled():
           strategy.transition('off')
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -292,9 +292,9 @@ target. While labgrid registers an ``atexit`` handler to cleanup targets, this h
 the advantage that exceptions can be handled by your application::
 
   >>> try:
-  >>>     target.cleanup()
-  >>> except Exception as e:
-  >>>     <your code here>
+  ...     target.cleanup()
+  ... except Exception as e:
+  ...     pass  # your code here
 
 .. _usage_environments:
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -236,6 +236,7 @@ After activation, we can use the driver to do our work::
 
   >>> t.activate(sd)
   >>> sd.write(b'test')
+  4
 
 If an underlying hardware resource is not available (or not available after a
 certain timeout, depending on the driver), the activation step will raise an
@@ -250,19 +251,22 @@ exception, e.g.::
 Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
 :any:`Protocol <labgrid.protocol>`) using some syntactic sugar::
 
+  >>> from labgrid import Target
+  >>> from labgrid.driver.fake import FakeConsoleDriver
   >>> target = Target('main')
   >>> console = FakeConsoleDriver(target, 'console')
   >>> target.activate(console)
   >>> target[FakeConsoleDriver]
-  FakeConsoleDriver(target=Target(name='main', …), name='console', …)
+  FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0)
   >>> target[FakeConsoleDriver, 'console']
-  FakeConsoleDriver(target=Target(name='main', …), name='console', …)
+  FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0)
 
 Driver Deactivation
 ^^^^^^^^^^^^^^^^^^^
 Driver deactivation works in a similar manner::
 
-   >>> t.deactivate(sd)
+  >>> target.deactivate(console)
+  [FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.bound: 1>, txdelay=0.0)]
 
 Drivers need to be deactivated in the following cases:
 
@@ -328,8 +332,9 @@ To access the target's console, the correct driver object can be found by using
 
   >>> cp = t.get_driver('ConsoleProtocol')
   >>> cp
-  SerialDriver(target=Target(name='example', env=Environment(config_file='example.yaml')), name=None, state=<BindingState.active: 2>, txdelay=0.0)
+  SerialDriver(target=Target(name='example', env=Environment(config_file='example-env.yaml')), name=None, state=<BindingState.active: 2>, txdelay=0.0, timeout=3.0)
   >>> cp.write(b'test')
+  4
 
 When using the ``get_driver`` method, the driver is automatically activated.
 The driver activation will also wait for unavailable resources when needed.
@@ -563,7 +568,7 @@ For this example, you should get a report similar to this:
 
 .. code-block:: bash
 
-  $ pytest --lg-env strategy-example.yaml -v
+  $ pytest --lg-env strategy-example.yaml -v --capture=no
   ============================= test session starts ==============================
   platform linux -- Python 3.5.3, pytest-3.0.6, py-1.4.32, pluggy-0.4.0
   …

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -395,6 +395,13 @@ Other labgrid-related pytest plugin options are:
   color schemes are available.
   See :ref:`LG_COLOR_SCHEME <usage-lgcolorscheme>`.
 
+``--lg-initial-state=STATE_NAME``
+  Sets the Strategy's initial state.
+  This is useful during development if the board is known to be in a defined
+  state already.
+  The Strategy used must implement the ``force()`` method.
+  See the shipped :any:`ShellStrategy` for an example.
+
 ``pytest --help`` shows these options in a separate *labgrid* section.
 
 Environment Variables

--- a/examples/usbpower/examplestrategy.py
+++ b/examples/usbpower/examplestrategy.py
@@ -57,7 +57,7 @@ class ExampleStrategy(Strategy):
             # interrupt barebox
             self.target.activate(self.barebox)
         elif status == Status.shell:
-            # tansition to barebox
+            # transition to barebox
             self.transition(Status.barebox)
             self.barebox.boot("")
             self.barebox.await_boot()

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -193,7 +193,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
     @Driver.check_active
     def await_boot(self):
-        """Wait for the initial Linux version string to verify we succesfully
+        """Wait for the initial Linux version string to verify we successfully
         jumped into the kernel.
         """
         self.console.expect(self.bootstring)

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -173,7 +173,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     @Driver.check_active
     @step()
     def await_boot(self):
-        """Wait for the initial Linux version string to verify we succesfully
+        """Wait for the initial Linux version string to verify we successfully
         jumped into the kernel.
         """
         self.console.expect(self.bootstring, timeout=self.boot_timeout)

--- a/labgrid/protocol/commandprotocol.py
+++ b/labgrid/protocol/commandprotocol.py
@@ -14,7 +14,7 @@ class CommandProtocol(abc.ABC):
     @abc.abstractmethod
     def run_check(self, command: str):
         """
-        Run a command, return str if succesful, ExecutionError otherwise
+        Run a command, return str if successful, ExecutionError otherwise
         """
         raise NotImplementedError
 

--- a/labgrid/protocol/infoprotocol.py
+++ b/labgrid/protocol/infoprotocol.py
@@ -6,7 +6,7 @@ class InfoProtocol(abc.ABC):
 
     @abc.abstractmethod
     def get_ip(self, interface: str = 'eth0'):
-        """Implementations should return the IP-adress for the supplied
+        """Implementations should return the IP address for the supplied
         interface."""
         raise NotImplementedError
 

--- a/labgrid/resource/serialport.py
+++ b/labgrid/resource/serialport.py
@@ -18,7 +18,7 @@ class RawSerialPort(SerialPort, Resource):
 @target_factory.reg_resource
 @attr.s(eq=False)
 class NetworkSerialPort(NetworkResource):
-    """A NetworkSerialPort is a remotely accessable serialport, usually
+    """A NetworkSerialPort is a remotely accessible serialport, usually
     accessed via rfc2217 or tcp raw.
 
     Args:

--- a/labgrid/resource/sigrok.py
+++ b/labgrid/resource/sigrok.py
@@ -11,7 +11,7 @@ class SigrokDevice(Resource):
 
     Args:
         driver (str): driver to use with sigrok
-        channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
+        channels (str): a sigrok channel mapping as described in the sigrok-cli man page
     """
     driver = attr.ib(default="demo")
     channels = attr.ib(

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -363,7 +363,7 @@ class SigrokUSBDevice(USBResource):
 
     Args:
         driver (str): driver to use with sigrok
-        channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
+        channels (str): a sigrok channel mapping as described in the sigrok-cli man page
     """
     driver = attr.ib(
         default=None,
@@ -388,7 +388,7 @@ class SigrokUSBSerialDevice(USBResource):
 
     Args:
         driver (str): driver to use with sigrok
-        channels (str): a sigrok channel mapping as desribed in the sigrok-cli man page
+        channels (str): a sigrok channel mapping as described in the sigrok-cli man page
     """
     driver = attr.ib(
         default=None,

--- a/labgrid/resource/xenamanager.py
+++ b/labgrid/resource/xenamanager.py
@@ -6,5 +6,5 @@ from .common import Resource
 @target_factory.reg_resource
 @attr.s(eq=False)
 class XenaManager(Resource):
-    """ Hostname/IP identifying the manageent address of the xena tester """
+    """ Hostname/IP identifying the management address of the xena tester """
     hostname = attr.ib(validator=attr.validators.instance_of(str))

--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -51,7 +51,7 @@ class BareboxStrategy(Strategy):
             # interrupt barebox
             self.target.activate(self.barebox)
         elif status == Status.shell:
-            # tansition to barebox
+            # transition to barebox
             self.transition(Status.barebox)  # pylint: disable=missing-kwoa
             self.barebox.boot("")
             self.barebox.await_boot()

--- a/labgrid/strategy/graphstrategy.py
+++ b/labgrid/strategy/graphstrategy.py
@@ -219,7 +219,7 @@ class GraphStrategy(Strategy):
     @property
     def graph(self):
         """
-        Returns a graphviz.Digraph for the directed graph the inerhiting strategy represents.
+        Returns a graphviz.Digraph for the directed graph the inheriting strategy represents.
 
         The graph can be rendered with:
         ``mystrategy.graph.render("filename") # renders to filename.png``

--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -48,7 +48,7 @@ class UBootStrategy(Strategy):
             # interrupt uboot
             self.target.activate(self.uboot)
         elif status == Status.shell:
-            # tansition to uboot
+            # transition to uboot
             self.transition(Status.uboot)
             self.uboot.boot("")
             self.uboot.await_boot()

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -242,13 +242,16 @@ class Target:
         Syntactic sugar to access drivers by class (optionally filtered by
         name).
 
+        >>> from labgrid import Target
+        >>> from labgrid.driver.fake import FakeConsoleDriver
+        >>>
         >>> target = Target('main')
         >>> console = FakeConsoleDriver(target, 'console')
         >>> target.activate(console)
         >>> target[FakeConsoleDriver]
-        FakeConsoleDriver(target=Target(name='main', …), name='console', …)
+        FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0)
         >>> target[FakeConsoleDriver, 'console']
-        FakeConsoleDriver(target=Target(name='main', …), name='console', …)
+        FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0)
         """
         name = None
         if not isinstance(key, tuple):

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -533,7 +533,7 @@ class Target:
 
 
     def cleanup(self):
-        """Clean up conntected drivers and resources in reversed order"""
+        """Clean up connected drivers and resources in reversed order"""
         self.deactivate_all_drivers()
         for res in reversed(self.resources):
             self.deactivate(res)

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -182,8 +182,8 @@ targets:
         prompt: \(aqroot@\ew+:[^ ]+ \(aq
         login_prompt: \(aq login: \(aq
         username: \(aqroot\(aq
+      IMXUSBDriver: {}
       MyStrategy: {}
-      IMXUSBLoader: {}
 tools:
   imx\-usb\-loader: "/opt/lg\-tools/imx\-usb\-loader"
 imports:

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -162,8 +162,8 @@ in the loaded local python file:
            prompt: 'root@\w+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
+	 IMXUSBDriver: {}
          MyStrategy: {}
-	 IMXUSBLoader: {}
    tools:
      imx-usb-loader: "/opt/lg-tools/imx-usb-loader"
    imports:


### PR DESCRIPTION
**Description**
- fixed typos in comments, doc strings, CHANGES.rst and docs
- fixed docs of Sigrok resources, AndroidFastbootDriver, FlashromDriver, ModbusRTU, DeditecRelais8, HIDRelay, SerialPortDigitalOutputDriver, FlashScriptDriver
- fix example code in docs, add missing imports (all non-pseudo-code examples should actually work now)
- fix example configurations (all non-pseudo-code configurations should actually work now)
- add "Arguments:" sections to resources, indent resource arguments
- add documentation of missing power backends
- add documentation of SysfsGPIO arguments
- example code simplifications
- document pytest plugin's `--lg-initial-state`

No functional changes intended.

**Checklist**
- [x] Man pages have been regenerated