### PR TITLE
util/managedfile: do not check file creation time in NFS check

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -565,7 +565,7 @@ available both locally and remotely via the same path:
 
   - check if GNU coreutils stat(1) with option --format exists on local and
     remote system
-  - check if inode number, total size and birth/modification timestamps match
+  - check if inode number, total size and modification timestamp match
     on local and remote system
 
 If this is the case the actual file transfer in ``sync_to_resource`` is

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -87,7 +87,7 @@ class ManagedFile:
 
         self._on_nfs_cached = False
 
-        fmt = "inode=%i,size=%s,birth=%W,modified=%Y"
+        fmt = "inode=%i,size=%s,modified=%Y"
         local = subprocess.run(["stat", "--format", fmt, self.local_path],
                                stdout=subprocess.PIPE)
         if local.returncode != 0:


### PR DESCRIPTION
**Description**
Since coreutils 8.31, the file creation time is supported:

> stat now prints file creation time when supported by the file system, on GNU Linux systems with glibc >= 2.28 and kernel >= 4.11. [1]

labgrid checks the file creation (birth) time locally and remotely. Prior to this change in coreutils' stat, this timestamp was always "0". Since this change, the actual creation timestamp is displayed on the local filesystem. Via NFS, however, the creation timestamp is not transferred.

This means that on recent kernels and coreutils versions, stat's output locally and remotely differ, although the file is actually the same. This results in an unneeded transfer of the file.

In order to fix this, drop the creation (birth) time from the stat call in labgrid altogether.

[1] https://lists.gnu.org/archive/html/info-gnu/2019-03/msg00003.html

**Checklist**
- [ ] CHANGES.rst has been updated
- [x] PR has been tested