### PR TITLE
use deferred imports for requests and pyudev

### DIFF
--- a/labgrid/driver/lxaiobusdriver.py
+++ b/labgrid/driver/lxaiobusdriver.py
@@ -1,6 +1,6 @@
-import attr
+from importlib import import_module
 
-import requests
+import attr
 
 from ..factory import target_factory
 from ..protocol import DigitalOutputProtocol
@@ -18,6 +18,7 @@ class LXAIOBusPIODriver(Driver, DigitalOutputProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        self._requests = import_module('requests')
 
     def on_activate(self):
         # we can only forward if the backend knows which port to use
@@ -29,7 +30,7 @@ class LXAIOBusPIODriver(Driver, DigitalOutputProtocol):
     def set(self, status):
         if self.pio.invert:
             status = not status
-        r = requests.post(
+        r = self._requests.post(
                 self._url, data={'value': '1' if status else '0'}
         )
         r.raise_for_status()
@@ -40,7 +41,7 @@ class LXAIOBusPIODriver(Driver, DigitalOutputProtocol):
     @Driver.check_active
     @step(result=['True'])
     def get(self):
-        r = requests.get(self._url)
+        r = self._requests.get(self._url)
         r.raise_for_status()
         j = r.json()
         if j["code"] != 0:

--- a/labgrid/resource/lxaiobus.py
+++ b/labgrid/resource/lxaiobus.py
@@ -1,8 +1,8 @@
 import logging
 from time import monotonic
+from importlib import import_module
 
 import attr
-import requests
 
 from ..factory import target_factory
 from .common import ManagedResource, ResourceManager
@@ -12,6 +12,7 @@ from .common import ManagedResource, ResourceManager
 class LXAIOBusNodeManager(ResourceManager):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+        self._requests = import_module('requests')
 
         self.log = logging.getLogger('LXAIOBusNodeManager')
 
@@ -19,11 +20,11 @@ class LXAIOBusNodeManager(ResourceManager):
 
     def _get_nodes(self, host):
         try:
-            r = requests.get(f'http://{host}/nodes/')
+            r = self._requests.get(f'http://{host}/nodes/')
             r.raise_for_status()
             j = r.json()
             return j["result"]
-        except requests.exceptions.ConnectionError:
+        except self._requests.exceptions.ConnectionError:
             self.log.exception("failed to connect to host %s", host)
             return []
 

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -4,9 +4,9 @@ import os
 import queue
 import warnings
 from collections import OrderedDict
+from importlib import import_module
 
 import attr
-import pyudev
 
 from ..factory import target_factory
 from .common import ManagedResource, ResourceManager
@@ -21,9 +21,10 @@ class UdevManager(ResourceManager):
         self.queue = queue.Queue()
 
         self.log = logging.getLogger('UdevManager')
-        self._context = pyudev.Context()
-        self._monitor = pyudev.Monitor.from_netlink(self._context)
-        self._observer = pyudev.MonitorObserver(self._monitor,
+        self._pyudev = import_module('pyudev')
+        self._context = self._pyudev.Context()
+        self._monitor = self._pyudev.Monitor.from_netlink(self._context)
+        self._observer = self._pyudev.MonitorObserver(self._monitor,
                                                 callback=self._insert_into_queue)
         self._observer.start()
 


### PR DESCRIPTION
**Description**
Although the parts of labgrid which need `requests` and `pyudev` are not used by `labgrid-client`, they are still loaded every time and cause a significant startup overhead. This is especially noticeable on smaller ARM systems.

**Checklist**
- [x] PR has been tested