### PR TITLE
debian/doc/man: extend copyright period to 2022

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -3,8 +3,8 @@ Upstream-Name: labgrid
 Source: https://github.com/labgrid-project/labgrid
 
 Files: *
-Copyright: Copyright (C) 2016-2021 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
-           Copyright (C) 2016-2021 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+Copyright: Copyright (C) 2016-2022 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
+           Copyright (C) 2016-2022 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
 License: LGPL-2.1+
 
 Files: man/*

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -55,7 +55,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'labgrid'
-copyright = '2016-2021 Pengutronix, Jan Luebbe and Rouven Czerwinski'
+copyright = '2016-2022 Pengutronix, Jan Luebbe and Rouven Czerwinski'
 author = 'Jan Luebbe, Rouven Czerwinski'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/man/labgrid-suggest.1
+++ b/man/labgrid-suggest.1
@@ -88,7 +88,7 @@ USBSerialPort:
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2021 Pengutronix. This library is free software;
+Copyright (C) 2016-2022 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-suggest.rst
+++ b/man/labgrid-suggest.rst
@@ -8,7 +8,7 @@ labgrid-suggest generator for YAML config files
 
 :organization: Labgrid-Project
 :Date:   2021-05-20
-:Copyright: Copyright (C) 2016-2021 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2022 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)


### PR DESCRIPTION
**Description**
labgrid is in active development, so extend the copyright period to reflect that.

**Checklist**
- [x] Man pages have been regenerated