### PR TITLE
doc: test code/config snippets in docs

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
-        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev ncurses-term
+        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev ncurses-term graphviz
         sudo mkdir -p /var/cache/labgrid/runner && sudo chown runner /var/cache/labgrid/runner
     - name: Prepare local SSH
       run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -58,6 +58,7 @@ jobs:
         rm man/*.[1-8]
         make -C man all
         git --no-pager diff --exit-code
+        make -C doc doctest
     - uses: codecov/codecov-action@v1
   docker:
     runs-on: ubuntu-latest

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -207,6 +207,20 @@ def setup(app):
 
 # -- Options for doctest --------------------------------------------------
 
+doctest_global_setup = '''
+import os
+
+doctest_dir = '.build/doctest'
+
+if not os.getcwd().endswith(doctest_dir):
+    os.chdir(doctest_dir)
+'''
+
+doctest_global_cleanup = '''
+if os.getcwd().endswith(doctest_dir):
+    os.chdir('../..')
+'''
+
 def write_literal_blocks(app, doctree):
     """
     Writes named literal blocks to a file with that respective name in the temporary doctest build

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -203,3 +203,29 @@ def run_apidoc(app):
 
 def setup(app):
     app.connect('builder-inited', run_apidoc)
+    app.connect('doctree-read', write_literal_blocks)
+
+# -- Options for doctest --------------------------------------------------
+
+def write_literal_blocks(app, doctree):
+    """
+    Writes named literal blocks to a file with that respective name in the temporary doctest build
+    directory. This allows doctest to test code snippets referring to these files as-is.
+    """
+    blocks = doctree.traverse(
+        condition=lambda node: node.tagname == 'literal_block'
+    )
+
+    for block in blocks:
+        name = '_'.join(block['names'])
+
+        if not name:
+            continue
+
+        out_path = os.path.join(app.outdir, name)
+
+        if os.path.exists(out_path):
+            raise Exception(f'literal block name "{name}" used multiple times')
+
+        with open(out_path, 'w') as f:
+            f.write(block.astext())

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -36,6 +36,7 @@ import sphinx_rtd_theme
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = ['sphinx.ext.autodoc',
+              'sphinx.ext.doctest',
               'sphinx.ext.napoleon',
               'sphinx.ext.coverage',
               'sphinx.ext.viewcode',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -209,6 +209,8 @@ def setup(app):
 
 doctest_global_setup = '''
 import os
+import shutil
+from unittest.mock import Mock, patch
 
 doctest_dir = '.build/doctest'
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2608,6 +2608,8 @@ Implements:
 Arguments:
   - None
 
+.. _conf-strategies:
+
 Strategies
 ----------
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2623,19 +2623,44 @@ A BareboxStrategy has four states:
 - barebox
 - shell
 
+Here is an example environment config:
 
-to transition to the shell state:
+.. code-block:: yaml
+   :name: barebox-env.yaml
 
-::
+   targets:
+     main:
+       resources:
+         RawSerialPort:
+           port: '/dev/ttyUSB0'
+       drivers:
+         ManualPowerDriver: {}
+         SerialDriver: {}
+         BareboxDriver: {}
+         ShellDriver:
+           prompt: 'root@\w+:[^ ]+ '
+           login_prompt: ' login: '
+           username: root
+         BareboxStrategy: {}
+
+In order to use the BareboxStrategy via labgrid as a library and transition to
+the ``shell`` state:
+
+.. testsetup:: barebox-strategy
+
+   from labgrid.strategy import BareboxStrategy
+
+   BareboxStrategy.transition = Mock(return_value=None)
+
+.. doctest:: barebox-strategy
 
    >>> from labgrid import Environment
-   >>> e = Environment("local.yaml")
+   >>> e = Environment("barebox-env.yaml")
    >>> t = e.get_target("main")
    >>> s = t.get_driver("BareboxStrategy")
    >>> s.transition("shell")
 
-
-this command would transition from the bootloader into a Linux shell and
+This command would transition from the bootloader into a Linux shell and
 activate the ShellDriver.
 
 ShellStrategy
@@ -2646,19 +2671,42 @@ A ShellStrategy has three states:
 - off
 - shell
 
+Here is an example environment config:
 
-to transition to the shell state:
+.. code-block:: yaml
+   :name: shell-env.yaml
 
-::
+   targets:
+     main:
+       resources:
+         RawSerialPort:
+           port: '/dev/ttyUSB0'
+       drivers:
+         ManualPowerDriver: {}
+         SerialDriver: {}
+         ShellDriver:
+           prompt: 'root@\w+:[^ ]+ '
+           login_prompt: ' login: '
+           username: root
+         ShellStrategy: {}
+
+In order to use the ShellStrategy via labgrid as a library and transition to
+the ``shell`` state:
+
+.. testsetup:: shell-strategy
+
+   from labgrid.strategy import ShellStrategy
+
+   ShellStrategy.transition = Mock(return_value=None)
+
+.. doctest:: shell-strategy
 
    >>> from labgrid import Environment
-   >>> e = Environment("local.yaml")
+   >>> e = Environment("shell-env.yaml")
    >>> t = e.get_target("main")
    >>> s = t.get_driver("ShellStrategy")
-   >>> s.transition("shell")
 
-
-this command would transition directly into a Linux shell and
+This command would transition directly into a Linux shell and
 activate the ShellDriver.
 
 UBootStrategy
@@ -2670,19 +2718,44 @@ A UBootStrategy has four states:
 - uboot
 - shell
 
+Here is an example environment config:
 
-to transition to the shell state:
+.. code-block:: yaml
+   :name: uboot-env.yaml
 
-::
+   targets:
+     main:
+       resources:
+         RawSerialPort:
+           port: '/dev/ttyUSB0'
+       drivers:
+         ManualPowerDriver: {}
+         SerialDriver: {}
+         UBootDriver: {}
+         ShellDriver:
+           prompt: 'root@\w+:[^ ]+ '
+           login_prompt: ' login: '
+           username: root
+         UBootStrategy: {}
+
+In order to use the UBootStrategy via labgrid as a library and transition to
+the ``shell`` state:
+
+.. testsetup:: uboot-strategy
+
+   from labgrid.strategy import UBootStrategy
+
+   UBootStrategy.transition = Mock(return_value=None)
+
+.. doctest:: uboot-strategy
 
    >>> from labgrid import Environment
-   >>> e = Environment("local.yaml")
+   >>> e = Environment("uboot-env.yaml")
    >>> t = e.get_target("main")
    >>> s = t.get_driver("UBootStrategy")
    >>> s.transition("shell")
 
-
-this command would transition from the bootloader into a Linux shell and
+This command would transition from the bootloader into a Linux shell and
 activate the ShellDriver.
 
 DockerStrategy
@@ -2693,14 +2766,37 @@ A DockerStrategy has three states:
 - gone
 - accessible
 
+Here is an example environment config:
+
+.. code-block:: yaml
+   :name: docker-env.yaml
+
+   targets:
+     main:
+       resources:
+         DockerDaemon:
+           docker_daemon_url: unix://var/run/docker.sock
+       drivers:
+         DockerDriver:
+           image_uri: "rastasheep/ubuntu-sshd:16.04"
+           container_name: "ubuntu-lg-example"
+           host_config: {"network_mode":"bridge"}
+           network_services: [{"port":22,"username":"root","password":"root"}]
+         DockerStrategy: {}
 
 In order to use the DockerStrategy via labgrid as a library and transition to
 the ``accessible`` state:
 
-::
+.. testsetup:: docker-strategy
+
+   from labgrid.strategy import DockerStrategy
+
+   DockerStrategy.transition = Mock(return_value=None)
+
+.. doctest:: docker-strategy
 
    >>> from labgrid import Environment
-   >>> e = Environment("local.yaml")
+   >>> e = Environment("docker-env.yaml")
    >>> t = e.get_target("main")
    >>> s = t.get_driver("DockerStrategy")
    >>> s.transition("accessible")

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2685,34 +2685,29 @@ to transition to the shell state:
 this command would transition from the bootloader into a Linux shell and
 activate the ShellDriver.
 
-DockerShellStrategy
-~~~~~~~~~~~~~~~~~~~
-A DockerShellStrategy has three states:
+DockerStrategy
+~~~~~~~~~~~~~~
+A DockerStrategy has three states:
 
 - unknown
-- off
-- shell
+- gone
+- accessible
 
 
-To transition to the shell state:
+In order to use the DockerStrategy via labgrid as a library and transition to
+the ``accessible`` state:
 
 ::
 
    >>> from labgrid import Environment
    >>> e = Environment("local.yaml")
    >>> t = e.get_target("main")
-   >>> s = t.get_driver("DockerShellStrategy")
-   >>> s.transition("shell")
-
+   >>> s = t.get_driver("DockerStrategy")
+   >>> s.transition("accessible")
 
 These commands would activate the docker driver which creates and starts
 a docker container. This will subsequently make `NetworkService`_ instance(s)
 available which can be used for e.g. SSH access.
-
-Note: Transitioning to the "off" state will make any `NetworkService`_
-instance(s) unresponsive - which may in turn invalidate SSH connection
-sharing. Therefore, during automated test suites, refrain from transitioning
-to the "off" state.
 
 Reporters
 ---------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2814,14 +2814,14 @@ StepReporter
 ~~~~~~~~~~~~
 The StepReporter outputs individual labgrid steps to `STDOUT`.
 
-::
+.. doctest::
 
     >>> from labgrid import StepReporter
     >>> StepReporter.start()
 
 The Reporter can be stopped with a call to the stop function:
 
-::
+.. doctest::
 
     >>> from labgrid import StepReporter
     >>> StepReporter.stop()
@@ -2839,14 +2839,14 @@ ConsoleLoggingReporter
 The ConsoleLoggingReporter outputs read calls from the console transports into
 files. It takes the path as a parameter.
 
-::
+.. doctest::
 
     >>> from labgrid import ConsoleLoggingReporter
     >>> ConsoleLoggingReporter.start(".")
 
 The Reporter can be stopped with a call to the stop function:
 
-::
+.. doctest::
 
     >>> from labgrid import ConsoleLoggingReporter
     >>> ConsoleLoggingReporter.stop()

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -56,7 +56,7 @@ classes.
 First of all import attr, the protocol and the common driver class
 into your new driver file.
 
-::
+.. testcode::
 
     import attr
 
@@ -68,7 +68,7 @@ driver class.
 Try to avoid subclassing existing other drivers, as this limits the flexibility
 provided by connecting drivers and resources on a given target at runtime.
 
-::
+.. testcode::
 
     import attr
 
@@ -85,7 +85,7 @@ subclass list.
 Using the mixin class allows sharing common code, which would otherwise need to
 be added into multiple drivers.
 
-::
+.. testcode::
 
     import attr
 
@@ -101,7 +101,12 @@ Additionally the driver needs to be registered with the :any:`target_factory`
 and provide a bindings dictionary, so that the :any:`Target` can resolve
 dependencies on other drivers or resources.
 
-::
+.. testsetup:: example-driver1
+
+    from labgrid.factory import target_factory
+    target_factory.all_classes.pop('ExampleDriver', None)
+
+.. testcode:: example-driver1
 
     import attr
 
@@ -134,7 +139,12 @@ If you need to do something during instantiation, you need to add a
 for non-attr-classes).
 The minimum requirement is a call to :code:`super().__attrs_post_init__()`.
 
-::
+.. testsetup:: example-driver2
+
+    from labgrid.factory import target_factory
+    target_factory.all_classes.pop('ExampleDriver', None)
+
+.. testcode:: example-driver2
 
     import attr
 
@@ -160,7 +170,7 @@ Writing a Resource
 To add a new resource to labgrid, we import attr into our new resource file.
 Additionally we need the :any:`target_factory` and the common ``Resource`` class.
 
-::
+.. testcode::
 
     import attr
 
@@ -170,7 +180,7 @@ Additionally we need the :any:`target_factory` and the common ``Resource`` class
 Next we add our own resource with the :code:`Resource` parent class and
 register it with the :any:`target_factory`.
 
-::
+.. testcode::
 
     import attr
 
@@ -185,7 +195,12 @@ register it with the :any:`target_factory`.
 All that is left now is to add attributes via :code:`attr.ib()` member
 variables.
 
-::
+.. testsetup:: example-resource
+
+    from labgrid.factory import target_factory
+    target_factory.all_classes.pop('ExampleResource', None)
+
+.. testcode:: example-resource
 
     import attr
 
@@ -208,7 +223,7 @@ labgrid offers only basic strategies, for complex use cases a customized
 strategy is required.
 Start by creating a strategy skeleton:
 
-::
+.. testcode::
 
     import enum
 
@@ -383,8 +398,10 @@ duplication.
 Example
 ~~~~~~~
 
+``teststrategy.py``:
+
 .. code-block:: python
-   :caption: teststrategy.py
+   :name: teststrategy.py
 
    from labgrid.strategy import GraphStrategy
    from labgrid.factory import target_factory
@@ -410,10 +427,10 @@ Example
        def state_linux_shell(self):
            pass
 
-The class can also render a graph as PNG (using GraphViz):
+``test.yaml``:
 
 .. code-block:: yaml
-   :caption: test.yaml
+   :name: test.yaml
 
    targets:
      main:
@@ -424,8 +441,10 @@ The class can also render a graph as PNG (using GraphViz):
    imports:
    - teststrategy.py
 
+The class can also render a graph as PNG (using GraphViz):
 
-::
+.. doctest::
+   :skipif: shutil.which('dot') is None
 
    >>> from labgrid.environment import Environment
    >>> env = Environment('test.yaml')
@@ -513,13 +532,18 @@ SSHManager
 labgrid provides a SSHManager to allow connection reuse with control sockets.
 To use the SSHManager in your code, import it from :any:`labgrid.util.ssh`:
 
-.. code-block:: python
+.. doctest::
 
    >>> from labgrid.util import sshmanager
 
 you can now request or remove port forwardings:
 
-.. code-block:: python
+.. testsetup:: sshmanager
+
+   from labgrid.util import sshmanager
+   sshmanager.get = Mock()
+
+.. doctest:: sshmanager
 
    >>> from labgrid.util import sshmanager
    >>> localport = sshmanager.request_forward('localhost', 'somehost', 3000)
@@ -527,7 +551,7 @@ you can now request or remove port forwardings:
 
 or get and put files:
 
-.. code-block:: python
+.. doctest:: sshmanager
 
    >>> from labgrid.util import sshmanager
    >>> sshmanager.put_file('somehost', '/path/to/local/file', '/path/to/remote/file')
@@ -551,10 +575,20 @@ Additionally it provides `get_remote_path()` to retrieve the complete file path,
 to easily employ it for driver implementations.
 To use it in conjunction with a `Resource` and a file:
 
-.. code-block:: python
+.. testsetup:: managed-file
+
+   import tempfile
+   from labgrid.resource import Resource
+   from labgrid import Target
+
+   f = tempfile.NamedTemporaryFile()
+   your_file = f.name
+   your_resource = Resource(Target("main"), "example")
+
+.. doctest:: managed-file
 
    >>> from labgrid.util.managedfile import ManagedFile
-   >>> mf = ManagedFile(<your-file>, <your-resource>)
+   >>> mf = ManagedFile(your_file, your_resource)
    >>> mf.sync_to_resource()
    >>> path = mf.get_remote_path()
 
@@ -579,10 +613,18 @@ used in the `SerialDriver` for proxy connections.
 
 Usage:
 
-.. code-block:: python
+.. testsetup:: proxy-manager
+
+   from labgrid.resource import Resource
+   from labgrid import Target
+
+   your_resource = Resource(Target("main"), "example")
+   your_resource.host = "localhost"
+
+.. doctest:: proxy-manager
 
    >>> from labgrid.util.proxy import proxymanager
-   >>> proxymanager.get_host_and_port(<resource>)
+   >>> host, port = proxymanager.get_host_and_port(your_resource)
 
 
 .. _contributing:

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -465,13 +465,7 @@ strategies.
 
 To use a strategy, add it and its dependencies to your configuration YAML,
 retrieve it in your test and call the ``transition(status)`` function.
-
-.. code-block:: python
-
-   >>> from labgrid import Environment
-   >>> env = Environment("env.yaml")
-   >>> target = env.get_target("main")
-   >>> strategy = target.get_driver("Strategy")
-   >>> strategy.transition("barebox")
+See the section about the various :ref:`shipped strategies <conf-strategies>`
+for examples on this.
 
 An example using the pytest plugin is provided under `examples/strategy`.

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -127,6 +127,8 @@ Each driver and resource can have an optional name. This parameter is required
 for all manual creations of drivers and resources. To manually bind to a
 specific driver set a binding mapping before creating the driver:
 
+.. doctest::
+
   >>> from labgrid import Target
   >>> from labgrid.resource import SerialPort
   >>> from labgrid.driver import SerialDriver
@@ -166,7 +168,7 @@ Otherwise, `0` is returned as the default priority.
 To set the priority of a protocol for a driver, add a class variable with the
 name `priorities`, e.g.
 
-.. code-block:: python
+.. testcode::
 
    import attr
    from labgrid.driver import Driver

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -188,13 +188,17 @@ Targets
    Nevertheless, we explain this in the following to clarify the underlying concepts,
    and how to work with targets on a lower level, e.g. in strategies.
 
-At the lower level, a :any:`Target` can be created directly::
+At the lower level, a :any:`Target` can be created directly:
+
+.. doctest::
 
   >>> from labgrid import Target
   >>> t = Target('example')
 
 Next, any required :any:`Resource` objects can be created, which each represent
-a piece of hardware to be used with labgrid::
+a piece of hardware to be used with labgrid:
+
+.. doctest::
 
   >>> from labgrid.resource import RawSerialPort
   >>> rsp = RawSerialPort(t, name=None, port='/dev/ttyUSB0')
@@ -205,13 +209,17 @@ a piece of hardware to be used with labgrid::
    same type, you can set the name to ``None``.
 
 Further on, a :any:`Driver` encapsulates logic how to work with resources.
-Drivers need to be created on the :any:`Target`::
+Drivers need to be created on the :any:`Target`:
+
+.. doctest::
 
   >>> from labgrid.driver import SerialDriver
   >>> sd = SerialDriver(t, name=None)
 
 As the :any:`SerialDriver` declares a binding to a :any:`SerialPort`, the target binds it
-to the resource object created above::
+to the resource object created above:
+
+.. doctest::
 
   >>> sd.port
   RawSerialPort(target=Target(name='example', env=None), name=None, state=<BindingState.bound: 1>, avail=True, port='/dev/ttyUSB0', speed=115200)
@@ -232,7 +240,21 @@ other applications while the :any:`SerialDriver` is activated.
 If we use a car analogy here, binding is the process of screwing the car parts
 together, and activation is igniting the engine.
 
-After activation, we can use the driver to do our work::
+After activation, we can use the driver to do our work:
+
+.. testsetup:: driver-activation
+
+  from labgrid.resource import RawSerialPort
+  from labgrid.driver import SerialDriver
+  from labgrid import Target
+
+  t = Target('example')
+  rsp = RawSerialPort(t, name=None, port='/dev/ttyUSB0')
+  sd = SerialDriver(t, name=None)
+  sd.serial.open = Mock()
+  sd.serial.write = Mock(return_value=4)
+
+.. doctest:: driver-activation
 
   >>> t.activate(sd)
   >>> sd.write(b'test')
@@ -249,7 +271,9 @@ exception, e.g.::
   FileNotFoundError: [Errno 2] No such file or directory: '/dev/ttyUSB0'
 
 Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
-:any:`Protocol <labgrid.protocol>`) using some syntactic sugar::
+:any:`Protocol <labgrid.protocol>`) using some syntactic sugar:
+
+.. doctest::
 
   >>> from labgrid import Target
   >>> from labgrid.driver.fake import FakeConsoleDriver
@@ -263,7 +287,17 @@ Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
 
 Driver Deactivation
 ^^^^^^^^^^^^^^^^^^^
-Driver deactivation works in a similar manner::
+Driver deactivation works in a similar manner:
+
+.. testsetup:: driver-deactivation
+
+  from labgrid import Target
+  from labgrid.driver.fake import FakeConsoleDriver
+  target = Target('main')
+  console = FakeConsoleDriver(target, 'console')
+  target.activate(console)
+
+.. doctest:: driver-deactivation
 
   >>> target.deactivate(console)
   [FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.bound: 1>, txdelay=0.0)]
@@ -289,7 +323,14 @@ Target Cleanup
 ^^^^^^^^^^^^^^
 After you are done with the target, optionally call the cleanup method on your
 target. While labgrid registers an ``atexit`` handler to cleanup targets, this has
-the advantage that exceptions can be handled by your application::
+the advantage that exceptions can be handled by your application:
+
+.. testsetup:: target-cleanup
+
+  from labgrid import Target
+  target = Target('main')
+
+.. doctest:: target-cleanup
 
   >>> try:
   ...     target.cleanup()
@@ -307,6 +348,7 @@ For this use-case, labgrid can construct targets from a configuration file in
 YAML format:
 
 .. code-block:: yaml
+  :name: example-env.yaml
 
   targets:
     example:
@@ -316,19 +358,36 @@ YAML format:
       drivers:
         SerialDriver: {}
 
-To parse this configuration file, use the :any:`Environment` class::
+To parse this configuration file, use the :any:`Environment` class:
+
+.. doctest::
 
   >>> from labgrid import Environment
   >>> env = Environment('example-env.yaml')
 
 Using :any:`Environment.get_target`, the configured `Targets` can be retrieved
 by name.
-Without an argument, `get_target` would default to 'main'::
+Without an argument, `get_target` would default to 'main':
+
+.. doctest::
 
   >>> t = env.get_target('example')
 
 To access the target's console, the correct driver object can be found by using
-:any:`Target.get_driver`::
+:any:`Target.get_driver`:
+
+.. testsetup:: get-driver
+
+  from labgrid import Environment
+
+  env = Environment('example-env.yaml')
+  t = env.get_target('example')
+
+  s = t.get_driver('SerialDriver', activate=False)
+  s.serial.open = Mock()
+  s.serial.write = Mock(return_value=4)
+
+.. doctest:: get-driver
 
   >>> cp = t.get_driver('ConsoleProtocol')
   >>> cp
@@ -454,7 +513,9 @@ access this board:
           login_prompt: ' login: '
           username: 'root'
 
-We then add the following test in a file called ``test_example.py``::
+We then add the following test in a file called ``test_example.py``:
+
+.. code-block:: python
 
   def test_echo(target):
       command = target.get_driver('CommandProtocol')
@@ -482,7 +543,9 @@ Custom Fixture Example
 When writing many test cases which use the same driver, we can get rid of some
 common code by wrapping the `CommandProtocol` in a fixture.
 As pytest always executes the ``conftest.py`` file in the test suite directory,
-we can define additional fixtures there::
+we can define additional fixtures there:
+
+.. code-block:: python
 
   import pytest
 
@@ -490,7 +553,9 @@ we can define additional fixtures there::
   def command(target):
       return target.get_driver('CommandProtocol')
 
-With this fixture, we can simplify the ``test_example.py`` file to::
+With this fixture, we can simplify the ``test_example.py`` file to:
+
+.. code-block:: python
 
   def test_echo(command):
       result = command.run_check('echo OK')
@@ -499,7 +564,9 @@ With this fixture, we can simplify the ``test_example.py`` file to::
 Strategy Fixture Example
 ~~~~~~~~~~~~~~~~~~~~~~~~
 When using a :any:`Strategy` to transition the target between states, it is
-useful to define a function scope fixture per state in ``conftest.py``::
+useful to define a function scope fixture per state in ``conftest.py``:
+
+.. code-block:: python
 
   import pytest
 
@@ -528,7 +595,9 @@ useful to define a function scope fixture per state in ``conftest.py``::
   <http://doc.pytest.org/en/latest/capture.html#accessing-captured-output-from-a-test-function>`_.
 
 With the fixtures defined above, switching between bootloader and Linux shells
-is easy::
+is easy:
+
+.. code-block:: python
 
   def test_barebox_initial(bootloader_command):
       stdout = bootloader_command.run_check('version')
@@ -595,13 +664,15 @@ Feature Flags
 ~~~~~~~~~~~~~
 labgrid includes support for feature flags on a global and target scope.
 Adding a ``@pytest.mark.lg_feature`` decorator to a test ensures it is only
-executed if the desired feature is available::
+executed if the desired feature is available:
+
+.. code-block:: python
 
    import pytest
 
    @pytest.mark.lg_feature("camera")
    def test_camera(target):
-      [...]
+      pass
 
 Here's an example environment configuration:
 
@@ -628,13 +699,15 @@ test because of the missing feature:
 
 pytest will record the missing feature as the skip reason.
 
-For tests with multiple required features, pass them as a list to pytest::
+For tests with multiple required features, pass them as a list to pytest:
+
+.. code-block:: python
 
    import pytest
 
    @pytest.mark.lg_feature(["camera", "console"])
    def test_camera(target):
-      [...]
+      pass
 
 Features do not have to be set per target, they can also be set via the global
 features key:


### PR DESCRIPTION
**Description**
In the past, a lot of code snippets in the documentation did not work (see #877). Use [sphinx' doctest extension](https://www.sphinx-doc.org/en/master/usage/extensions/doctest.html) to test code snippets and configurations where feasible.

While at it, fix the documentation of the docker strategy.

**Checklist**
- [x] PR has been tested

Fixes #301