### PR TITLE
shelldriver: Redirect rx stderr to /dev/null

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -320,7 +320,8 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         if not self._xmodem_cached_rx_cmd:
             if self._run('which rx')[0]:
                 # busybox rx
-                self._xmodem_cached_rx_cmd = "rx '{filename}'"
+                # lrz may provide rx so redirect stderr for the same reason as below
+                self._xmodem_cached_rx_cmd = "rx '{filename}' 2>/dev/null"
             elif self._run('which lrz')[0]:
                 # redirect stderr to prevent lrz from printing "ready to receive
                 # $file", which will confuse the XMODEM instance


### PR DESCRIPTION
lrzsz also provides the `rx` command, and it will output the same banner
to stderr as the `lrz` command. Suppress stderr to handle this case

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
