### PR TITLE
driver: power: rest/simplerest: raise error on power_set() if one occurred

### DIFF
--- a/labgrid/driver/power/rest.py
+++ b/labgrid/driver/power/rest.py
@@ -17,7 +17,8 @@ import requests
 def power_set(host, port, index, value):
     assert port is None
     value = b"1" if value else b"0"
-    requests.put(host.format(index=index), data=value)
+    r = requests.put(host.format(index=index), data=value)
+    r.raise_for_status()
 
 def power_get(host, port, index):
     assert port is None

--- a/labgrid/driver/power/simplerest.py
+++ b/labgrid/driver/power/simplerest.py
@@ -17,7 +17,8 @@ def power_set(host, port, index, value):
 
     index = int(index)
     value = 1 if value else 0
-    requests.get(host.format(value=value, index=index))
+    r = requests.get(host.format(value=value, index=index))
+    r.raise_for_status()
 
 def power_get(host, port, index):
     assert port is None


### PR DESCRIPTION
**Description**
Do not ignore HTTP errors on power set in `rest`/`simplerest` backends.

**Checklist**
- [ ] CHANGES.rst has been updated
- [.] PR has been tested (tested `rest` backend, `simplerest` should work similarly)

Fixes #219
Fixes #723
