### PR TITLE
Add release-from

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New Features in 0.5.0
   there are multiple NetworkService resources available.
 - eg_pms2_network power port driver supports controlling the Energenie power
   management series with devices like the EG_PMS2_LAN & EG_PMS2_WLAN
+- The client and coordinator learned of a new "release-from" operation that only releases a place
+  if it acquired by a specific user. This can be used to prevent race conditions when attempting to
+  automate the cleanup of unused places (e.g. in CI jobs)
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -625,6 +625,17 @@ class ClientSession(ApplicationSession):
 
         print(f"released place {place.name}")
 
+    async def release_from(self):
+        """Release a place, but only if acquired by a specific user"""
+        place = self.get_place()
+        res = await self.call(
+            'org.labgrid.coordinator.release_place_from', place.name, self.args.acquired,
+        )
+        if not res:
+            raise ServerError(f"failed to release place {place.name}")
+
+        print(f"{self.args.acquired} has released place {place.name}")
+
     async def allow(self):
         """Allow another use access to a previously acquired place"""
         place = self.get_place()
@@ -1624,6 +1635,13 @@ def main():
     subparser.add_argument('-k', '--kick', action='store_true',
                            help="release a place even if it is acquired by a different user")
     subparser.set_defaults(func=ClientSession.release)
+
+    subparser = subparsers.add_parser('release-from',
+                                     help="atomically release a place, but only if locked by a specific user")
+    subparser.add_argument("acquired",
+                           metavar="HOST/USER",
+                           help="User and host to match against when releasing")
+    subparser.set_defaults(func=ClientSession.release_from)
 
     subparser = subparsers.add_parser('allow', help="allow another user to access a place")
     subparser.add_argument('user', help="<host>/<username>")

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -155,6 +155,12 @@ matches anything.
 \fBallow\fP user                  Allow another user to access a place
 .sp
 \fBrelease (unlock)\fP            Release a place
+.INDENT 0.0
+.TP
+.B \fBrelease\-from\fP host/user      Atomically release a place, but only if acquired by a specific user. Note that this
+command returns success as long as specified user no longer owns the place, meaning it may
+be acquired by another user or not at all.
+.UNINDENT
 .sp
 \fBenv\fP                         Generate a labgrid environment file for a place
 .sp

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -150,6 +150,10 @@ LABGRID-CLIENT COMMANDS
 
 ``release (unlock)``            Release a place
 
+``release-from`` host/user      Atomically release a place, but only if acquired by a specific user. Note that this
+                                command returns success as long as specified user no longer owns the place, meaning it may
+                                be acquired by another user or not at all.
+
 ``env``                         Generate a labgrid environment file for a place
 
 ``power (pw)`` action           Change (or get) a place's power status, where action is one of get, on, off, status

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -192,6 +192,52 @@ def test_place_acquire_broken(place, exporter):
         print(spawn.before.decode())
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+def test_place_release_from(monkeypatch, place, exporter):
+    user = "test-user"
+    host = "test-host"
+    monkeypatch.setenv("LG_USERNAME", user)
+    monkeypatch.setenv("LG_HOSTNAME", host)
+
+    # Acquire place
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    # Ensure place is acquired by user
+    with pexpect.spawn('python -m labgrid.remote.client who') as spawn:
+        spawn.expect(f"{user}\\s+{host}\\s+test")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    # Use release-from to release for a different user
+    with pexpect.spawn('python -m labgrid.remote.client -p test release-from foo/bar') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    # Ensure place is still acquired by this user
+    with pexpect.spawn('python -m labgrid.remote.client who') as spawn:
+        spawn.expect(f"{user}\\s+{host}\\s+test")
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    # Use release-from to release place for this user
+    with pexpect.spawn(f'python -m labgrid.remote.client -p test release-from {host}/{user}') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    # Ensure place is still no longer acquired
+    with pexpect.spawn('python -m labgrid.remote.client who') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        before = spawn.before.decode("utf-8").strip()
+        assert user not in before and not host in before, before
+
 def test_place_add_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client create') as spawn:
         spawn.expect("missing place name")


### PR DESCRIPTION
Adds coordinator and client API to release a place, but *only* if it is
acquired by a specific user in an atomic manner.

The intention is that this can be used by cleanup procedures to ensure
that there is not a race condition between figuring out which user has a
resource locked, and actually kicking that user. For example, some CI
systems may leave a place locked if they don't get a chance to cleanup
properly. A cleanup procedure might cross reference the user that has a
place locked with a list of active CI jobs, and if a user is found
that doesn't match any running CI job, the place it has acquired is
released. This presents a race however if this procedure is occuring in
multiple places simultaneously, as it's possible one of them releases
the place, then it gets acquired by an active CI job, then another
cleanup procedure releases it again.

This API prevents the above case because the cleanup procedure can
ensure that the place will *only* be released if it was acquired by the
specific user that it thinks should have it.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
