### PR TITLE
client: Add missing name argument

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1695,24 +1695,28 @@ def main():
 
     subparser = subparsers.add_parser('scp',
                                       help="transfer file via scp")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.add_argument('src', help='source path (use :dir/file for remote side)')
     subparser.add_argument('dst', help='destination path (use :dir/file for remote side)')
     subparser.set_defaults(func=ClientSession.scp)
 
     subparser = subparsers.add_parser('rsync',
                                       help="transfer files via rsync")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.add_argument('src', help='source path (use :dir/file for remote side)')
     subparser.add_argument('dst', help='destination path (use :dir/file for remote side)')
     subparser.set_defaults(func=ClientSession.rsync)
 
     subparser = subparsers.add_parser('sshfs',
                                       help="mount via sshfs (blocking)")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.add_argument('path', help='remote path on the target')
     subparser.add_argument('mountpoint', help='local path')
     subparser.set_defaults(func=ClientSession.sshfs)
 
     subparser = subparsers.add_parser('forward',
                                       help="forward local port to remote target")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.add_argument("--local", "-L", metavar="[LOCAL:]REMOTE",
                            action=LocalPort,
                            help="Forward local port LOCAL to remote port REMOTE. If LOCAL is unspecified, an arbitrary port will be chosen")


### PR DESCRIPTION
Since 361a7f7 ("client: Add named resource arg to SSH subparser"), a
"name" argument is required for all SSH operations, but it was omitted
from the `scp`, `rsync`, `sshfs`, and `forward` subcommands.

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
