### PR TITLE
examples: remove custom strategy fixtures

### DIFF
--- a/examples/strategy/test_barebox_strategy.py
+++ b/examples/strategy/test_barebox_strategy.py
@@ -3,13 +3,6 @@ import pytest
 from labgrid.exceptions import NoDriverFoundError
 
 
-@pytest.fixture()
-def strategy(target):
-    try:
-        return target.get_driver('BareboxStrategy')
-    except NoDriverFoundError:
-        pytest.skip("strategy not found")
-
 @pytest.fixture(scope="function")
 def in_bootloader(strategy, capsys):
     with capsys.disabled():

--- a/examples/strategy/test_uboot_strategy.py
+++ b/examples/strategy/test_uboot_strategy.py
@@ -1,14 +1,6 @@
 import pytest
 
 
-@pytest.fixture()
-def strategy(target):
-    try:
-        return target.get_driver('UBootStrategy')
-    except NoDriverFoundError:
-        pytest.skip("strategy not found")
-
-
 @pytest.fixture(scope="function")
 def in_bootloader(strategy, capsys):
     with capsys.disabled():

--- a/examples/usbpower/test_example.py
+++ b/examples/usbpower/test_example.py
@@ -3,14 +3,6 @@ import pytest
 from labgrid.exceptions import NoDriverFoundError
 
 
-@pytest.fixture()
-def strategy(target):
-    try:
-        return target.get_driver('ExampleStrategy')
-    except NoDriverFoundError:
-        pytest.skip("strategy not found")
-
-
 @pytest.fixture(scope="function")
 def bootloader(target, strategy, capsys):
     with capsys.disabled():


### PR DESCRIPTION
Since 5d9e76ad888c (pytestplugin: add a --lg-initial-state= option to use
during development), labgrid provides a strategy fixture which matches on the
abstract Strategy class. Accordingly, these custom fixtures are no longer
needed and currently break use of --lg-initial-state=.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated
