### PR TITLE
strategy/bareboxstrategy: add force function

### DIFF
--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -62,3 +62,16 @@ class BareboxStrategy(Strategy):
                 f"no transition found from {self.status} to {status}"
             )
         self.status = status
+
+    @step(args=['status'])
+    def force(self, status):
+        if not isinstance(status, Status):
+            status = Status[status]
+        self.target.activate(self.power)
+        if status == Status.barebox:
+            self.target.activate(self.barebox)
+        elif status == Status.shell:
+            self.target.activate(self.shell)
+        else:
+            raise StrategyError("can not force state {}".format(status))
+        self.status = status


### PR DESCRIPTION
This adds support for `--lg-initial-state=barebox/shell` when using the pytest
plugin.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] CHANGES.rst has been updated
- [x] PR has been tested
- [ ] Man pages have been regenerated
