### PR TITLE
Check for duplicate matches on add-match/add-named-match

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,7 @@ New Features in 0.5.0
 - SmallUBootDriver driver now supports wide range of Ralink/mt7621 devices
   which expects ``boot_secret`` without new line with new ``boot_secret_nolf``
   boolean config option.
+- labgrid-client add-match/add-named-match check for duplicate matches
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -492,13 +492,13 @@ class ClientSession(ApplicationSession):
         if place.acquired:
             raise UserError(f"can not change acquired place {place.name}")
         for pattern in self.args.patterns:
-            if pattern in map(repr, place.matches):
-                print(f"pattern '{pattern}' exists, skipping")
-                continue
             if not 2 <= pattern.count("/") <= 3:
                 raise UserError(
                     f"invalid pattern format '{pattern}' (use 'exporter/group/cls/name')"
                 )
+            if place.hasmatch(pattern.split("/")):
+                print(f"pattern '{pattern}' exists, skipping")
+                continue
             res = await self.call(
                 'org.labgrid.coordinator.add_place_match', place.name, pattern
             )
@@ -513,13 +513,12 @@ class ClientSession(ApplicationSession):
         if place.acquired:
             raise UserError(f"can not change acquired place {place.name}")
         for pattern in self.args.patterns:
-            if pattern not in map(repr, place.matches):
-                print(f"pattern '{pattern}' not found, skipping")
-                continue
             if not 2 <= pattern.count("/") <= 3:
                 raise UserError(
                     f"invalid pattern format '{pattern}' (use 'exporter/group/cls/name')"
                 )
+            if not place.hasmatch(pattern.split("/")):
+                print(f"pattern '{pattern}' not found, skipping")
             res = await self.call(
                 'org.labgrid.coordinator.del_place_match', place.name, pattern
             )
@@ -537,12 +536,12 @@ class ClientSession(ApplicationSession):
             raise UserError(f"can not change acquired place {place.name}")
         pattern = self.args.pattern
         name = self.args.name
-        if pattern in map(repr, place.matches):
-            raise UserError(f"pattern '{pattern}' exists")
         if not 2 <= pattern.count("/") <= 3:
             raise UserError(
                 f"invalid pattern format '{pattern}' (use 'exporter/group/cls/name')"
             )
+        if place.hasmatch(pattern.split("/")):
+            raise UserError(f"pattern '{pattern}' exists")
         if '*' in pattern:
             raise UserError(
                 f"invalid pattern '{pattern}' ('*' not allowed for named matches)"

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -118,14 +118,19 @@ class ResourceMatch:
 
     def ismatch(self, resource_path):
         """Return True if this matches the given resource"""
-        exporter, group, cls, name = resource_path
+        try:
+            exporter, group, cls, name = resource_path
+        except ValueError:
+            exporter, group, cls = resource_path
+            name = None
+
         if not fnmatchcase(exporter, self.exporter):
             return False
         if not fnmatchcase(group, self.group):
             return False
         if not fnmatchcase(cls, self.cls):
             return False
-        if self.name and not fnmatchcase(name, self.name):
+        if name and self.name and not fnmatchcase(name, self.name):
             return False
 
         return True

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -133,6 +133,26 @@ def test_place_match(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+def test_place_match_duplicates(place):
+    # first given match should succeed, second should be skipped
+    matches = (
+        ("e1/g1/r1", "e1/g1/r1"),
+        ("e1/g1/r1/n1", "e1/g1/r1/n1"),
+        ("e1/g1/r1/n1", "e1/g1/r1"),
+        ("e1/g1/r1", "e1/g1/r1/n1"),
+    )
+    for match in matches:
+        with pexpect.spawn(f'python -m labgrid.remote.client -p test add-match "{match[0]}" "{match[1]}"') as spawn:
+            spawn.expect(f"pattern '{match[1]}' exists, skipping")
+            spawn.expect(pexpect.EOF)
+            spawn.close()
+            assert spawn.exitstatus == 0, spawn.before.strip()
+
+        with pexpect.spawn(f'python -m labgrid.remote.client -p test del-match "{match[0]}"') as spawn:
+            spawn.expect(pexpect.EOF)
+            spawn.close()
+            assert spawn.exitstatus == 0, spawn.before.strip()
+
 def test_place_acquire(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)


### PR DESCRIPTION
**Description**
Do not add matches without a name in their resource path that already exist with a name (and vice versa).

**Checklist**
- [x] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #888