### PR TITLE
modbus: add support for Papouch Quido ETH I/O modules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ New Features in 0.5.0
 - The client and coordinator learned of a new "release-from" operation that only releases a place
   if it acquired by a specific user. This can be used to prevent race conditions when attempting to
   automate the cleanup of unused places (e.g. in CI jobs)
+- ModbusTCPCoil driver supports writing using multiple coils write method
+  in order to make driver usable with Papouch Quido I/O modules
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -362,6 +362,8 @@ Arguments:
   - coil (int): index of the coil e.g. 3
   - invert (bool, default=False): whether the logic level is inverted
     (active-low)
+  - write_multiple_coils (bool, default=False): whether to perform write
+    using "write multiple coils" method instead of "write single coil"
 
 Used by:
   - `ModbusCoilDriver`_

--- a/labgrid/driver/modbusdriver.py
+++ b/labgrid/driver/modbusdriver.py
@@ -38,9 +38,15 @@ class ModbusCoilDriver(Driver, DigitalOutputProtocol):
 
     @Driver.check_active
     def set(self, status):
+        write_status = None
         if self.coil.invert:
             status = not status
-        write_status = self.client.write_single_coil(self.coil.coil, bool(status))
+        if self.coil.write_multiple_coils:
+            write_status = self.client.write_multiple_coils(
+                self.coil.coil, [bool(status)]
+            )
+        else:
+            write_status = self.client.write_single_coil(self.coil.coil, bool(status))
         if write_status is None:
             self._handle_error("write")
 

--- a/labgrid/resource/modbus.py
+++ b/labgrid/resource/modbus.py
@@ -12,7 +12,12 @@ class ModbusTCPCoil(Resource):
     Args:
         host (str): hostname of the Modbus TCP server e.g. "192.168.23.42:502"
         coil (int): index of the coil e.g. 3
-        invert (bool): optional, whether the logic level is be inverted (active-low)"""
+        invert (bool): optional, whether the logic level is be inverted (active-low)
+        write_multiple_coils (bool): optional, whether write using multiple coils method"""
+
     host = attr.ib(validator=attr.validators.instance_of(str))
     coil = attr.ib(validator=attr.validators.instance_of(int))
     invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    write_multiple_coils = attr.ib(
+        default=False, validator=attr.validators.instance_of(bool)
+    )


### PR DESCRIPTION
**Description**

[Quido ETH](https://en.papouch.com/io-modules/quido/ethernet/) is a family of I/O modules with up to 32 digital outputs (relays) and ethernet interface which makes them quite nice devices for DUT power control.

![image](https://user-images.githubusercontent.com/43848/157925869-0e5157e5-853a-47f8-bfe7-3e345fff0fe5.png)

In order to control the state of the relay outputs, firmware needs to be instructed using Modbus function code 15, multiple coils write method as single coil write method is not supported, only single coil state reading is. Write using single method ends with `Could not write coil (code=7/exception=1)` error.

So in order to support those modules, new `write_multiple` boolean config option has been added to `ModbusTCPCoil` resource. When enabled, the Modbus driver is going to use `write_multiple_coils()` method instead of defaul `write_single_coil()`.

Example usage tested with Quido ETH 8/8 (coils 0-7) module:

```yaml
    resources:
      ModbusTCPCoil:
        host: 192.168.1.254
        coil: 7
        write_multiple: True
    drivers:
      ModbusCoilDriver: {}
      DigitalOutputPowerDriver: {}
```

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested
