### PR TITLE
dockerfiles: use https instead of git protocol

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -12,7 +12,7 @@ RUN set -e ;\
     pip3 install -U pip;\
     apt clean ;\
     rm -rf /var/lib/apt/lists/* ;\
-    git clone git://github.com/vishnubob/wait-for-it.git opt/wait-for-it && cd opt/wait-for-it  && git reset --hard 54d1f0bfeb6557adf8a3204455389d0901652242
+    git clone https://github.com/vishnubob/wait-for-it.git opt/wait-for-it && cd opt/wait-for-it  && git reset --hard 54d1f0bfeb6557adf8a3204455389d0901652242
 
 #
 # Client


### PR DESCRIPTION
**Description**
GitHub disabled support for the git protocol [1]. Use https instead.

Fixes:
> Cloning into 'opt/wait-for-it'...
> fatal: remote error:
>   The unauthenticated git protocol on port 9418 is no longer supported.

[1] https://github.blog/2021-09-01-improving-git-protocol-security-github/