### PR TITLE
crossbar-requirements: do not install werkzeug>=2.1

### DIFF
--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -2,3 +2,4 @@
 setuptools>=38.0.0
 crossbar==21.3.1
 idna==2.5
+werkzeug>=0.14.1,<2.1


### PR DESCRIPTION
**Description**
crossbar <= v22.3.1 and werkzeug v2.1.0 are not compatible. werkzeug deprecated `werkzeug.utils.escape` in v2.0.0 [1] and removed it in v2.1.0 [2]. crossbar still uses it, though:

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.2/x64/bin/crossbar", line 8, in <module>
    sys.exit(run())
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/crossbar/__init__.py", line 175, in run
    _personalities = personalities()
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/crossbar/__init__.py", line 213, in personalities
    from crossbar import personality as standalone
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/crossbar/personality.py", line 47, in <module>
    from crossbar.webservice import wsgi, rest, longpoll, websocket, misc, static, archive, wap
  File "/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/crossbar/webservice/wap.py", line 39, in <module>
    from werkzeug.utils import escape
ImportError: cannot import name 'escape' from 'werkzeug.utils' (/opt/hostedtoolcache/Python/3.10.2/x64/lib/python3.10/site-packages/werkzeug/utils.py)
```

Prevent installing werkzeug >= v2.1 until we update crossbar to a release that contains the werkzeug version constraint [3] or stops using `werkzeug.utils.escape`.

[1] https://github.com/pallets/werkzeug/commit/e13b8fba7ddc0d56b1266f439a190dd11aa40c0d
[2] https://werkzeug.palletsprojects.com/en/2.1.x/changes/#version-2-1-0
[3] https://github.com/crossbario/crossbar/pull/1974

**Checklist**
- [x] PR has been tested