### PR TITLE
Add support for more webcams and a generic fallback pipeline

### DIFF
--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -42,6 +42,12 @@ class USBVideoDriver(Driver, VideoProtocol):
                 ("mid", "image/jpeg,width=1280,height=720,framerate=30/1"),
                 ("high", "image/jpeg,width=1920,height=1080,framerate=30/1"),
                 ])
+        if match == (0x05a3, 0x9331): # WansView Webcam 102
+            return ("mid", [
+                ("low","video/x-h264,width=640,height=360,framerate=30/1"),
+                ("mid","video/x-h264,width=1280,height=720,framerate=30/1"),
+                ("high","video/x-h264,width=1920,height=1080,framerate=30/1"),
+                ])
         if match == (0x534d, 0x2109): # MacroSilicon
             return ("mid", [
                 ("low", "image/jpeg,width=720,height=480,framerate=10/1"),
@@ -79,6 +85,8 @@ class USBVideoDriver(Driver, VideoProtocol):
             inner = None
         elif match == (0x1224, 0x2825): # LogiLink UA0371
             inner = None  # just forward the jpeg frames
+        elif match == (0x05a3, 0x9331): # WansView Webcam 102
+            inner = "h264parse"
         elif match == (0x534d, 0x2109):
             inner = None  # just forward the jpeg frames
         elif match == (0x1d6c, 0x0103):

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -1,11 +1,13 @@
 # pylint: disable=no-member
 import subprocess
+
 import attr
 
-from .common import Driver
-from ..factory import target_factory
 from ..exceptions import InvalidConfigError
+from ..factory import target_factory
 from ..protocol import VideoProtocol
+from .common import Driver
+
 
 @target_factory.reg_driver
 @attr.s(eq=False)

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -36,6 +36,12 @@ class USBVideoDriver(Driver, VideoProtocol):
                 ("mid", "image/jpeg,width=1280,height=720,framerate=15/2"),
                 ("high", "image/jpeg,width=1920,height=1080,framerate=10/1"),
                 ])
+        if match == (0x1224, 0x2825): # LogiLink UA0371
+            return ("mid", [
+                ("low", "image/jpeg,width=640,height=480,framerate=30/1"),
+                ("mid", "image/jpeg,width=1280,height=720,framerate=30/1"),
+                ("high", "image/jpeg,width=1920,height=1080,framerate=30/1"),
+                ])
         if match == (0x534d, 0x2109): # MacroSilicon
             return ("mid", [
                 ("low", "image/jpeg,width=720,height=480,framerate=10/1"),
@@ -71,6 +77,8 @@ class USBVideoDriver(Driver, VideoProtocol):
         elif match == (0x046d, 0x08e5):
             controls = controls or "focus_auto=1"
             inner = None
+        elif match == (0x1224, 0x2825): # LogiLink UA0371
+            inner = None  # just forward the jpeg frames
         elif match == (0x534d, 0x2109):
             inner = None  # just forward the jpeg frames
         elif match == (0x1d6c, 0x0103):

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -546,6 +546,14 @@ class SiSPMPowerPort(USBResource):
 @target_factory.reg_resource
 @attr.s(eq=False)
 class USBVideo(USBResource):
+    def filter_match(self, device):
+        capabilities = device.properties.get('ID_V4L_CAPABILITIES').split(':')
+
+        if 'capture' not in capabilities:
+            return False
+
+        return super().filter_match(device)
+
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'video4linux'
         self.match['@SUBSYSTEM'] = 'usb'


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
This
- adds support for two additional webcam models
- fixes up the USBVideoDevice resource to export the correct video device for webcams that have multiple device nodes
- adds a generic fallback pipeline so many webcams are usable without having to adapt labgrid. The parameters are what I found in common in the `gst-device-monitor-1.0` output for both added webcams and my laptops internal webcam.
- a commit that i deem optional. It produces a verbose warning when using the fallback pipeline. I dislike the string indentation mess it leaves in the source code, but the error message looks as intended:
    ```
  WARNING: Unkown USB video device 1224:2825, using fallback pipeline. This might not
             work as expected.
             Consider adding support for your camera model to labgrid as described here:
             https://labgrid.readthedocs.io/en/latest/configuration.html#usbvideodriver
    ```
    This commit should either be dropped or squashed into the preciding one 

All changes have been tested locally.
- Before the [`resource/udev: filter USBVideoDevice to skip metadata only devices`](https://github.com/labgrid-project/labgrid/commit/b2a5436637079c2bf9a3686aaca1fe08512054bb) change the pipeline occasionally failed to start due to the wrong `/dev/videoX` being used. This has not happend since.
- The fallback pipeline works fine with the webcams I have available. Tested by removing the support for those models again. 


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
