### PR TITLE
tests: Enable labgrid-exporter without the executable

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -136,7 +136,7 @@ def exporter(tmpdir, crossbar):
     """
     )
     spawn = pexpect.spawn(
-            'labgrid-exporter exports.yaml',
+            f'{sys.executable} -m labgrid.remote.exporter exports.yaml',
             logfile=Prefixer(sys.stdout.buffer, 'exporter'),
             cwd=str(tmpdir))
     try:


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Lets you run the test suite without havin the labgrid-exporter installed in $PATH.

- [x] PR has been tested