### PR TITLE
remote/exporter: enable multiple ser2net connections

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -238,6 +238,8 @@ class SerialPortExport(ResourceExport):
                 '-n',
                 '-Y', f'connection: &con01#  accepter: telnet(rfc2217,mode=server),{self.port}',
                 '-Y', f'  connector: serialdev(nouucplock=true),{start_params["path"]},{self.local.speed}n81,local',  # pylint: disable=line-too-long
+                '-Y', f'  options:',
+                '-Y', f'    max-connections: 10',
             ]
         else:
             cmd = [


### PR DESCRIPTION
ser2net allows multiple, multiplexed connections.  Enable by default
with a max of 10.

RFC: this should probably be an optional feature, with the number a parameter, but this is just to show how it can be done.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>

