### PR TITLE
remote/exporter: support /usr/local/sbin/ser2net

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -196,6 +196,8 @@ class SerialPortExport(ResourceExport):
         if self.ser2net_bin is None:
             if os.path.isfile("/usr/sbin/ser2net"):
                 self.ser2net_bin = "/usr/sbin/ser2net"
+            elif os.path.isfile("/usr/local/sbin/ser2net"):
+                self.ser2net_bin = "/usr/local/sbin/ser2net"
 
             if self.ser2net_bin is None:
                 warnings.warn("ser2net binary not found, falling back to /usr/bin/ser2net")


### PR DESCRIPTION
Locally modified/compiled installs of ser2net could be in
/usr/local, allow that as a fallback when not found in
the other locations.

Signed-off-by: Kevin Hilman <khilman@baylibre.com>
