### PR TITLE
mqtt: Make availability payload more generic

### DIFF
--- a/labgrid/resource/mqtt.py
+++ b/labgrid/resource/mqtt.py
@@ -37,10 +37,10 @@ class MQTTManager(ResourceManager):
     def _on_message(self, client, userdata, msg):
         payload = msg.payload.decode('utf-8')
         topic = msg.topic
-        if payload == "Online":
+        if payload.lower() == "online":
             with self._avail_lock:
                 self._available.add(topic)
-        if payload == "Offline":
+        elif payload.lower() == "offline":
             with self._avail_lock:
                 self._available.discard(topic)
 


### PR DESCRIPTION
The mqtt availability payload is really device-specific; Tasmota uses `Online` and `Offline`, whereas ESPHome uses `online` and `offline`. Let's make MQTTManager a little bit more device-agnostic and allow both cases to satisfy the criteria.

Signed-off-by: Christopher Obbard <chris.obbard@collabora.com>

---

This is the minimum change required to support ESPhome firmware as a `TasmotaPowerPort`. I think it makes sense to change the availability payload detection where I have done it.

PS: Let me know if also like to have a separate driver called `ESPHomePowerPort` or similar, I can do a separate commit on top