### PR TITLE
Fix Udev Attribute matching

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -28,6 +28,7 @@ Bug fixes in 0.5.0
 - Fixed ``labgrid-client forward --remote``/``-R``, which used either the LOCAL
   part of ``--local``/``-L`` accidentally (if specified) or raised an
   UnboundLocalError.
+- Fix udev matching by attributes
 
 Breaking changes in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -109,7 +109,7 @@ class USBResource(ManagedResource):
             def match_single(dev, key, value):
                 if dev.properties.get(key) == value:
                     return True
-                if dev.attributes.get(key) == value:
+                if dev.attributes.get(key) and dev.attributes.asstring(key) == value:
                     return True
                 if getattr(dev, key, None) == value:
                     return True


### PR DESCRIPTION


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Udev matching by ATTR(S){} does currently not work on my machine.

I found the issue because I have a 4-port usb-to-serial device where I can only determine the ports by looking at the attributes. 
This is also the device I used for testing locally.

After some search I found that pyudev internally stores attributes as bytes, not strings.
To compare them with the expectation when doing udev matching, they need to be encoded.
Luckily, pyudev already has a function for that, just without a default value. 

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
