### PR TITLE
smallubootdriver: allow sending of boot_secret without new line

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ New Features in 0.5.0
   automate the cleanup of unused places (e.g. in CI jobs)
 - ModbusTCPCoil driver supports writing using multiple coils write method
   in order to make driver usable with Papouch Quido I/O modules
+- SmallUBootDriver driver now supports wide range of Ralink/mt7621 devices
+  which expects ``boot_secret`` without new line with new ``boot_secret_nolf``
+  boolean config option.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -42,10 +42,12 @@ class SmallUBootDriver(UBootDriver):
 
     Args:
         boot_secret (str): optional, secret used to unlock prompt
+        boot_secret_nolf (bool): optional, send boot_secret without new line
         login_timeout (int): optional, timeout for login prompt detection,
     """
 
     boot_secret = attr.ib(default="a", validator=attr.validators.instance_of(str))
+    boot_secret_nolf = attr.ib(default=False, validator=attr.validators.instance_of(bool))
     login_timeout = attr.ib(default=60, validator=attr.validators.instance_of(int))
 
     @step()
@@ -57,7 +59,10 @@ class SmallUBootDriver(UBootDriver):
 
         # wait for boot expression. Afterwards enter secret
         self.console.expect(self.boot_expression, timeout=self.login_timeout)
-        self.console.sendline(self.boot_secret)
+        if self.boot_secret_nolf:
+            self.console.write(self.boot_secret.encode('ASCII'))
+        else:
+            self.console.sendline(self.boot_secret)
         self._status = 1
 
         # wait until UBoot has reached it's prompt


### PR DESCRIPTION
**Description**

By default SmallUBootDriver sends `boot_secret` terminated with new
line, which works fine on multitude of devices, but fails for example on
quite popular ralink/mt7621 based Ubiquiti ER-X devices, where
bootloader offers following boot menu:

 Please choose the operation:
  1: Load system code to SDRAM via TFTP.
  2: Load system code then write to Flash via TFTP.
  3: Boot system code via Flash (default).
  4: Entr boot command line interface.
  7: Load Boot Loader code then write to Flash via Serial.
  9: Load Boot Loader code then write to Flash via TFTP.
  r: Start TFTP recovery.

and expects only single character choice, otherwise uses default choice
3, but in order to control such DUTs we need to enter boot prompt by
selecting choice 4. and thus sending `4` verbatim, without new line.

So allow usage of SmallUBootDriver on such devices by introducing
`boot_secret_nolf` boolean config option, which when set to `True` sends
`boot_secret` without new line character.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested
