### PR TITLE
Add instructions to update pip when setting up a virtualenv for labgrid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,19 +83,21 @@ Create and activate a virtualenv for labgrid:
 
    $ virtualenv -p python3 venv
    $ source venv/bin/activate
+   venv $ pip install --upgrade pip setuptools wheel
+
 
 Install labgrid into the virtualenv:
 
 .. code-block:: bash
 
-   $ pip install -r requirements.txt
-   $ python setup.py install
+   venv $ pip install -r requirements.txt
+   venv $ python setup.py install
 
 Tests can now run via:
 
 .. code-block:: bash
 
-   $ python -m pytest --lg-env <config>
+   venv $ python -m pytest --lg-env <config>
 
 
 .. |license| image:: https://img.shields.io/badge/license-LGPLv2.1-blue.svg

--- a/doc/RELEASE.rst
+++ b/doc/RELEASE.rst
@@ -83,6 +83,7 @@ Test the upload by using pypi dev as a download source
 
    virtualenv -p python3 labgrid-release-<your-version-number>
    source labgrid-release-<your-version-number>/bin/activate
+   pip install --upgrade pip setuptools wheel
    pip install --index-url https://test.pypi.org/simple/ labgrid
 
 And optionally run the tests:

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -17,6 +17,7 @@ Create and activate a virtualenv for labgrid:
 
    virtualenv -p python3 venv
    source venv/bin/activate
+   pip install --upgrade pip setuptools wheel
 
 Install required dependencies:
 
@@ -676,10 +677,11 @@ Building the documentation
 When contributing to documentation it's practical to be able to build it also locally.
 
 .. code-block:: bash
-    
+
     # Optional - install requirements in a virtualenv
     virtualenv -p python3 labgrid-venv
     source labgrid-venv/bin/activate
+    pip install --upgrade pip setuptools wheel
 
     git clone https://github.com/labgrid-project/labgrid.git
     cd labgrid

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -23,6 +23,7 @@ In many cases, the easiest way is to install labgrid into a virtualenv:
 
     $ virtualenv -p python3 labgrid-venv
     $ source labgrid-venv/bin/activate
+    labgrid-venv $ pip install --upgrade pip setuptools wheel
 
 Start installing labgrid by cloning the repository and installing the
 requirements from the `requirements.txt` file:
@@ -178,6 +179,7 @@ extra virtualenv and install the dependencies via the requirements file.
     $ sudo apt install libsnappy-dev
     $ virtualenv -p python3 crossbar-venv
     $ source crossbar-venv/bin/activate
+    crossbar-venv $ pip install --upgrade pip setuptools wheel
     crossbar-venv $ git clone https://github.com/labgrid-project/labgrid
     crossbar-venv $ cd labgrid && pip install -r crossbar-requirements.txt
     crossbar-venv $ python setup.py install


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Extend Documentation to update pip when creating a new virtualenv. The dependency resolver of older pip versions (at least until 2.0.2, as shipped with Ubuntu 20.04) is not able to install the current set of required versions. 

Fixes #919

