### PR TITLE
doc: configuration: add missing AndroidFastboot arguments

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -616,6 +616,10 @@ An AndroidFastboot resource describes a USB device in the fastboot state.
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
 Arguments:
+  - usb_vendor_id (str, default="1d6b"): USB vendor ID to be compared with the
+    ``ID_VENDOR_ID`` udev property
+  - usb_product_id (str, default="0104"): USB product ID, to be compared with
+    the ``ID_MODEL_ID`` udev property
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 
 Used by:


### PR DESCRIPTION
**Description**
Add the AndroidFastboot arguments `usb_vendor_id` and `usb_product_id` to the docs.

**Checklist**
- [x] The arguments and description in doc/configuration.rst have been updated

Fixes #923

