### PR TITLE
remote/config: Add more templating variables, like the hostname and exporter name

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Release 0.5.0 (unreleased)
 
 New Features in 0.5.0
 ~~~~~~~~~~~~~~~~~~~~~
+- Exporter config templates now have access to the following new variables:
+  isolated (all resource accesses must be tunneled True/False),
+  hostname (of the exporter host), name (of the exporter).
 - ModbusRTU driver for instruments
 - Support for Eaton ePDU and TP-Link power strips added, either can be used as a NetworkPowerPort.
 - Consider a combination of multiple "lg_feature" markers instead of

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3116,5 +3116,16 @@ Statements like ``{{ 4000 + idx }}`` are expanded based on variables in the
 Jinja2 template.
 
 The template processing also supports use of OS environment variables, using
-something like `{{ env['FOOBAR'] }}` to insert the content of environment
-variable `FOOBAR`.
+something like ``{{ env['FOOBAR'] }}`` to insert the content of environment
+variable ``FOOBAR``.
+In addition to ``env`` the template also has access to the following variables:
+
+isolated
+  ``True`` or ``False``, depending on the :code:`--isolated` command line option.
+
+hostname
+  The hostname of the exporter host. Can be used to e.g. construct URLs to the
+  current host (``http://{{ hostname }}/``).
+
+name
+  The name of the exporter.

--- a/labgrid/remote/config.py
+++ b/labgrid/remote/config.py
@@ -12,6 +12,9 @@ from ..exceptions import NoConfigFoundError
 @attr.s(eq=False)
 class ResourceConfig:
     filename = attr.ib(validator=attr.validators.instance_of(str))
+    template_env = attr.ib(
+        default=attr.Factory(dict), validator=attr.validators.instance_of(dict)
+    )
 
     def __attrs_post_init__(self):
         env = jinja2.Environment(
@@ -26,7 +29,7 @@ class ResourceConfig:
             raise NoConfigFoundError(
                 f"{self.filename} could not be found"
             )
-        rendered = template.render(env=os.environ)
+        rendered = template.render(self.template_env)
         pprint(('rendered', rendered))
         self.data = load(rendered)
         pprint(('loaded', self.data))

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -705,7 +705,15 @@ class ExporterSession(ApplicationSession):
         await self.register(self.version, f'{prefix}.version')
 
         try:
-            resource_config = ResourceConfig(self.config.extra['resources'])
+            config_template_env = {
+                'env': os.environ,
+                'isolated': self.isolated,
+                'hostname': self.hostname,
+                'name': self.name,
+            }
+            resource_config = ResourceConfig(
+                self.config.extra['resources'], config_template_env
+            )
             for group_name, group in resource_config.data.items():
                 group_name = str(group_name)
                 for resource_name, params in group.items():


### PR DESCRIPTION
Previously you could only use os.environ in your resource config templates. Add exporter name, hostname and isolation status to the mix. This allows you to e.g. export network resources on the host this exporter is running on:

    dut_power:
      NetworkPowerPort:
        model: rest
        host: 'http://{{ hostname }}/dut/enable'
        index: '0'

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature
  I did not find a suitable existing test to extend and don't really have the appropriate project knowledge to add a completely new one.
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
  I've used it to construct an URL containing the hostname, as show above.