### PR TITLE
remote/coordinator: switch to using the custom yaml loader/dumper

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -9,14 +9,13 @@ from enum import Enum
 from functools import wraps
 
 import attr
-import yaml
 from autobahn import wamp
 from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 from autobahn.wamp.types import RegisterOptions
 
 from .common import *
 from .scheduler import TagSet, schedule
-from ..util import atomic_replace
+from ..util import atomic_replace, yaml
 
 
 class Action(Enum):
@@ -297,10 +296,10 @@ class CoordinatorComponent(ApplicationSession):
         self.save_scheduled = False
 
         resources = self._get_resources()
-        resources = yaml.dump(resources, default_flow_style=False)
+        resources = yaml.dump(resources)
         resources = resources.encode()
         places = self._get_places()
-        places = yaml.dump(places, default_flow_style=False)
+        places = yaml.dump(places)
         places = places.encode()
 
         loop = asyncio.get_event_loop()

--- a/labgrid/util/yaml.py
+++ b/labgrid/util/yaml.py
@@ -63,11 +63,12 @@ def load(stream):
     return yaml.load(stream, Loader=Loader)
 
 
-def dump(data, stream=None):
+def dump(data, stream=None, **kwargs):
     """
     Wrapper for yaml dump function with custom dumper.
     """
-    return yaml.dump(data, stream, Dumper=Dumper, default_flow_style=False)
+    kwargs.pop("Dumper", None)
+    return yaml.dump(data, stream, Dumper=Dumper, **kwargs)
 
 
 def resolve_templates(data, mapping):

--- a/labgrid/util/yaml.py
+++ b/labgrid/util/yaml.py
@@ -23,6 +23,10 @@ def _dict_constructor(loader, node):
 Loader.add_constructor(
     yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _dict_constructor
 )
+Loader.add_constructor(
+    "tag:yaml.org,2002:python/tuple",
+    yaml.constructor.FullConstructor.construct_python_tuple,
+)
 
 
 def _dict_representer(dumper, data):

--- a/labgrid/util/yaml.py
+++ b/labgrid/util/yaml.py
@@ -7,10 +7,14 @@ from string import Template
 
 import yaml
 
+
 class Loader(yaml.SafeLoader):
     pass
+
+
 class Dumper(yaml.SafeDumper):
     pass
+
 
 def _dict_constructor(loader, node):
     return OrderedDict(loader.construct_pairs(node))


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Using `yaml.load()` without specifying a loader has been deprecated since 5.1. As such this series changes `remote/coordinator` to make use of the custom yaml loader/dumper within `util/yaml`, which ultimately results in use of the SafeLoader and the SafeDumper. Previously however the coordinator will have `yaml.dump`ed tuples with the `python/tuple` tag, which the SafeLoader will not load, in order to not break any existing deployments on upgrade this series also adds the tuple constructor to the custom loader.

Additionally does a little miscellaneous tidying within `util/yaml`, including changing `dump()` to take kwargs.

I've tested this series against a local deployment of a labgrid coordinator and exporter.

**Checklist**
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested