### PR TITLE
man: fix crossbar option, add missing subcommands

### DIFF
--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -51,7 +51,7 @@ display command line help
 .BI \-p \ PLACE\fR,\fB \ \-\-place \ PLACE
 specify the place to operate on
 .TP
-.B  \-x\fP,\fB  \-\-crossbar\-url
+.BI \-x \ URL\fR,\fB \ \-\-crossbar \ URL
 the crossbar url of the coordinator, defaults to \fBws://127.0.0.1:20408/ws\fP
 .TP
 .BI \-c \ CONFIG\fR,\fB \ \-\-config \ CONFIG
@@ -176,9 +176,13 @@ not at all.
 .sp
 \fBfastboot\fP arg                Run fastboot with argument
 .sp
+\fBflashscript\fP script arg      Run arbitrary script with arguments to flash device
+.sp
 \fBbootstrap\fP filename          Start a bootloader
 .sp
 \fBsd\-mux\fP action               Switch USB SD Muxer, where action is one of dut (device\-under\-test), host, off
+.sp
+\fBusb\-mux\fP action              Switch USB Muxer, where action is one of off, dut\-device, host\-dut, host\-device, host\-dut+host\-device
 .sp
 \fBssh\fP                         Connect via SSH
 .sp
@@ -188,9 +192,13 @@ not at all.
 .sp
 \fBsshfs\fP                       Mount a remote path via sshfs
 .sp
+\fBforward\fP                     Forward local port to remote target
+.sp
 \fBtelnet\fP                      Connect via telnet
 .sp
 \fBvideo\fP                       Start a video stream
+.sp
+\fBaudio\fP                       Start an audio stream
 .sp
 \fBtmc\fP command                 Control a USB TMC device
 .sp
@@ -203,6 +211,8 @@ not at all.
 \fBwait\fP token                  Wait for a reservation to be allocated
 .sp
 \fBreservations\fP                List current reservations
+.sp
+\fBexport\fP filename             Export driver information to file (needs environment with drivers)
 .SH ADDING NAMED RESOURCES
 .sp
 If a target contains multiple Resources of the same type, named matches need to

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -167,9 +167,13 @@ LABGRID-CLIENT COMMANDS
 
 ``fastboot`` arg                Run fastboot with argument
 
+``flashscript`` script arg      Run arbitrary script with arguments to flash device
+
 ``bootstrap`` filename          Start a bootloader
 
 ``sd-mux`` action               Switch USB SD Muxer, where action is one of dut (device-under-test), host, off
+
+``usb-mux`` action              Switch USB Muxer, where action is one of off, dut-device, host-dut, host-device, host-dut+host-device
 
 ``ssh``                         Connect via SSH
 
@@ -179,9 +183,13 @@ LABGRID-CLIENT COMMANDS
 
 ``sshfs``                       Mount a remote path via sshfs
 
+``forward``                     Forward local port to remote target
+
 ``telnet``                      Connect via telnet
 
 ``video``                       Start a video stream
+
+``audio``                       Start an audio stream
 
 ``tmc`` command                 Control a USB TMC device
 
@@ -194,6 +202,8 @@ LABGRID-CLIENT COMMANDS
 ``wait`` token                  Wait for a reservation to be allocated
 
 ``reservations``                List current reservations
+
+``export`` filename             Export driver information to file (needs environment with drivers)
 
 ADDING NAMED RESOURCES
 ----------------------

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -38,7 +38,7 @@ OPTIONS
     display command line help
 -p PLACE, --place PLACE
     specify the place to operate on
--x, --crossbar-url
+-x URL, --crossbar URL
     the crossbar url of the coordinator, defaults to ``ws://127.0.0.1:20408/ws``
 -c CONFIG, --config CONFIG
     set the configuration file

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -47,7 +47,7 @@ USB devices and various other controllers.
 .B  \-h\fP,\fB  \-\-help
 display command line help
 .TP
-.B  \-x\fP,\fB  \-\-crossbar\-url
+.B  \-x\fP,\fB  \-\-crossbar
 the crossbar url of the coordinator
 .TP
 .B  \-i\fP,\fB  \-\-isolated

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -38,7 +38,7 @@ OPTIONS
 -------
 -h, --help
     display command line help
--x, --crossbar-url
+-x, --crossbar
     the crossbar url of the coordinator
 -i, --isolated
     enable isolated mode (always request SSH forwards)


### PR DESCRIPTION
**Description**
- fix long crossbar option for `labgrid-client`/`labgrid-exporter`
- add missing `labgrid-client` subcommands

**Checklist**
- [x] Man pages have been regenerated

Fixes: #28