### PR TITLE
Introduce DFUDevice, DFUDriver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,9 @@ New Features in 0.5.0
   which expects ``boot_secret`` without new line with new ``boot_secret_nolf``
   boolean config option.
 - labgrid-client add-match/add-named-match check for duplicate matches
+- `DFUDriver` has been added to communicate with a `DFUDevice`, a device in DFU
+  (Device Firmware Upgrade) mode.
+- ``labgrid-client dfu`` added to allow communcation with devices in DFU mode.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -625,6 +625,23 @@ Arguments:
 Used by:
   - `AndroidFastbootDriver`_
 
+DFUDevice
+~~~~~~~~~
+A DFUDevice resource describes a USB device in DFU (Device Firmware Upgrade)
+mode.
+
+.. code-block:: yaml
+
+   DFUDevice:
+     match:
+       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+
+Arguments:
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - `DFUDriver`_
+
 USBNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~
 A USBNetworkInterface resource describes a USB network adapter (such as

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1573,6 +1573,25 @@ Arguments:
     same as the fastboot default, which is computed after querying the target's
     ``max-download-size`` variable.
 
+DFUDriver
+~~~~~~~~~
+A DFUDriver allows the download of images to a device in DFU (Device Firmware
+Upgrade) mode.
+
+Binds to:
+  dfu:
+    - `DFUDevice`_
+
+Implements:
+  - None (yet)
+
+.. code-block:: yaml
+
+   DFUDriver: {}
+
+Arguments:
+  - None
+
 OpenOCDDriver
 ~~~~~~~~~~~~~
 An OpenOCDDriver controls OpenOCD to bootstrap a target with a bootloader.

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -7,6 +7,7 @@ from .sshdriver import SSHDriver
 from .externalconsoledriver import ExternalConsoleDriver
 from .exception import CleanUpError, ExecutionError
 from .fastbootdriver import AndroidFastbootDriver
+from .dfudriver import DFUDriver
 from .openocddriver import OpenOCDDriver
 from .quartushpsdriver import QuartusHPSDriver
 from .flashromdriver import FlashromDriver

--- a/labgrid/driver/dfudriver.py
+++ b/labgrid/driver/dfudriver.py
@@ -1,0 +1,60 @@
+# pylint: disable=no-member
+import attr
+
+from ..factory import target_factory
+from ..step import step
+from .common import Driver
+from ..util.managedfile import ManagedFile
+from ..util.helper import processwrapper
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class DFUDriver(Driver):
+    bindings = {
+        "dfu": {"DFUDevice", "NetworkDFUDevice"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        # FIXME make sure we always have an environment or config
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('dfu-util') or 'dfu-util'
+        else:
+            self.tool = 'dfu-util'
+
+    def _get_dfu_prefix(self):
+        return self.dfu.command_prefix + [
+            self.tool,
+            "-p", self.dfu.path,
+        ]
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    @Driver.check_active
+    @step(args=['altsetting', 'filename'])
+    def download(self, altsetting, filename):
+        mf = ManagedFile(filename, self.dfu)
+        mf.sync_to_resource()
+
+        processwrapper.check_output(
+            self._get_dfu_prefix() + ['--alt', str(altsetting), '--download', mf.get_remote_path()],
+            print_on_silent_log=True
+        )
+
+    @step()
+    def detach(self, altsetting):
+        processwrapper.check_output(
+            self._get_dfu_prefix() + ['--alt', str(altsetting), '--detach']
+        )
+
+    @step()
+    def list(self):
+        processwrapper.check_output(
+            self._get_dfu_prefix() + ['--list'],
+            print_on_silent_log=True
+        )

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -492,6 +492,7 @@ class USBFlashableExport(USBGenericExport):
         return p
 
 exports["AndroidFastboot"] = USBGenericExport
+exports["DFUDevice"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
 exports["MXSUSBLoader"] = USBGenericExport
 exports["RKUSBLoader"] = USBGenericExport

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -121,6 +121,14 @@ class NetworkAndroidFastboot(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkDFUDevice(RemoteUSBResource):
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkIMXUSBLoader(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -11,6 +11,7 @@ from .udev import (
     USBVideo,
     IMXUSBLoader,
     AndroidFastboot,
+    DFUDevice,
     USBSDMuxDevice,
     USBSDWireDevice,
     AlteraUSBBlaster,
@@ -41,6 +42,7 @@ class Suggester:
         self.resources.append(USBVideo(**args))
         self.resources.append(IMXUSBLoader(**args))
         self.resources.append(AndroidFastboot(**args))
+        self.resources.append(DFUDevice(**args))
         self.resources.append(USBMassStorage(**args))
         self.resources.append(USBSDMuxDevice(**args))
         self.resources.append(USBSDWireDevice(**args))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -324,6 +324,15 @@ class AndroidFastboot(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class DFUDevice(USBResource):
+    def filter_match(self, device):
+        if ':fe0102:' not in device.properties.get('ID_USB_INTERFACES', ''):
+            return False
+
+        return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class USBNetworkInterface(USBResource, NetworkInterface):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'net'

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -174,6 +174,8 @@ not at all.
 .sp
 \fBconsole (con)\fP               Connect to the console
 .sp
+\fBdfu\fP arg                     Run dfu commands
+.sp
 \fBfastboot\fP arg                Run fastboot with argument
 .sp
 \fBbootstrap\fP filename          Start a bootloader

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -165,6 +165,8 @@ LABGRID-CLIENT COMMANDS
 
 ``console (con)``               Connect to the console
 
+``dfu`` arg                     Run dfu commands
+
 ``fastboot`` arg                Run fastboot with argument
 
 ``bootstrap`` filename          Start a bootloader


### PR DESCRIPTION
**Description**
Add a resource, driver and client sub command to communicate with devices in DFU (Device Firmware Upgrade) mode. labgrid uses the [dfu-util tool](http://dfu-util.sourceforge.net/).

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated