### PR TITLE
remote/client: no block in async console, loop even on unavailable resource

### DIFF
--- a/labgrid/util/timeout.py
+++ b/labgrid/util/timeout.py
@@ -11,7 +11,7 @@ class Timeout:
     )
 
     def __attrs_post_init__(self):
-        if self.timeout <= 0.0:
+        if self.timeout < 0.0:
             raise ValueError("timeout must be positive")
         self._deadline = time.monotonic() + self.timeout
 


### PR DESCRIPTION
**Description**
`labgrid-client console --loop` should keep trying to connect to the console even if the serial port is currently unvailable.
The console method is declared async because it needs to handle crossbar communication with the coordinator concurrently, see [1] (e.g. place kicks, resouces becoming available).

Until now it only tries again if microcom comes back with a return code != 0. But in case the resource is unavailable, labgrid bails out early because `target.get_resource()` raises a `NoResourceFoundError`.

Calling `target.get_resource()` waits until the resources are available by default. This is done in a blocking `poll()`/`time.sleep()` loop until a timeout is reached allowing no crossbar communication in the meantime. This again means changes in resource availability we wait for cannot arrive. So there is no point in waiting for them at all.

Fix that by awaiting the `NetworkSerialPort` resource while allowing other tasks to run when `--loop` is given. Afterwards "wait" for the `NetworkSerialPort` for 0 seconds. This either succeeds or a `NoResourceFoundError` is raised, both happens instantly. To make this work, instant `Timeout(0.0)` is now allowed. 

[1] 19757a18 ("remote/client: close console connection on place release")

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #926