### PR TITLE
driver/usbvideodriver: add support for AUKEY PC-LM1E

### DIFF
--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -66,6 +66,12 @@ class USBVideoDriver(Driver, VideoProtocol):
                 ("mid", "video/x-h264,width=1280,height=720,framerate=25/1"),
                 ("high", "video/x-h264,width=1920,height=1080,framerate=25/1"),
                 ])
+        if match == (0x0c45, 0x636d): # AUKEY PC-LM1E
+            return ("mid", [
+                ("low", "image/jpeg,width=640,height=480,pixel-aspect-ratio=1/1,framerate=30/1"),
+                ("mid", "image/jpeg,width=864,height=480,pixel-aspect-ratio=1/1,framerate=30/1"),
+                ("high", "image/jpeg,width=1280,height=1024,pixel-aspect-ratio=1/1,framerate=30/1"),
+                ])
         self.logger.warning(
             "Unkown USB video device {:04x}:{:04x}, using fallback pipeline."
             .format(*match))
@@ -105,6 +111,9 @@ class USBVideoDriver(Driver, VideoProtocol):
         elif match == (0x1d6c, 0x0103):
             controls = controls or "focus_auto=1"
             inner = "h264parse"
+        elif match == (0x0c54, 0x636d):
+            controls = controls or "focus_auto=1"
+            inner = None  # just forward the jpeg frames
         else: # fallback pipeline
             inner = None  # just forward the jpeg frames
 


### PR DESCRIPTION
**Description**

Add support for the AUKEY PC-LM1E camera

**Checklist**

- [x] PR has been tested.  Patch was based on 1d1cecb (base of our current labgrid installation) and then been rebased onto master 