### PR TITLE
driver/qemudriver: let _read() handle max_size kwarg

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -231,13 +231,15 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 "Can't use monitor command on non-running target")
         return self.qmp.execute(command)
 
-    def _read(self, size=1, timeout=10):
+    def _read(self, size=1, timeout=10, max_size=None):
         ready, _, _ = select.select([self._clientsocket], [], [], timeout)
         if ready:
             # Collect some more data
             time.sleep(0.01)
             # Always read a page, regardless of size
-            res = self._clientsocket.recv(4096)
+            size = 4096
+            size = min(max_size, size) if max_size else size
+            res = self._clientsocket.recv(size)
         else:
             raise TIMEOUT(f"Timeout of {timeout:.2f} seconds exceeded")
         return res

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -41,9 +41,46 @@ def qemu_driver(qemu_target):
         rootfs='rootfs')
     return q
 
+@pytest.fixture
+def qemu_mock(mocker):
+    popen_mock = mocker.patch('subprocess.Popen')
+    popen_mock.return_value.wait.return_value = 0
+    popen_mock.return_value.stdout.readline.return_value = b"""
+    {
+      "QMP": {
+        "version": {}
+      },
+      "return": {}
+    }
+    """
+
+    select_mock = mocker.patch('select.select')
+    select_mock.return_value = True, None, None
+
+    socket_mock = mocker.patch('socket.socket')
+    socket_mock.return_value.accept.return_value = mocker.MagicMock(), ''
+
 def test_qemu_instance(qemu_target, qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
 
 def test_qemu_activate_deactivate(qemu_target, qemu_driver):
     qemu_target.activate(qemu_driver)
+    qemu_target.deactivate(qemu_driver)
+
+def test_qemu_on_off(qemu_target, qemu_driver, qemu_mock):
+    qemu_target.activate(qemu_driver)
+
+    qemu_driver.on()
+    qemu_driver.off()
+
+    qemu_target.deactivate(qemu_driver)
+
+def test_qemu_read_write(qemu_target, qemu_driver, qemu_mock):
+    qemu_target.activate(qemu_driver)
+
+    qemu_driver.on()
+    qemu_driver.read()
+    qemu_driver.read(max_size=10)
+    qemu_driver.write(b'abc')
+
     qemu_target.deactivate(qemu_driver)


### PR DESCRIPTION
**Description**
#912 introduced the new kwarg `max_size` in `ConsoleExpectMixin` which is passed through to the driver's internal `_read()` method. The `QEMUDriver` was not adjusted accordingly, so do that now.

While at it, add tests for the `QEMUDriver` to prevent such issues in the future.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested

Fixes #912