### PR TITLE
remote/client: update resources before checking NetworkSerialPort availability

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -856,8 +856,10 @@ class ClientSession(ApplicationSession):
 
         # async await resources
         timeout = Timeout(timeout)
-        while not resource.avail and (loop or not timeout.expired):
+        while True:
             target.update_resources()
+            if resource.avail or (not loop and timeout.expired):
+                break
             await asyncio.sleep(0.1)
 
         # use zero timeout to prevent blocking sleeps


### PR DESCRIPTION
**Description**
PR #935 added async waiting for the NetworkSerialPort. This makes `labgrid-client console --loop` work as long as the resource changes from being unavailable to being available. It does not work vice versa, however: the resources are not being updated before being checked for availability. The code inside the while loop does not run in this case.
This makes the subsequent `target.await_resources()` raise a NoResourceFoundError which is not handled anywhere causing an error message and exit of labgrid-client despite being called with ``--loop``.

Fix that by updating the resources before checking the resource's availability. `labgrid-client console --loop` will now loop even if the NetworkSerialPort changes from being available to unavailable.

**Checklist**
- [x] PR has been tested

Fixes #935
Fixes #926