### PR TITLE
ubootdriver: allow handling of console output decoding errors 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ New Features in 0.5.0
 - `DFUDriver` has been added to communicate with a `DFUDevice`, a device in DFU
   (Device Firmware Upgrade) mode.
 - ``labgrid-client dfu`` added to allow communcation with devices in DFU mode.
+- UBootDriver and SmallUBootDriver now allows overriding of console output
+  decoding errors via new ``console_decodeerrors`` config option.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -68,7 +68,7 @@ class SmallUBootDriver(UBootDriver):
         # wait until UBoot has reached it's prompt
         self.console.expect(self.prompt)
         for command in self.init_commands:  #pylint: disable=not-an-iterable
-            self._run(command)
+            self._run(command, decodeerrors=self.console_decodeerrors)
 
     def _run(self, cmd: str, *, timeout: int = 30, codec: str = "utf-8", decodeerrors: str = "strict"):  # pylint: disable=unused-argument,line-too-long
         """

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -78,7 +78,6 @@ class SmallUBootDriver(UBootDriver):
         Arguments:
         cmd - Command to run
         """
-        # TODO: use codec, decodeerrors
 
         # Check if Uboot is in command line mode
         if self._status != 1:
@@ -97,7 +96,7 @@ class SmallUBootDriver(UBootDriver):
         _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)
 
         data = self.re_vt100.sub(
-            '', before.decode('utf-8'), count=1000000
+            '', before.decode(codec, decodeerrors), count=1000000
         ).replace("\r", "").split("\n")
         data = data[1:]
         data = data[data.index(f"Unknown command 'echo{marker}' - try 'help'") +1 :]

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -71,7 +71,6 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         self._status = 0
 
     def _run(self, cmd: str, *, timeout: int = 30, codec: str = "utf-8", decodeerrors: str = "strict"):  # pylint: disable=unused-argument,line-too-long
-        # TODO: use codec, decodeerrors
         # TODO: Shell Escaping for the U-Boot Shell
         marker = gen_marker()
         cmp_command = f"""echo '{marker[:4]}''{marker[4:]}'; {cmd}; echo "$?"; echo '{marker[:4]}''{marker[4:]}';"""  # pylint: disable=line-too-long
@@ -80,7 +79,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
             _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)
             # Remove VT100 Codes and split by newline
             data = self.re_vt100.sub(
-                '', before.decode('utf-8'), count=1000000
+                '', before.decode(codec, decodeerrors), count=1000000
             ).replace("\r", "").split("\n")
             self.logger.debug("Received Data: %s", data)
             # Remove first element, the invoked cmd

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -32,6 +32,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         boot_command (str): optional boot command to boot target
         login_timeout (int): optional, timeout for login prompt detection
         boot_timeout (int): optional, timeout for initial Linux Kernel version detection
+        console_decodeerrors (str): optional, handling of console byte decoding errors
 
     """
     bindings = {"console": ConsoleProtocol, }
@@ -46,6 +47,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     boot_command = attr.ib(default="run bootcmd", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
     boot_timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
+    console_decodeerrors = attr.ib(default="strict", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -104,7 +106,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
         Returns:
             Tuple[List[str],List[str], int]: if successful, None otherwise
         """
-        return self._run(cmd, timeout=timeout)
+        return self._run(cmd, decodeerrors=self.console_decodeerrors, timeout=timeout)
 
     def get_status(self):
         """Retrieve status of the UBootDriver.
@@ -167,7 +169,7 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
             self._check_prompt()
 
         for command in self.init_commands:  #pylint: disable=not-an-iterable
-            self._run_check(command)
+            self._run_check(command, decodeerrors=self.console_decodeerrors)
 
     @Driver.check_active
     @step()

--- a/tests/test_ubootdriver.py
+++ b/tests/test_ubootdriver.py
@@ -28,7 +28,7 @@ class TestUBootDriver:
         d._run.reset_mock()
         res = d.run("test")
         assert res == (['success'], [], 0)
-        d._run.assert_called_once_with("test", timeout=30)
+        d._run.assert_called_once_with("test", decodeerrors='strict', timeout=30)
 
     def test_uboot_run_error(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
@@ -42,4 +42,4 @@ class TestUBootDriver:
         d._run.reset_mock()
         res = d.run("test")
         assert res == (['error'], [], 1)
-        d._run.assert_called_once_with("test", timeout=30)
+        d._run.assert_called_once_with("test", decodeerrors='strict', timeout=30)


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

ubootdriver: allow handling of console output decoding errors

Some buggy vendor bootloaders can output non ASCII characters to the
serial console:

```shell
 00001e50  74 68 20 6e 61 6d 65 20  5b 58 38 36 5f 36 34 20  |th name [X86_64 |
 00001e60  4c 45 44 45 20 4c 69 6e  75 78 2d 73 73 68 5f 5f  |LEDE Linux-ssh__|
 00001e70  5f 67 69 74 5f 64 65 73  69 1f 8b 08 5d 0d 0d 0a  |_git_desi...]...|
                                       |
                                       `-- printf buffer overflow starts here
```

Which leads to the following decoding issue as the default error handler
is set to `strict`:

```python
    '', before.decode('utf-8'), count=1000000
 UnicodeDecodeError: 'utf-8' codec can't decode byte 0x8b in position 6453: invalid start byte
```

So fix it by allowing overriding of console output decoding errors via
new `console_decodeerrors` config option, so one could use for example
`backslashreplace` decoding error handler.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
<!---
A library feature which other developers can use:
--->
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->