### PR TITLE
path too long error fix

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -81,7 +81,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def _start_own_master_once(self, timeout):
 
-        self.tmpdir = tempfile.mkdtemp(prefix='labgrid-ssh-tmp-')
+        self.tmpdir = tempfile.mkdtemp(prefix='lg-ssh-')
         control = os.path.join(
             self.tmpdir, f'control-{self.networkservice.address}'
         )

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -136,7 +136,7 @@ class SSHConnection:
         default=False, init=False, validator=attr.validators.instance_of(bool)
     )
     _tmpdir = attr.ib(
-        default=attr.Factory(lambda: tempfile.mkdtemp(prefix="labgrid-connection-")),
+        default=attr.Factory(lambda: tempfile.mkdtemp(prefix="lg-con-")),
         init=False,
         validator=attr.validators.instance_of(str)
     )


### PR DESCRIPTION
Fixes #948

changes the names for the temporary file_paths from 
`labgrid-ssh-tmp-` to `lg-ssh-` 
and
 `labgrid-connection-` to `lg-con-`

in order to be compatible with MacOS and its longer tempdir-path
