### PR TITLE
driver: ykushpower: support remote control via ssh.

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -732,6 +732,7 @@ class ClientSession(ApplicationSession):
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import (NetworkUSBPowerPort, NetworkSiSPMPowerPort)
         from ..resource.mqtt import TasmotaPowerPort
+        from ..resource import YKUSHPowerPort
 
         drv = None
         try:
@@ -763,6 +764,11 @@ class ClientSession(ApplicationSession):
                         drv = target.get_driver(TasmotaPowerDriver)
                     except NoDriverFoundError:
                         drv = TasmotaPowerDriver(target, name=None)
+                elif isinstance(resource, YKUSHPowerPort):
+                    try:
+                        drv = target.get_driver(YKUSHPowerDriver)
+                    except NoDriverFoundError:
+                        drv = YKUSHPowerDriver(target, name=None)
                 if drv:
                     break
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -669,6 +669,26 @@ class LXAIOBusNodeExport(ResourceExport):
 
 exports["LXAIOBusPIO"] = LXAIOBusNodeExport
 
+@attr.s(eq=False)
+class YKUSHPowerPortExport(ResourceExport):
+    """ResourceExport for YKUSHPowerPort devices"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        local_cls_name = self.cls
+        self.data['cls'] = f"{local_cls_name}"
+        from ..resource import ykushpowerport
+        local_cls = getattr(ykushpowerport, local_cls_name)
+        self.local = local_cls(target=None, name=None, host=self.host, **self.local_params)
+
+    def _get_params(self):
+        return {
+            "host": self.host,
+            "serial": self.local.serial,
+            "index": self.local.index
+        }
+
+exports["YKUSHPowerPort"] = YKUSHPowerPortExport
 
 class ExporterSession(ApplicationSession):
     def onConnect(self):

--- a/labgrid/resource/ykushpowerport.py
+++ b/labgrid/resource/ykushpowerport.py
@@ -1,12 +1,12 @@
 import attr
 
 from ..factory import target_factory
-from .common import Resource
+from .common import NetworkResource
 
 
 @target_factory.reg_resource
 @attr.s(eq=False)
-class YKUSHPowerPort(Resource):
+class YKUSHPowerPort(NetworkResource):
     """This resource describes a YEPKIT YKUSH switchable USB hub.
 
     Args:


### PR DESCRIPTION
enable driver for resource YKUSHPowerPort,
change to use ykushcmd as control driver,
support remote control via ssh.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>


**Description**

support to control YKUSHPowerPort device remotely via ssh.

