### PR TITLE
Integrate nxp uuu into labgrid.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,7 @@ New Features in 0.5.0
 - `DFUDriver` has been added to communicate with a `DFUDevice`, a device in DFU
   (Device Firmware Upgrade) mode.
 - ``labgrid-client dfu`` added to allow communcation with devices in DFU mode.
+- Add NXP uuu resource/driver, add labgrid-client uuu command.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~
@@ -299,7 +300,7 @@ New and Updated Drivers
 - The `SerialDriver` now supports using plain TCP instead of RFC 2217, which is
   needed from some console servers.
 - The `ShellDriver` has been improved:
-  
+
   - It supports configuring the various timeouts used during the login process.
   - It can use xmodem to transfer file from and to the target.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -625,6 +625,45 @@ Arguments:
 Used by:
   - `AndroidFastbootDriver`_
 
+UUU
+~~~
+An UUU resource describes a i.mx uuu device in the serialdownload mode which attached to exporter.
+
+.. code-block:: yaml
+
+   UUU:
+     usb_otg_path: "3:8"
+
+   UUU:
+     usb_otg_path: ["3:8", "2:8"]
+
+Arguments:
+  - usb_otg_path (str or list): UUU otg paths, could obtain it with ``uuu -lsusb``
+
+Used by:
+  - `UniversalUpdateUtilityDriver`_
+
+NetworkUUU
+~~~~~~~~~~
+An UUU resource describes a i.mx uuu device in the serialdownload mode which not directly attached to exporter.
+
+.. code-block:: yaml
+
+   UUU:
+     host: "10.192.244.109"
+     usb_otg_path: "3:8"
+
+   UUU:
+     host: "10.192.244.109"
+     usb_otg_path: ["3:8", "2:8"]
+
+Arguments:
+  - host (str): the host which with uuu device attached.
+  - usb_otg_path (str or list): UUU otg paths, could obtain it with ``uuu -lsusb``
+
+Used by:
+  - `UniversalUpdateUtilityDriver`_
+
 DFUDevice
 ~~~~~~~~~
 A DFUDevice resource describes a USB device in DFU (Device Firmware Upgrade)
@@ -1572,6 +1611,22 @@ Arguments:
     fastboot manpage -S option for allowed size suffixes). The default is the
     same as the fastboot default, which is computed after querying the target's
     ``max-download-size`` variable.
+
+UniversalUpdateUtilityDriver
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+An UniversalUpdateUtilityDriver allows the upload of images to a i.mx device
+in the serialdownload mode.
+
+Binds to:
+  uuu:
+    - `NetworkUUU`_
+
+Implements:
+  - None (yet)
+
+.. code-block:: yaml
+
+   UniversalUpdateUtilityDriver: {}
 
 DFUDriver
 ~~~~~~~~~

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -42,3 +42,4 @@ from .mqtt import TasmotaPowerDriver
 from .manualswitchdriver import ManualSwitchDriver
 from .usbtmcdriver import USBTMCDriver
 from .deditecrelaisdriver import DeditecRelaisDriver
+from .uuudriver import UniversalUpdateUtilityDriver

--- a/labgrid/driver/uuudriver.py
+++ b/labgrid/driver/uuudriver.py
@@ -1,0 +1,62 @@
+import logging
+import os
+import attr
+
+from ..factory import target_factory
+from .common import Driver
+from ..util.managedfile import ManagedFile
+from ..util.helper import processwrapper
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class UniversalUpdateUtilityDriver(Driver):
+    bindings = {
+        "uuu": {"NetworkUUU"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.logger = logging.getLogger(f"{self}({self.target})")
+
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('uuu') or 'uuu'
+        else:
+            self.tool = 'uuu'
+
+    def _get_uuu_cmd(self, *args):
+        if not hasattr(self.uuu, "extra"):
+            setattr(self.uuu, "extra", {})
+        self.uuu.extra["ssh_extra_args"] = ["-tq"]
+
+        uuu_otg_path = []
+        for usb_otg_path in self.uuu.usb_otg_path:
+            uuu_otg_path.append("-m")
+            uuu_otg_path.append(usb_otg_path)
+
+        native_uuu_cmd = [self.tool] + uuu_otg_path + list(args)
+        self.logger.info(" ".join(native_uuu_cmd))
+
+        uuu_cmd = self.uuu.command_prefix + native_uuu_cmd
+
+        return uuu_cmd
+
+    @Driver.check_active
+    def __call__(self, *args):
+        processwrapper.check_output(
+            self._get_uuu_cmd(*args),
+            print_on_silent_log=True
+        )
+
+    @Driver.check_active
+    def run(self, *args):
+        def handle_args():
+            for arg in args:
+                if os.path.isfile(arg):
+                    mf = ManagedFile(arg, self.uuu)
+                    mf.sync_to_resource()
+                    yield mf.get_remote_path()
+                else:
+                    yield arg
+
+        self(*list(handle_args()))

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -966,6 +966,20 @@ class ClientSession(ApplicationSession):
             return
         drv(*args)
 
+    def uuu(self):
+        place = self.get_acquired_place()
+        args = self.args.leftover
+        if not args:
+            raise UserError("not enough arguments for uuu")
+        target = self._get_target(place)
+        from ..driver.uuudriver import UniversalUpdateUtilityDriver
+        try:
+            drv = target.get_driver(UniversalUpdateUtilityDriver)
+        except NoDriverFoundError:
+            drv = UniversalUpdateUtilityDriver(target, name=None)
+        target.activate(drv)
+        drv.run(*args)
+
     def flashscript(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
@@ -1734,6 +1748,10 @@ def main():
     subparser.add_argument('--wait', type=float, default=10.0)
     subparser.set_defaults(func=ClientSession.fastboot)
 
+    subparser = subparsers.add_parser('uuu',
+                                      help="run uuu")
+    subparser.set_defaults(func=ClientSession.uuu)
+
     subparser = subparsers.add_parser('flashscript',
                                      help="run flash script")
     subparser.add_argument('script', help="Flashing script")
@@ -1884,7 +1902,7 @@ def main():
 
     # make any leftover arguments available for some commands
     args, leftover = parser.parse_known_args()
-    if args.command not in ['ssh', 'rsync', 'forward']:
+    if args.command not in ['ssh', 'rsync', 'forward', 'uuu']:
         args = parser.parse_args()
     else:
         args.leftover = leftover

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -178,6 +178,26 @@ class ResourceExport(ResourceEntry):
 
 
 @attr.s(eq=False)
+class UUUExport(ResourceExport):
+    """ResourceExport for UUU"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        from ..resource.uuu import UUU
+        self.local = UUU(target=None, name=None, **self.local_params)
+        self.data['cls'] = "NetworkUUU"
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': self.host,
+            'usb_otg_path': self.local.usb_otg_path,
+        }
+
+
+exports["UUU"] = UUUExport
+
+@attr.s(eq=False)
 class SerialPortExport(ResourceExport):
     """ResourceExport for a USB or Raw SerialPort"""
 

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -22,3 +22,4 @@ from .pyvisa import PyVISADevice
 from .provider import TFTPProvider
 from .mqtt import TasmotaPowerPort
 from .httpvideostream import HTTPVideoStream
+from .uuu import UUU, NetworkUUU

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -70,12 +70,15 @@ class NetworkResource(Resource):
     def command_prefix(self):
         host = self.host
 
+        ssh_extra_args = []
         if hasattr(self, 'extra'):
             if self.extra.get('proxy_required'):
                 host = self.extra.get('proxy')
+            if self.extra.get("ssh_extra_args"):
+                ssh_extra_args = self.extra.get("ssh_extra_args")
 
         conn = sshmanager.get(host)
-        prefix = conn.get_prefix()
+        prefix = conn.get_prefix(ssh_extra_args)
 
         return prefix + ['--']
 

--- a/labgrid/resource/uuu.py
+++ b/labgrid/resource/uuu.py
@@ -1,0 +1,31 @@
+import attr
+
+from ..factory import target_factory
+from .common import Resource, NetworkResource
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class UUU(Resource):
+    """Describes a uuu resource which is available on the exporter."""
+    def _convert(value):
+        if isinstance(value, str):
+            return [value]
+        elif isinstance(value, list):
+            return value
+        else:
+            raise Exception(f"{value} is neither a string nor a list")
+
+    usb_otg_path = attr.ib(converter=_convert)
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        if self.usb_otg_path is None:
+            raise ValueError("UUU must be configured with a usb_otg_path")
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkUUU(NetworkResource, UUU):
+    """A NetworkUUU could let you specify any host which connected with a uuu device."""
+    pass

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -195,8 +195,8 @@ class SSHConnection:
         )
 
     @_check_connected
-    def get_prefix(self):
-        return ["ssh"] + self._get_ssh_args() + [self.host]
+    def get_prefix(self, ssh_extra_args=[]):
+        return ["ssh"] + ssh_extra_args + self._get_ssh_args() + [self.host]
 
     @_check_connected
     def run(self, command, *, codec="utf-8", decodeerrors="strict",

--- a/tests/test_uuu.py
+++ b/tests/test_uuu.py
@@ -1,0 +1,65 @@
+import pytest
+
+from labgrid.resource import UUU
+from labgrid.resource import NetworkUUU
+from labgrid.driver import UniversalUpdateUtilityDriver
+from labgrid import Environment
+
+
+class TestUUU:
+    def test_uuu_instanziation(self):
+        u = UUU(None, "uuu", "3:8")
+        u = UUU(None, "uuu", ["3:8"])
+        with pytest.raises(Exception):
+            u = UUU(None, "uuu", {"3":"8"})
+
+    def test_network_uuu_instanziation(self):
+        u = NetworkUUU(None, "uuu", "ip", "3:8")
+        u = NetworkUUU(None, "uuu", "ip", ["3:8"])
+        with pytest.raises(Exception):
+            u = NetworkUUU(None, "uuu", "ip", {"3":"8"})
+
+
+class TestUUUDriver:
+    def test_uuu_cmd(self, tmpdir):
+        p = tmpdir.join("uuu.yaml")
+        p.write(
+            """
+        targets:
+          example:
+            resources:
+              NetworkUUU:
+                host: "localhost"
+                usb_otg_path: "3:8"
+            drivers:
+              UniversalUpdateUtilityDriver: {}
+        """
+        )
+
+        env = Environment(str(p))
+        t = env.get_target('example')
+        ud = t.get_driver('UniversalUpdateUtilityDriver')
+
+        assert isinstance(ud, UniversalUpdateUtilityDriver)
+        assert isinstance(ud.uuu, NetworkUUU)
+        uuu_cmd = ud._get_uuu_cmd("-lsusb")
+        uuu_cmd[10] = uuu_cmd[10].split("=")[0]
+        assert uuu_cmd == [
+            'ssh',
+            '-tq',
+            '-x',
+            '-o',
+            'LogLevel=ERROR',
+            '-o',
+            'PasswordAuthentication=no',
+            '-o',
+            'ControlMaster=no',
+            '-o',
+            'ControlPath',
+            'localhost',
+            '--',
+            'uuu',
+            '-m',
+            '3:8',
+            '-lsusb'
+        ]


### PR DESCRIPTION
This PR to add nxp uuu support to labgrid, we use uuu to flash images to i.mx boards.

**Description**

Some considerations here:

* I notice there is realization for uuu driver [here](https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/usbloader.py#L151), but it's really not how we use it in NXP internal, see [official example](https://github.com/NXPmicro/mfgtools#examples), also how we use it in [lava](https://validation.linaro.org/static/docs/v2/actions-boot.html#contents)
* Usually user need to use uuu to remotely flash a bootloader into broken board, so `labgrid-client uuu` added.
* We don't design `uuu resource` based on `udev`, this is because `uuu` will be separated into several stages: SDP, FB, etc. For `SDP`, uuu will use usb2.0 protocol, while for `FB`, if the board connected to a `usb3.0`, uuu will use usb3.0 protocol. That means the otg path may jump from `3:8` to `2:8` during uuu run. But if we use udev method we are not able to get some like `uuu -m 3:8 -m 2:8` before run uuu, so we choose to statically specify `["3:8", "2:8"]`.
* In our scenario, some boards not directly linked to exporter, so a `NetworkUUU` could be specified for such case.
* When use ssh to call uuu, we will have to allocate a pseudo terminal there as when uuu flash, it will has a progress bar. Without `-t`, the screen will be chaos. 

Local test here:

![image](https://user-images.githubusercontent.com/3738458/182096948-fdd1882a-f90a-450c-8909-1459e9e31ca4.png)

![image](https://user-images.githubusercontent.com/3738458/182097174-55d77099-a7c4-4ca8-8c4d-a5d25a8e0693.png)

**Checklist**
- [√] Documentation for the feature
- [√] Tests for the feature
- [√] The arguments and description in doc/configuration.rst have been updated
- [√ ] CHANGES.rst has been updated
- [√ ] PR has been tested

