### PR TITLE
Add LG_SSH_CONNECT_TIMEOUT environment variable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@ New Features in 0.5.0
   a string to be passed to stdin of the process
 - The ``NetworkInterfaceDriver`` now supports local and remote SSH port
   forwarding to/from the exporter.
+- The SSH connection timeout can now be globally controlled using the
+  ``LG_SSH_CONNECT_TIMEOUT`` environment variable.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -20,6 +20,7 @@ from .exception import ExecutionError
 from ..util.helper import get_free_port
 from ..util.proxy import proxymanager
 from ..util.timeout import Timeout
+from ..util.ssh import get_ssh_connect_timeout
 
 
 @target_factory.reg_driver
@@ -30,7 +31,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     priorities = {CommandProtocol: 10, FileTransferProtocol: 10}
     keyfile = attr.ib(default="", validator=attr.validators.instance_of(str))
     stderr_merge = attr.ib(default=False, validator=attr.validators.instance_of(bool))
-    connection_timeout = attr.ib(default=30.0, validator=attr.validators.instance_of(float))
+    connection_timeout = attr.ib(default=float(get_ssh_connect_timeout()), validator=attr.validators.instance_of(float))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -6,6 +6,8 @@ import subprocess
 import traceback
 import logging
 
+from .ssh import get_ssh_connect_timeout
+
 def b2s(b):
     return base64.b85encode(b).decode('ascii')
 
@@ -50,7 +52,8 @@ class AgentWrapper:
                 agent_data = agent_fd.read()
             agent_hash = hashlib.sha256(agent_data).hexdigest()
             agent_remote = f'.labgrid_agent_{agent_hash}.py'
-            ssh_opts = 'ssh -x -o ConnectTimeout=5 -o PasswordAuthentication=no'.split()
+            connect_timeout = get_ssh_connect_timeout()
+            ssh_opts = f'ssh -x -o ConnectTimeout={connect_timeout} -o PasswordAuthentication=no'.split()
             subprocess.check_call(
                 ['rsync', '-e', ' '.join(ssh_opts), '-tq', agent,
                  f'{host}:{agent_remote}'],

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -113,6 +113,10 @@ CI pipelines where the hostname may not be consistent between pipeline stages.
 .sp
 Override the username used when accessing a resource. Typically only useful for
 CI pipelines where the username may not be consistent between pipeline stages.
+.SS LG_SSH_CONNECT_TIMEOUT
+.sp
+Set the connection timeout when using SSH (The \fBConnectTimeout\fP option). If
+unspecified, defaults to 30 seconds.
 .SH MATCHES
 .sp
 Match patterns are used to assign a resource to a specific place. The format is:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -106,6 +106,11 @@ LG_USERNAME
 Override the username used when accessing a resource. Typically only useful for
 CI pipelines where the username may not be consistent between pipeline stages.
 
+LG_SSH_CONNECT_TIMEOUT
+~~~~~~~~~~~~~~~~~~~~~~
+Set the connection timeout when using SSH (The ``ConnectTimeout`` option). If
+unspecified, defaults to 30 seconds.
+
 MATCHES
 -------
 Match patterns are used to assign a resource to a specific place. The format is:


### PR DESCRIPTION

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Adds an environment variable called LG_SSH_CONNECT_TIMEOUT  which
controls the timeout passed to SSH when attempting a connection.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
