### PR TITLE
driver: fastbootdriver: support fastboot over network

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -605,13 +605,13 @@ NetworkRKUSBLoader
 ~~~~~~~~~~~~~~~~~~~
 A NetworkRKUSBLoader describes an `RKUSBLoader`_ available on a remote computer.
 
-AndroidFastboot
-~~~~~~~~~~~~~~~
-An AndroidFastboot resource describes a USB device in the fastboot state.
+AndroidUSBFastboot
+~~~~~~~~~~~~~~~~~~
+An AndroidUSBFastboot resource describes a USB device in the fastboot state.
 
 .. code-block:: yaml
 
-   AndroidFastboot:
+   AndroidUSBFastboot:
      match:
        ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
 
@@ -621,6 +621,25 @@ Arguments:
   - usb_product_id (str, default="0104"): USB product ID, to be compared with
     the ``ID_MODEL_ID`` udev property
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - `AndroidFastbootDriver`_
+
+AndroidNetFastboot
+~~~~~~~~~~~~~~~~~~
+An AndroidNetFastboot resource describes a network device in fastboot state.
+
+.. code-block:: yaml
+
+   AndroidNetFastboot:
+     address: "192.168.23.42"
+
+Arguments:
+  - address (str): ip address of the fastboot device
+  - port (int, default=5554): udp/tcp fastboot port that is used in the
+    device. (e.g. Barebox uses port 5554)
+  - protocol (str, default="udp"): which protocol should be used when issuing
+    fastboot commands. (Barebox supports currently only the udp protocol)
 
 Used by:
   - `AndroidFastbootDriver`_
@@ -1159,7 +1178,7 @@ The initial matching and monitoring for udev events is handled by the
 :any:`UdevManager` class.
 This manager is automatically created when a resource derived from
 :any:`USBResource` (such as :any:`USBSerialPort`, :any:`IMXUSBLoader` or
-:any:`AndroidFastboot`) is instantiated.
+:any:`AndroidUSBFastboot`) is instantiated.
 
 To identify the kernel device which corresponds to a configured `USBResource`,
 each existing (and subsequently added) kernel device is matched against the
@@ -1205,15 +1224,15 @@ device's parents instead of directly to itself.
 This is necessary for the `USBSerialPort` because we actually want to find the
 ``ttyUSB?`` device below the USB serial converter device.
 
-Matching an Android Fastboot Device
-+++++++++++++++++++++++++++++++++++
+Matching an Android USB Fastboot Device
++++++++++++++++++++++++++++++++++++++++
 
 In this case, we want to match the USB device on that port directly, so we
 don't use a parent match.
 
 .. code-block:: yaml
 
-  AndroidFastboot:
+  AndroidUSBFastboot:
     match:
       sys_name: '1-1.2.3'
 
@@ -1548,12 +1567,13 @@ Arguments:
 
 AndroidFastbootDriver
 ~~~~~~~~~~~~~~~~~~~~~
-An AndroidFastbootDriver allows the upload of images to a device in the USB
-fastboot state.
+An AndroidFastbootDriver allows the upload of images to a device in the USB or
+network fastboot state.
 
 Binds to:
   fastboot:
-    - `AndroidFastboot`_
+    - `AndroidUSBFastboot`_
+    - `AndroidNetFastboot`_
 
 Implements:
   - None (yet)

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -608,6 +608,8 @@ A NetworkRKUSBLoader describes an `RKUSBLoader`_ available on a remote computer.
 AndroidUSBFastboot
 ~~~~~~~~~~~~~~~~~~
 An AndroidUSBFastboot resource describes a USB device in the fastboot state.
+Previously, this resource was named AndroidFastboot and this name still
+supported for backwards compatibility.
 
 .. code-block:: yaml
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -33,7 +33,7 @@ Resources
 `Resources` are passive and only store the information to access the
 corresponding part of the `Target`.
 Typical examples of resources are :any:`RawSerialPort`, :any:`NetworkPowerPort`
-and :any:`AndroidFastboot`.
+and :any:`AndroidUSBFastboot`.
 
 An important type of `Resources` are :any:`ManagedResources <ManagedResource>`.
 While normal `Resources` are always considered available for use and have fixed
@@ -44,7 +44,7 @@ They can appear/disappear at runtime and have different properties each time
 they are discovered.
 The most common examples of `ManagedResources` are the various USB resources
 discovered using udev, such as :any:`USBSerialPort`, :any:`IMXUSBLoader` or
-:any:`AndroidFastboot`.
+:any:`AndroidUSBFastboot`.
 
 Drivers and Protocols
 ~~~~~~~~~~~~~~~~~~~~~
@@ -112,7 +112,7 @@ A realistic sequence of activation might look like this:
   :any:`IMXUSBLoader` resource to be available)
 - load the bootloader (:any:`BootstrapProtocol.load`)
 - activate the :any:`AndroidFastbootDriver` driver on the target (this will
-  wait for the :any:`AndroidFastboot` resource to be available)
+  wait for the :any:`AndroidUSBFastboot` resource to be available)
 - boot the kernel (:any:`AndroidFastbootDriver.boot`)
 - activate the :any:`ShellDriver` driver on the target (this will wait for the
   :any:`USBSerialPort` resource to be available and log in)
@@ -347,7 +347,7 @@ For resource types which do not have an existing, network-transparent protocol
 the mapping done by the exporter.
 
 For generic USB resources, the exporter for example maps a
-:any:`AndroidFastboot` resource to a :any:`NetworkAndroidFastboot` resource and
+:any:`AndroidUSBFastboot` resource to a :any:`RemoteAndroidUSBFastboot` resource and
 adds a hostname property which needs to be used by the client to connect to the
 exporter.
 To avoid the need for additional remote access protocols and authentication,

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -491,7 +491,14 @@ class USBFlashableExport(USBGenericExport):
         p['devnode'] = self.local.devnode
         return p
 
+@attr.s(eq=False)
+class USBGenericRemoteExport(USBGenericExport):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.data['cls'] = f"Remote{self.cls}".replace("Network", "")
+
 exports["AndroidFastboot"] = USBGenericExport
+exports["AndroidUSBFastboot"] = USBGenericRemoteExport
 exports["DFUDevice"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
 exports["MXSUSBLoader"] = USBGenericExport
@@ -669,6 +676,21 @@ class LXAIOBusNodeExport(ResourceExport):
 
 exports["LXAIOBusPIO"] = LXAIOBusNodeExport
 
+@attr.s(eq=False)
+class AndroidNetFastbootExport(ResourceExport):
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        local_cls_name = self.cls
+        self.data['cls'] = f"Remote{self.cls}"
+        from ..resource import fastboot
+        local_cls = getattr(fastboot, local_cls_name)
+        self.local = local_cls(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {'host' : self.host, **self.local_params}
+
+exports["AndroidNetFastboot"] = AndroidNetFastbootExport
 
 class ExporterSession(ApplicationSession):
     def onConnect(self):

--- a/labgrid/resource/fastboot.py
+++ b/labgrid/resource/fastboot.py
@@ -1,0 +1,11 @@
+import attr
+
+from ..factory import target_factory
+from .common import Resource
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class AndroidNetFastboot(Resource):
+    address = attr.ib(validator=attr.validators.instance_of(str))
+    port = attr.ib(default=5554, validator=attr.validators.instance_of(int))
+    protocol = attr.ib(default="udp", validator=attr.validators.instance_of(str))

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -113,10 +113,28 @@ class RemoteUSBResource(NetworkResource, ManagedResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
-class NetworkAndroidFastboot(RemoteUSBResource):
+class RemoteAndroidUSBFastboot(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkAndroidFastboot(RemoteAndroidUSBFastboot):
+    def __attrs_post_init__(self):
+        import warnings
+        warnings.warn("NetworkAndroidFastboot is deprecated, use RemoteAndroidUSBFastboot instead",
+                      DeprecationWarning)
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class RemoteAndroidNetFastboot(NetworkResource):
+    address = attr.ib(validator=attr.validators.instance_of(str))
+    port = attr.ib(default=5554, validator=attr.validators.instance_of(int))
+    protocol = attr.ib(default="udp", validator=attr.validators.instance_of(str))
 
 
 @target_factory.reg_resource

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -10,7 +10,7 @@ from .udev import (
     USBTMC,
     USBVideo,
     IMXUSBLoader,
-    AndroidFastboot,
+    AndroidUSBFastboot,
     DFUDevice,
     USBSDMuxDevice,
     USBSDWireDevice,
@@ -41,7 +41,7 @@ class Suggester:
         self.resources.append(USBTMC(**args))
         self.resources.append(USBVideo(**args))
         self.resources.append(IMXUSBLoader(**args))
-        self.resources.append(AndroidFastboot(**args))
+        self.resources.append(AndroidUSBFastboot(**args))
         self.resources.append(DFUDevice(**args))
         self.resources.append(USBMassStorage(**args))
         self.resources.append(USBSDMuxDevice(**args))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -312,7 +312,7 @@ class MXSUSBLoader(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
-class AndroidFastboot(USBResource):
+class AndroidUSBFastboot(USBResource):
     usb_vendor_id = attr.ib(default='1d6b', validator=attr.validators.instance_of(str))
     usb_product_id = attr.ib(default='0104', validator=attr.validators.instance_of(str))
     def filter_match(self, device):
@@ -321,6 +321,14 @@ class AndroidFastboot(USBResource):
         if device.properties.get('ID_MODEL_ID') != self.usb_product_id:
             return False
         return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class AndroidFastboot(AndroidUSBFastboot):
+    def __attrs_post_init__(self):
+        warnings.warn("AndroidFastboot is deprecated, use AndroidUSBFastboot instead",
+                      DeprecationWarning)
+        super().__attrs_post_init__()
 
 @target_factory.reg_resource
 @attr.s(eq=False)

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -88,7 +88,7 @@ imports:
         targets:
           test1:
             resources:
-            - AndroidFastboot:
+            - AndroidUSBFastboot:
                 name: "fastboot"
                 match: {}
             - RawSerialPort:
@@ -106,7 +106,7 @@ imports:
         targets:
           test1:
             resources:
-            - AndroidFastboot:
+            - AndroidUSBFastboot:
                 name: "fastboot"
                 match: {}
             - RawSerialPort:


### PR DESCRIPTION
Signed-off-by: Oleg Karfich <oleg.karfich@wago.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Extend the currently fastboot implementation in labgrid by supporting fastboot over ethernet.

The extension is tested with an WAGO PFC200 (750-8212) with running Barebox v2021.10.0. We also tested the currently implemented USB functionality in case of some breaking changes. 

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
