### PR TITLE
driver/power/siglent: use backend function signatures expected by NetworkPowerDriver

### DIFF
--- a/labgrid/driver/power/siglent.py
+++ b/labgrid/driver/power/siglent.py
@@ -3,7 +3,8 @@
 import vxi11
 
 
-def power_set(host, index, value):
+def power_set(host, port, index, value):
+    assert port is None
     index = int(index)
     assert 1 <= index <= 2
     value = "ON" if value else "OFF"
@@ -11,7 +12,8 @@ def power_set(host, index, value):
     psu.write(f"OUTPUT CH{index},{value}")
 
 
-def power_get(host, index):
+def power_get(host, port, index):
+    assert port is None
     index = int(index)
     assert 1 <= index <= 2
     psu = vxi11.Instrument(host)


### PR DESCRIPTION
**Description**
When using the siglent power backend with the NetworkPowerDriver, this error occurs:

```
  self = NetworkPowerDriver(target=Target(name='Test', env=None), name='power', state=<BindingState.active: 2>, delay=2.0)

      @Driver.check_active
      @step()
      def off(self):
  >       self.backend.power_set(self._host, self._port, self.port.index, False)
  E       TypeError: power_set() takes 3 positional arguments but 4 were given

  labgrid/driver/powerdriver.py:219: TypeError
```

The siglent backend does not follow the function signatures expected by the NetworkPowerDriver, because it's missing the port parameter. Fix that by adding the port parameter and making sure that it's `None`, just like other backends do (apc, rest, sentry, simplerest, tplink).

Note: I have no Siglent device here to actually test this. I stumbled upon this while trying to add a test for another power-related change.

/cc @esben 

**Checklist**
- [ ] Tests for the feature 
- [ ] CHANGES.rst has been updated
- [ ] PR has been tested

Fixes #717
