### PR TITLE
serialdriver: handle newer pyserial version

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -27,7 +27,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         bindings = {"port": "SerialPort", }
     else:
         bindings = {"port": {"SerialPort", "NetworkSerialPort"}, }
-    if version.parse(serial.__version__) != version.Version('3.4.0.1'):
+    if version.parse(serial.__version__) < version.Version('3.4.0.1'):
         message = ("The installed pyserial version does not contain important RFC2217 fixes.\n"
                    "You can install the labgrid fork via:\n"
                    "pip uninstall pyserial\n"


### PR DESCRIPTION
When running labgrid-client I got:
/usr/lib/python3.9/site-packages/labgrid/driver/serialdriver.py:35: UserWarning: The installed pyserial version does not contain important RFC2217 fixes.
You can install the labgrid fork via:
pip uninstall pyserial
pip install https://github.com/labgrid-project/pyserial/archive/v3.4.0.1.zip#egg=pyserial

I have pyserial version 3.5, so I should not get this warning.

Signed-off-by: Corentin Labbe <clabbe.montjoie@gmail.com>