### PR TITLE
tests: record coordinator's coverage

### DIFF
--- a/.crossbar/config.yaml
+++ b/.crossbar/config.yaml
@@ -54,7 +54,8 @@ workers:
   type: guest
   executable: python3
   arguments:
-  - -mlabgrid.remote.coordinator
+  - -m
+  - labgrid.remote.coordinator
   options:
     workdir: .
     env:


### PR DESCRIPTION
**Description**
Recording the coordinator's coverage is useful to determine, which parts of the component are executed during tests.

crossbar runs labgrid's coordinator component as a guest worker. Guest workers are spawned as subprocesses by crossbar. Therefore recording coverage of the coordinator component does not work out of the box.

To allow recording coordinator coverage, set the coverage command line tool as the `excutable` in the crossbar configuration, whose 'run' subcommand works as a drop-in replacement for 'python'. This way the coverage of the guest worker is recorded separately. The `--parallel-mode` switch makes coverage add a unique suffix to the coverage data file. Set the location of the coverage data via `--data-file` to the root directory. pytest-cov automatically combines the coverage data in this directory.

Since the crossbar process is forcefully terminated during the tests, the coverage data can not be written. Since the coverage tool registers an atexit SIGTERM handler to write its data, send crossbar SIGTERM, wait for any remaining output and the process to exit.

Now the coverage data contains labgrid's coordinator component.

**Checklist**
- [x] PR has been tested