### PR TITLE
add port-forwarding helpers on the NetworkInterfaceDriver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -31,6 +31,8 @@ New Features in 0.5.0
   an interupted U-Boot.
 - ProcessWrapper now supports an "input" argument to check_output() that allows
   a string to be passed to stdin of the process
+- The ``NetworkInterfaceDriver`` now supports local and remote SSH port
+  forwarding to/from the exporter.
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -58,6 +58,14 @@ class Driver(BindingMixin):
         """Get a dictionary of variables to be exported."""
         return {}
 
+    @property
+    def skip_deactivate_on_export(self):
+        """Drivers are deactivated on export by default.
+
+        If the driver can handle external accesses even while active, it can
+        return True here.
+        """
+        return False
 
 def check_file(filename, *, command_prefix=[]):
     if subprocess.call(command_prefix + ['test', '-r', filename]) != 0:

--- a/labgrid/driver/networkinterfacedriver.py
+++ b/labgrid/driver/networkinterfacedriver.py
@@ -41,7 +41,11 @@ class NetworkInterfaceDriver(Driver):
             self.wrapper = None
             self.proxy = None
 
-    @Driver.check_bound
+    @property
+    def skip_deactivate_on_export(self):
+        # We need to keep the agent and SSH exports active.
+        return True
+
     def get_export_vars(self):
         return {
             "host": self.iface.host,

--- a/labgrid/driver/networkinterfacedriver.py
+++ b/labgrid/driver/networkinterfacedriver.py
@@ -1,9 +1,13 @@
+import contextlib
+
 import attr
 
 from .common import Driver
+from .exception import ExecutionError
 from ..factory import target_factory
 from ..step import step
 from ..util.agentwrapper import AgentWrapper
+from ..util.ssh import sshmanager
 from ..resource.remote import RemoteNetworkInterface
 
 
@@ -21,8 +25,11 @@ class NetworkInterfaceDriver(Driver):
     def on_activate(self):
         if isinstance(self.iface, RemoteNetworkInterface):
             host = self.iface.host
+            self.ssh = sshmanager.get(host)
         else:
             host = None
+            # port forwarding is not useful for localhost
+            self.ssh = None
         self.wrapper = AgentWrapper(host)
         self.proxy = self.wrapper.load('network_interface')
 
@@ -113,3 +120,64 @@ class NetworkInterfaceDriver(Driver):
         if the last scan is more than 30 seconds old.
         """
         return self.proxy.get_access_points(self.iface.ifname, scan)
+
+    @Driver.check_active
+    @contextlib.contextmanager
+    def forward_local(self, remote_host, remote_port, local_port=None):
+        """Forward a local port to an address and port via the exporter.
+
+        A context manager that keeps the local port forwarded as long as the
+        context remains valid. A connection can be made to the returned port on
+        localhost and it will be forwarded to the address and port.
+
+        If localport is not set, a random free port will be selected.
+
+        usage:
+            with netif.forward_local('127.0.0.1', 8080, local_port=1234) as local_port:
+                # Use localhost:1234 here to connect to port 8080 on
+                # the exporter
+
+            with netif.forward_local('192.168.1.2', 8080) as local_port:
+                # Use localhost:local_port here to connect to port 8080 on
+                # 192.168.1.2
+
+        returns:
+            local_port
+        """
+        if not self.ssh:
+            raise ExecutionError("Resource is not on an exporter")
+
+        local_port = self.ssh.add_port_forward(remote_host, remote_port, local_port)
+        try:
+            yield local_port
+        finally:
+            self.ssh.remove_port_forward(remote_host, remote_port)
+
+    @Driver.check_active
+    @contextlib.contextmanager
+    def forward_remote(self, remote_port, local_port, remote_bind=None):
+        """Forward a remote port on the exporter to a local port.
+
+        A context manager that keeps a remote port forwarded to a local port as
+        long as the context remains valid. A connection can be made to the
+        remote port on the target device will be forwarded to the returned local
+        port on localhost.
+
+        Note that the remote socket is not *bound* to any specific IP by
+        default, making it reachable by the target. Also, 'GatewayPorts
+        clientspecified' needs to be configured in the remote host's
+        sshd_config.
+
+        usage:
+            with netif.forward_remote(8080, 8081) as local_port:
+                # Connections to port 8080 on the exporter will be redirected to
+                # localhost:8081
+        """
+        if not self.ssh:
+            raise ExecutionError("Resource is not on an exporter")
+
+        self.ssh.add_remote_port_forward(remote_port, local_port, remote_bind)
+        try:
+            yield
+        finally:
+            self.ssh.remove_remote_port_forward(remote_port, local_port, remote_bind)

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -61,6 +61,11 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         finally:
             self._cleanup_own_master()
 
+    @property
+    def skip_deactivate_on_export(self):
+        # We need to keep the connection to the target open.
+        return True
+
     def _start_own_master(self):
         """Starts a controlmaster connection in a temporary directory."""
 

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -501,6 +501,8 @@ class Target:
             print("An exception occured during cleanup, call the cleanup() "
                   "method on targets yourself to handle exceptions explictly.")
             print(f"Error: {e}")
+            import traceback
+            traceback.print_exc()
 
     def export(self):
         """

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -508,7 +508,8 @@ class Target:
         """
         Export information from drivers.
 
-        All drivers are deactivated before being exported.
+        All drivers are deactivated before being exported, unless their
+        skip_deactivate_on_export property is true.
 
         The Strategy can decide for which driver the export method is called and
         with which name. Otherwise, all drivers are exported.
@@ -522,8 +523,10 @@ class Target:
 
         assert len(name_map) == len(set(name_map.values())), "duplicate export name"
 
-        # drivers need to be deactivated for export to avoid conflicts
-        self.deactivate_all_drivers()
+        # drivers may need to be deactivated for export to avoid conflicts
+        for drv in reversed(self.drivers):
+            if not drv.skip_deactivate_on_export:
+                self.deactivate(drv)
 
         export_vars = {}
         for driver in selection:

--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -58,13 +58,17 @@ class AgentWrapper:
             self.agent = subprocess.Popen(
                 ssh_opts + [host, '--', 'python3', agent_remote],
                 stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE)
+                stdout=subprocess.PIPE,
+                start_new_session=True,
+            )
         else:
             # run locally
             self.agent = subprocess.Popen(
                 ['python3', agent],
                 stdin=subprocess.PIPE,
-                stdout=subprocess.PIPE)
+                stdout=subprocess.PIPE,
+                start_new_session=True,
+            )
 
     def __del__(self):
         self.close()

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -331,9 +331,10 @@ class SSHConnection:
         )
 
     @_check_connected
-    def add_port_forward(self, remote_host, remote_port):
+    def add_port_forward(self, remote_host, remote_port, local_port=None):
         """forward command"""
-        local_port = get_free_port()
+        if local_port is None:
+            local_port = get_free_port()
         destination = f"{remote_host}:{remote_port}"
 
         if destination in self._forwards:

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -357,7 +357,7 @@ class SSHConnection:
 
         self._run_socket_command(
             "cancel", [
-                f"-L{local_port}:localhost:{remote_port}"
+                f"-L{local_port}:{destination}"
             ]
         )
 

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -523,6 +523,14 @@ class SSHConnection:
 
     def cleanup(self):
         if self.isconnected():
+            # cancel local forwards
+            for destination, local_port in self._l_forwards.items():
+                self._run_socket_command("cancel", [f"-L{local_port}:{destination}"])
+            self._l_forwards.clear()
+            # cancel remote forwards
+            for forward in self._r_forwards:
+                self._run_socket_command("cancel", [forward])
+            self._r_forwards.clear()
             self.disconnect()
         shutil.rmtree(self._tmpdir)
 

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -135,7 +135,7 @@ class SSHConnection:
         init=False,
         validator=attr.validators.instance_of(str)
     )
-    _forwards = attr.ib(init=False, default=attr.Factory(dict))
+    _l_forwards = attr.ib(init=False, default=attr.Factory(dict))
 
     def __attrs_post_init__(self):
         self._logger = logging.getLogger(f"{self}")
@@ -337,21 +337,21 @@ class SSHConnection:
             local_port = get_free_port()
         destination = f"{remote_host}:{remote_port}"
 
-        if destination in self._forwards:
-            return self._forwards[destination]
+        if destination in self._l_forwards:
+            return self._l_forwards[destination]
         self._run_socket_command(
             "forward", [
                 f"-L{local_port}:{destination}"
             ]
         )
-        self._forwards[destination] = local_port
+        self._l_forwards[destination] = local_port
         return local_port
 
     @_check_connected
     def remove_port_forward(self, remote_host, remote_port):
         """cancel command"""
         destination = f"{remote_host}:{remote_port}"
-        local_port = self._forwards.pop(destination, None)
+        local_port = self._l_forwards.pop(destination, None)
 
         if local_port is None:
             raise ForwardError("Forward does not exist")

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -490,6 +490,7 @@ class SSHConnection:
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            start_new_session=True,
         )
 
         self._logger.debug('Started keepalive for %s', self.host)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -164,8 +164,6 @@ def test_sshconnection_port_forward_add_duplicate(connection_localhost):
 
 @pytest.mark.localsshmanager
 def test_sshconnection_put_file(connection_localhost, tmpdir):
-    port = 1337
-
     p = tmpdir.join("config.yaml")
     p.write(
         """Teststring"""

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -11,6 +11,7 @@ import pytest
 import logging
 
 from labgrid.util import diff_dict, flat_dict, filter_dict
+from labgrid.util.helper import get_free_port
 from labgrid.util.ssh import ForwardError, SSHConnection, sshmanager
 from labgrid.util.proxy import proxymanager
 from labgrid.util.managedfile import ManagedFile
@@ -132,7 +133,7 @@ def test_sshconnection_run_fail(connection_localhost):
 
 @pytest.mark.localsshmanager
 def test_sshconnection_port_forward_add_remove(connection_localhost):
-    port = 1337
+    port = get_free_port()
     test_string = "Hello World"
 
     local_port = connection_localhost.add_port_forward('localhost', port)
@@ -149,14 +150,14 @@ def test_sshconnection_port_forward_add_remove(connection_localhost):
 
 @pytest.mark.localsshmanager
 def test_sshconnection_port_forward_remove_raise(connection_localhost):
-    port = 1337
+    port = get_free_port()
 
     with pytest.raises(ForwardError):
         connection_localhost.remove_port_forward('localhost', port)
 
 @pytest.mark.localsshmanager
 def test_sshconnection_port_forward_add_duplicate(connection_localhost):
-    port = 1337
+    port = get_free_port()
 
     first_port = connection_localhost.add_port_forward('localhost', port)
     second_port = connection_localhost.add_port_forward('localhost', port)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -206,7 +206,7 @@ def test_sshmanager_remove_forward(sshmanager_fix):
     port = sshmanager_fix.request_forward("localhost", 'localhost', 3000)
     sshmanager_fix.remove_forward('localhost', 'localhost', 3000)
 
-    assert 3000 not in sshmanager_fix.get('localhost')._forwards
+    assert 3000 not in sshmanager_fix.get('localhost')._l_forwards
 
 @pytest.mark.localsshmanager
 def test_sshmanager_close(sshmanager_fix):

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -163,6 +163,27 @@ def test_sshconnection_port_forward_add_duplicate(connection_localhost):
     second_port = connection_localhost.add_port_forward('localhost', port)
     assert first_port == second_port
 
+
+@pytest.mark.localsshmanager
+def test_sshconnection_port_remote_forward_add_remove(connection_localhost):
+    rport = get_free_port()
+    lport = get_free_port()
+    test_string = "Hello World"
+
+    connection_localhost.add_remote_port_forward(rport, lport)
+    server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server_socket.bind(("127.0.0.1", lport))
+    server_socket.listen(1)
+    send_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    send_socket.connect(("127.0.0.1", rport))
+    client_socket, address = server_socket.accept()
+    send_socket.send(test_string.encode('utf-8'))
+
+    assert client_socket.recv(16).decode("utf-8") == test_string
+    connection_localhost.remove_remote_port_forward(rport, lport)
+    assert connection_localhost._r_forwards == set()
+
+
 @pytest.mark.localsshmanager
 def test_sshconnection_put_file(connection_localhost, tmpdir):
     p = tmpdir.join("config.yaml")


### PR DESCRIPTION
**Description**
When using a RemoteNetworkInterface, it is useful to open connections from the
exporter to the DUT. We can make that easy by using the sshmanager we already
have for managing access to the exporter.

Also fix some minor issues on the way.

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
- [x] CHANGES.rst has been updated
- [x] PR has been tested