### PR TITLE
qemudriver: Add display support

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,11 @@ New Features in 0.5.0
   (Device Firmware Upgrade) mode.
 - ``labgrid-client dfu`` added to allow communcation with devices in DFU mode.
 - Support for QEMU Q35 machine added.
+- The `QEMUDriver` now supports a ``display`` option which can specify if an
+  display device should be created. ``none`` (the default) will not create a
+  display device, ``fb-headeless`` will create a headless framebuffer device
+  for software rendering, and ``egl-headless`` will create a headless GPU
+  device for accelerated rendering (but requires host support)
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2266,6 +2266,10 @@ Arguments:
   - rootfs (str): optional, reference to the paths key for use as the virtio-9p filesystem
   - dtb (str): optional, reference to the image key for the device tree
   - bios (str): optional, reference to the image key for the bios image
+  - display (str, default="none"): optional, display output to enable; must be one of:
+    - none: Do not create a display device
+    - fb-headless: Create a headless framebuffer device
+    - egl-headless: Create a headless GPU-backed graphics card. Requires host support
 
 The QEMUDriver also requires the specification of:
 


### PR DESCRIPTION
Adds support for configuring the driver to create a display device,
which can either be no device, a software framebuffer, or a accelerated
GPU (which requires host support)

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [x] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
