### PR TITLE
driver/qemudriver: fix disk attribute for vexpress-a9 machine

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -121,7 +121,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 self._cmd.append(
                     f"if=sd,format={disk_format},file={disk_path},id=mmc0")
                 boot_args.append("root=/dev/mmcblk0p1 rootfstype=ext4 rootwait")
-            if self.machine == "q35":
+            elif self.machine == "q35":
                 self._cmd.append("-drive")
                 self._cmd.append(
                     f"if=virtio,format={disk_format},file={disk_path}")


### PR DESCRIPTION
**Description**
Since the q35 machine was added, using the vexpress-a9 machine with a disk attribute ends up with a `NotImplementedError`. Fix that.

**Checklist**
- [x] PR has been tested

Fixes #961