### PR TITLE
util/qmp: log representation of line instead of line

### DIFF
--- a/labgrid/util/qmp.py
+++ b/labgrid/util/qmp.py
@@ -27,7 +27,7 @@ class QMPMonitor:
 
     def _read_parse_json(self):
         line = self.monitor_out.readline().decode('utf-8')
-        self.logger.debug("Received line: %s", line)
+        self.logger.debug("Received line: %s", line.rstrip("\r\n"))
         if not line:
             raise QMPError("Received empty response")
         return json.loads(line)


### PR DESCRIPTION
**Description**
Lines end with '\r\n', so an extra empty line is logged after each QMP line received. Log the representation of the line to get rid of extra lines.

**Checklist**
- [x] PR has been tested