### PR TITLE
driver/openocddriver: fix command quoting and add tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
@@ -25,7 +25,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
-        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev ncurses-term graphviz
+        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev ncurses-term graphviz openocd
         sudo mkdir -p /var/cache/labgrid/runner && sudo chown runner /var/cache/labgrid/runner
     - name: Prepare local SSH
       run: |

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -64,7 +64,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
 
     def _get_usb_path_cmd(self):
         # OpenOCD supports "adapter usb location" since a1b308ab, released with 0.11.0-rc1
-        return ["--command", f"'adapter usb location \"{self.interface.path}\"'"]
+        return ["--command", f"adapter usb location \"{self.interface.path}\""]
 
     def _run_commands(self, commands: list):
         cmd = self.interface.command_prefix+[self.tool]
@@ -89,7 +89,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
             cmd.append("--file")
             cmd.append(mconfig.get_remote_path())
 
-        cmd += chain.from_iterable(("--command", f"'{command}'") for command in commands)
+        cmd += chain.from_iterable(("--command", f"{command}") for command in commands)
         processwrapper.check_output(
             cmd,
             print_on_silent_log=True

--- a/tests/test_openocd.py
+++ b/tests/test_openocd.py
@@ -1,0 +1,34 @@
+import pytest
+from shutil import which
+import subprocess
+
+from labgrid.resource.udev import USBDebugger
+from labgrid.driver.openocddriver import OpenOCDDriver
+
+
+pytestmark = pytest.mark.skipif(not which("openocd"),
+                              reason="openocd not available")
+
+
+def test_openocd_resource(target):
+    r = USBDebugger(target, name=None, match={"sys_name": "1-12"})
+
+
+def test_openocd_driver_activate(target):
+    r = USBDebugger(target, name=None, match={"sys_name": "1-12"})
+    r.avail = True
+    d = OpenOCDDriver(target, name=None)
+    target.activate(d)
+
+
+def test_openocd_driver(target, tmpdir):
+    r = USBDebugger(target, name=None, match={"sys_name": "1-12"})
+    r.avail = True
+    d = OpenOCDDriver(target, name=None, load_commands=["shutdown"])
+    target.activate(d)
+    d.load(__file__)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        d.execute(["invalid_command_labgrid"])
+
+    d.execute(["shutdown"])


### PR DESCRIPTION
**Description**
It seems that OpenOCD no longer accepts (or requires) extra quoting around the
`--command` arguments, so remove it. Also add some simple tests to detect
regressions in this area earlier.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested
