### PR TITLE
driver/shelldriver: handle bracketed-paste mode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ New Features in 0.5.0
 - Support for QEMU Q35 machine added.
 - `UBootDriver` now handles idle console, allowing driver activation on
   an interupted U-Boot.
+- `ShellDriver` now handles bracketed-paste mode (default in bash >= 5.1,
+  readline >= 8.1)
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -95,8 +95,9 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         # hide marker from expect
         cmp_command = f'''MARKER='{marker[:4]}''{marker[4:]}' run {shlex.quote(cmd)}'''
         self.console.sendline(cmp_command)
+        # match output by run function, bracketed-paste escape sequence (optionally), prompt
         _, _, match, _ = self.console.expect(
-            rf'{marker}(.*){marker}\s+(\d+)\s+{self.prompt}',
+            rf'{marker}(.*){marker}\s+(\d+)\s+(\x1b\[\?2004h)?{self.prompt}',
             timeout=timeout
         )
         # Remove VT100 Codes, split by newline and remove surrounding newline
@@ -200,8 +201,9 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         # hide marker from expect
         self.console.sendline(f"echo '{marker[:4]}''{marker[4:]}'")
         try:
+            # match marker, bracketed-paste escape sequence (optionally), prompt
             self.console.expect(
-                rf"{marker}\s+{self.prompt}",
+                rf"{marker}\s+(\x1b\[\?2004h)?{self.prompt}",
                 timeout=5
             )
             self._status = 1


### PR DESCRIPTION
**Description**
bash >= 5.1 and readline >= 8.1 enable bracketed-paste mode by default, allowing the terminal emulator to tell a program whether input was typed or pasted. To achieve this, `\e[?2004h` is inserted when user input is expected enabling paste detection. `\e[?2004l` is inserted to disable it.

To handle the escape sequences, match the enable sequence between marker and prompt. The disable sequence is already stripped by the regex removing all VT100 codes.

See https://github.com/pexpect/pexpect/issues/669

Tested with readline 8.1 and bash 5.1.16

**Checklist**
- [x] CHANGES.rst has been updated
- [x] PR has been tested

Fixes #969