### PR TITLE
driver/ubootdriver: Fix reset method

### DIFF
--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -141,9 +141,9 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     def reset(self):
         """Reset the board via a CPU reset
         """
-        self.status = 0
-        self.send("reset\n")
-        self.await_prompt()
+        self._status = 0
+        self.console.sendline("reset")
+        self._await_prompt()
 
     @step()
     def _await_prompt(self):


### PR DESCRIPTION
Update the U-Boot reset method to be equal with the Barebox method.

Signed-off-by: Daniel Schultz <d.schultz@phytec.de>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**

<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

Fixes #105