### PR TITLE
util: expect: implement sendcontrol()

### DIFF
--- a/labgrid/util/expect.py
+++ b/labgrid/util/expect.py
@@ -1,3 +1,5 @@
+import string
+
 import pexpect
 
 
@@ -21,6 +23,15 @@ class PtxExpect(pexpect.spawn):
 
         b = s
         return self.driver.write(b)
+
+    def sendcontrol(self, char):
+        """Send control character to underlying transport, e.g. Ctrl-C or Ctrl-Z."""
+        char = char.lower()
+        try:
+            ord_ = string.ascii_lowercase.index(char) + 1
+            self.send(bytes([ord_]))
+        except ValueError:
+            raise NotImplementedError(f"Sending control character {char} is not supported yet")
 
     def read_nonblocking(self, size=1, timeout=-1):
         """Pexpects needs a nonblocking read function, simply use pyserial with


### PR DESCRIPTION
**Description**
Sometimes it's useful to send Ctrl-C to interrupt a process or Ctrl-Z to send a hung process to the background and kill it then (e.g. gst-validate-1.0). This is often faster than transitioning to the off/root state and back to the shell.

Although pexpect.spawn has a sendcontrol() method, it relies on ptyprocess which is not useful for labgrid's usecase. So implement it here.

Note: was originally part of #552.

**Checklist**
- [ ] Tests for the feature 
- [x] PR has been tested