### PR TITLE
dockerfiles: add qemu-utils to labgrid-client

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -26,7 +26,7 @@ RUN set -e ;\
     pip3 install --no-cache-dir -r requirements.txt ;\
     SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" python3 setup.py install ;\
     apt update -q=2 ;\
-    apt install -q=2 --yes --no-install-recommends microcom openssh-client rsync jq qemu-system; \
+    apt install -q=2 --yes --no-install-recommends microcom openssh-client rsync jq qemu-system qemu-utils ;\
     apt clean ;\
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Timeout will occur in some configurations, for example, when the
ConsoleProtocol is used to match on events during a boostrap proccess
and those events are used to determine the when the ShellDriver is
deactivated/activated. This issue is fixed by including `qemu-utils` in
the image.

Signed-off-by: Emil Kronborg Andersen <emil.kronborg@protonmail.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
I tested this locally using an image that reboots by design. Without `qemu-utils`, the reboot event is not caught by the ConsoleProtocol and the test timeouts. When `qemu-utils` is included, it runs as expected in the container, that is, like it runs when not containerized. 

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
