### PR TITLE
sshdriver: escape password when writing to pass_file

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -4,6 +4,7 @@ import contextlib
 import logging
 import os
 import stat
+import shlex
 import shutil
 import subprocess
 import tempfile
@@ -117,7 +118,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             #openssh<8.4 requires the DISPLAY var and a detached process with start_new_session=True
             env = {'SSH_ASKPASS': pass_file, 'DISPLAY':'', 'SSH_ASKPASS_REQUIRE':'force'}
             with open(fd, 'w') as f:
-                f.write("#!/bin/sh\necho " + self.networkservice.password)
+                f.write("#!/bin/sh\necho " + shlex.quote(self.networkservice.password))
 
         self.process = subprocess.Popen(args, env=env,
                                         stdout=subprocess.PIPE,


### PR DESCRIPTION
This avoids shell interpretation in case the password contains special
characters.