### PR TITLE
Fix simplerest

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -198,7 +198,7 @@ Currently available are:
 
 ``simplerest``
   This is a generic backend for PDU implementations which can be controlled via
-  HTTP GET requests (both set and get).
+  HTTP GET and PUT requests.
   See the `docstring in the module
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
   for details.

--- a/labgrid/driver/power/simplerest.py
+++ b/labgrid/driver/power/simplerest.py
@@ -17,8 +17,7 @@ def power_set(host, port, index, value):
 
     index = int(index)
     value = 1 if value else 0
-    r = requests.get(host.format(value=value, index=index))
-    r.raise_for_status()
+    requests.put(host.format(value=value, index=index))
 
 def power_get(host, port, index):
     assert port is None

--- a/labgrid/driver/power/simplerest.py
+++ b/labgrid/driver/power/simplerest.py
@@ -25,5 +25,6 @@ def power_get(host, port, index):
     index = int(index)
     # remove trailing /
     r = requests.get(host.format(value='', index=index).rstrip('/'))
+    data = r.json()
     r.raise_for_status()
-    return r.text == '1'
+    return data['state'] == '1'


### PR DESCRIPTION
Hi

We want the python3-powerrelay from meta-labgrid to work. python3-powerrelay has always worked using PUT, and not get, for setting power. Hence patching is needing either in python3-powerrelay or labgrid. Proposing to do the change in labgrid.

If someone are using an alternative to python3-powerrelay that uses GET, I would like to know so we can switch to using that instead.

