### PR TITLE
remote/client: relax SerialDriver requirement for -s/--state

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -710,12 +710,15 @@ class ClientSession(ApplicationSession):
                     from labgrid.stepreporter import StepReporter
                     StepReporter()
                 from labgrid.strategy import Strategy
-                from labgrid.driver import SerialDriver
                 strategy = target.get_driver(Strategy)
                 print(f"Transitioning into state {self.args.state}")
                 strategy.transition(self.args.state)
-                serial = target.get_active_driver(SerialDriver)
-                target.deactivate(serial)
+                # deactivate console drivers so we are able to connect with microcom later
+                try:
+                    con = target.get_active_driver("ConsoleProtocol")
+                    target.deactivate(con)
+                except NoDriverFoundError:
+                    pass
         else:
             target = Target(place.name, env=self.env)
             RemotePlace(target, name=place.name)


### PR DESCRIPTION
**Description**
When using -s/--state labgrid deactivates the SerialDriver after transitioning to the Strategy state to allow exclusive access to the serial port for microcom. Strategies and environment configs do not necessarily contain an (active) SerialDriver, e.g. in case only a SSHDriver is used or a state is requested with no SerialDriver active yet. Or an ExternalConsoleDriver might be in use instead.

To relax this requirement, try to get an active driver implementing the ConsoleProtocol. If no such driver is found, continue.

**Checklist**
- [x] PR has been tested