### PR TITLE
factory: pass copy of driver/resource args to avoid modifying config in place

### DIFF
--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -87,6 +87,7 @@ class TargetFactory:
                 result.append(item)
         elif isinstance(data, dict):
             for cls, args in data.items():
+                args = args.copy()
                 args.setdefault('cls', cls)
                 result.append(args)
         else:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from copy import deepcopy
 
 import attr
 import pytest
@@ -16,49 +17,56 @@ def test_empty():
 
 
 def test_resources():
-    t = target_factory.make_target(
-        'dummy', {
-            'resources': OrderedDict([
-                ('RawSerialPort', {
-                    'port': 'foo',
-                    'speed': 115200
-                }),
-            ]),
-        }
-    )
+    original_config = {
+        'resources': OrderedDict([
+            ('RawSerialPort', {
+                'port': 'foo',
+                'speed': 115200,
+                'name': 'console',
+            }),
+        ]),
+    }
+    config = deepcopy(original_config)
+    t = target_factory.make_target('dummy', config)
     assert isinstance(t, Target)
     assert t.get_resource(SerialPort) is not None
+    assert config == original_config
 
 
 def test_drivers():
-    t = target_factory.make_target(
-        'dummy', {
-            'resources': OrderedDict([
-                ('RawSerialPort', {
-                    'port': 'foo',
-                    'speed': 115200
-                }),
-            ]),
-            'drivers': OrderedDict([
-                ('FakeConsoleDriver', {}),
-                ('ShellDriver', {
-                    'prompt': '',
-                    'login_prompt': '',
-                    'username': ''
-                }),
-            ]),
-        }
-    )
+    original_config = {
+        'resources': OrderedDict([
+            ('RawSerialPort', {
+                'port': 'foo',
+                'speed': 115200
+            }),
+        ]),
+        'drivers': OrderedDict([
+            ('FakeConsoleDriver', {
+                'name': 'console',
+            }),
+            ('ShellDriver', {
+                'name': 'shell',
+                'prompt': '',
+                'login_prompt': '',
+                'username': ''
+            }),
+        ]),
+    }
+    config = deepcopy(original_config)
+    t = target_factory.make_target('dummy', config)
     assert isinstance(t, Target)
     assert t.get_resource(SerialPort) is not None
+    assert config == original_config
 
 
 def test_convert_dict():
-    data = load("""
+    original_data = load("""
     FooPort: {}
     BarPort:
       name: bar
     """)
+    data = deepcopy(original_data)
     l = target_factory._convert_to_named_list(data)
     assert l == [
         {
@@ -70,14 +78,16 @@ def test_convert_dict():
             'name': 'bar'
         },
     ]
+    assert data == original_data
 
 
 def test_convert_simple_list():
-    data = load("""
+    original_data = load("""
     - FooPort: {}
     - BarPort:
         name: bar
     """)
+    data = deepcopy(original_data)
     l = target_factory._convert_to_named_list(data)
     assert l == [
         {
@@ -89,14 +99,16 @@ def test_convert_simple_list():
             'name': 'bar'
         },
     ]
+    assert data == original_data
 
 
 def test_convert_explicit_list():
-    data = load("""
+    original_data = load("""
     - cls: FooPort
     - cls: BarPort
       name: bar
     """)
+    data = deepcopy(original_data)
     l = target_factory._convert_to_named_list(data)
     assert l == [
         {
@@ -108,6 +120,7 @@ def test_convert_explicit_list():
             'name': 'bar'
         },
     ]
+    assert data == original_data
 
 
 def test_convert_error():

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -123,6 +123,32 @@ def test_convert_explicit_list():
     assert data == original_data
 
 
+def test_normalize_config():
+    original_config = {
+        'resources': OrderedDict([
+            ('RawSerialPort', {
+                'port': 'foo',
+                'speed': 115200
+            }),
+        ]),
+        'drivers': OrderedDict([
+            ('FakeConsoleDriver', {
+                'name': 'console',
+            }),
+        ]),
+    }
+    config = deepcopy(original_config)
+    resources, drivers = target_factory.normalize_config(config)
+
+    assert 'RawSerialPort' in resources
+    assert resources['RawSerialPort'] == {None: ({'port': 'foo', 'speed': 115200},)}
+
+    assert 'FakeConsoleDriver' in drivers
+    assert drivers['FakeConsoleDriver'] == {'console': ({}, {})}
+
+    assert config == original_config
+
+
 def test_convert_error():
     with pytest.raises(InvalidConfigError) as excinfo:
         data = load("""


### PR DESCRIPTION
**Description**
`normalize_config()` and `make_target()` modify the referenced dicts returned by `_convert_to_named_list()`, meaning they modify the config in case resources or drivers are dictionaries, not lists:

```yaml
resources: # or drivers
  FooPort: {}
  BarPort:
    name: "bar"
```

For the list case, copies of the relevant items are already used.

The modification happens when popping `name`, `cls` and `bindings` from the arguments.

This can be observed with an env.yaml containing a RemotePlace resource having a `name` argument:

```yaml
targets:
  main:
    resources:
      RemotePlace:
        name: myplace
```

Now we pass this environment config to labgrid-client:

```
  $ labgrid-client --debug --config env.yaml console
  Selected role main and place myplace from configuration file
    DEBUG: expanded remote resources for place None: [NetworkPowerPort(target=Target(name='main', env=Environment(config_file='env.yaml')), name='NetworkPowerPort', state=<BindingState.bound: 1>, avail=True, model='netio', host='example.com', index='3')]
```

Note the "place myplace" in the first message and the "place None" in the second message. Between these messages, the RemotePlace's name was dropped and replaced with a default (`None`).

Note that RemotePlace is only a simple example for a resource or driver with an argument that is modified in the config.

To avoid config modification, make `_convert_to_named_list()` return a list of copied argument dictionaries that can be normalized and turned into a target without modifying the config.

Add check to factory tests that `make_target()` does not modify given config.
Also add a test for `target_factory.normalize_config()`.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested