### PR TITLE
github/pull_request_template: drop CHANGES.rst update checkbox

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,10 +29,6 @@ A library feature which other developers can use:
 --->
 - [ ] Add a section on how to use the feature to doc/development.rst
 <!---
-Provide a short summary for the CHANGES.rst file
---->
-- [ ] CHANGES.rst has been updated
-<!---
 Did you test the change locally? If yes, best to mention how you did it in the description section.
 --->
 - [ ] PR has been tested

--- a/doc/RELEASE.rst
+++ b/doc/RELEASE.rst
@@ -33,8 +33,7 @@ A frozen environment is already created in the previous step.
 3. Update CHANGES.rst
 =====================
 
-Update the `CHANGES.rst` file. This should ideally be done in every pull request,
-but its better to check that the `CHANGES.rst` is up to date.
+Update the `CHANGES.rst` file.
 Ensure that no incompatiblities are unlisted and that all major features are
 described in a separate section.
 It's best to compare against the git log.


### PR DESCRIPTION
**Description**
Experience shows that these tend to introduce merge conflicts. Since we have to dig through the PRs anyway to make sure the release notes are complete when doing a release, we can drop the checkbox altogether.