### PR TITLE
Added Vendor/Model ID for Olimex USBDebuggers

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -687,6 +687,10 @@ class USBDebugger(USBResource):
 
         if match not in [("0403", "6010"),  # FT2232C/D/H Dual UART/FIFO IC
                          ("0483", "374f"),  # STLINK-V3
+                         ("15ba", "0003"),  # Olimex ARM-USB-OCD
+                         ("15ba", "002b"),  # Olimex ARM-USB-OCD-H
+                         ("15ba", "0004"),  # Olimex ARM-USB-TINY
+                         ("15ba", "002a"),  # Olimex ARM-USB-TINY-H
                          ]:
             return False
 


### PR DESCRIPTION

**Description**
added support for olimex usb-debuggers by including their IDs in resources/udev.py

**Checklist**
- [x] PR has been tested
- not locally but same exact changes work on remote machine
- only ARM-USB-OCD-H has been tested, the others were included expecting them to work as well
- IDs are specified in https://www.olimex.com/Products/ARM/JTAG/_resources/ARM-USB-OCD_and_OCD_H_manual.pdf
- (page 7 table 2)

Signed-off-by: Marvin Sacher marvin.sacher@protonmail.com
