### PR TITLE
Added Vendor/Model IDs for Olimex USBDebuggers

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -687,6 +687,10 @@ class USBDebugger(USBResource):
 
         if match not in [("0403", "6010"),  # FT2232C/D/H Dual UART/FIFO IC
                          ("0483", "374f"),  # STLINK-V3
+                         ("15ba", "0003"),  # Olimex ARM-USB-OCD
+                         ("15ba", "002b"),  # Olimex ARM-USB-OCD-H
+                         ("15ba", "0004"),  # Olimex ARM-USB-TINY
+                         ("15ba", "002a"),  # Olimex ARM-USB-TINY-H
                          ]:
             return False
 


### PR DESCRIPTION
Signed-off-by: Marvin Sacher marvin.sacher@protonmail.com

**Description**
Added Vendor/Model IDs to support Olimex Products in /resource/udev.py USBDebugger

**Checklist**
- [x] PR has been tested
- has been tested on remote machine with exact same changes
- only ARM-USB-OCD-H has been tested, expecting the others to work as well 