### PR TITLE
Added Olimex Vendor/Product IDs for USBDebugger resource

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -687,6 +687,10 @@ class USBDebugger(USBResource):
 
         if match not in [("0403", "6010"),  # FT2232C/D/H Dual UART/FIFO IC
                          ("0483", "374f"),  # STLINK-V3
+			 ("15ba", "0003"),  # Olimex ARM-USB-OCD
+			 ("15ba", "002b"),  # Olimex ARM-USB-OCD-H
+			 ("15ba", "0004"),  # Olimex ARM-USB-TINY
+			 ("15ba", "002a"),  # Olimex ARM-USB-TINY-H
                          ]:
             return False
 


### PR DESCRIPTION
Signed-off-by: Marvin Sacher <marvin.sacher@protonmail.com>

**Description**
Added support for Olimex USB-Debugger Devices.
Resource USBDebugger now supports those IDs.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Provide a short summary for the CHANGES.rst file
--->
- [ ] CHANGES.rst has been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
- ARM-USB-OCD-H has been tested on remote machine with exact same changes.
- Others are expected to work as well
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
