### PR TITLE
Allow proxying of dynamic port power backends with URL in host parameter

### DIFF
--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -1,6 +1,6 @@
 import os
 
-from urllib.parse import urlsplit, urlunsplit
+from urllib.parse import urlsplit, urlunsplit, urlparse
 
 from .ssh import sshmanager
 
@@ -43,7 +43,8 @@ class ProxyManager:
         """
         assert isinstance(res, Resource)
 
-        s = urlsplit('//'+res.host)
+        prefix = '' if '//' in res.host else '//'
+        s = urlparse(prefix + res.host)
         host = s.hostname
         if force_port:
             port = force_port

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -1,3 +1,5 @@
+from urllib.parse import urlparse
+
 import pytest
 
 from labgrid.resource import NetworkPowerPort
@@ -158,6 +160,40 @@ class TestNetworkPowerDriver:
         r = NetworkPowerPort(target, 'power', model='netio', host='dummy', index='1')
         d = NetworkPowerDriver(target, 'power')
         assert isinstance(d, NetworkPowerDriver)
+
+    @pytest.mark.parametrize('backend', ('rest', 'simplerest'))
+    @pytest.mark.parametrize(
+        'host',
+        (
+            'http://example.com/{index}',
+            'https://example.com/{index}',
+            'http://example.com:1234/{index}',
+            'https://example.com:1234/{index}',
+        )
+    )
+    def test_create_backend_with_url_in_host(self, target, mocker, backend, host):
+        get = mocker.patch('requests.get')
+        get.return_value.text = '1'
+        mocker.patch('requests.put')
+
+        index = '1'
+        NetworkPowerPort(target, 'power', model=backend, host=host, index=index)
+        d = NetworkPowerDriver(target, 'power')
+        assert isinstance(d, NetworkPowerDriver)
+        target.activate(d)
+
+        d.cycle()
+        assert d.get() is True
+
+        # the called URL should be similar to the one configured in the resource, but with
+        # index and explicit port
+        expected_host = host.format(index=index)
+        url = urlparse(expected_host)
+        if ':' not in url.netloc:
+            implicit_port = 443 if url.scheme == 'https' else 80
+            expected_host = expected_host.replace(url.netloc, f'{url.netloc}:{implicit_port}')
+
+        get.assert_called_with(expected_host)
 
     def test_import_backends(self):
         import labgrid.driver.power


### PR DESCRIPTION
**Description**
Some power backends (`rest`, `simplerest`) store a full URL in the resource's host parameter. As these backends cannot specify a `PORT` since it can be a flexible part of the URL specified in the exporter, such resources cannot be proxied currently.

As a prerequisite, allow this when requesting a proxy connection for such a resource.

Then add a method to the `NetworkPowerDriver` trying to handle the host parameter as a URL and extract the port from it. Use this port to request the proxy forward for. Finally construct a proxied variant of the host parameter to pass to `on()`, `off()` and `get()`.

This allows to use power backends such as `rest` and `simplerest` to be proxied.

Tested with a remote [LXA Test Automation Controller](https://www.linux-automation.com/en/products/lxa-tac.html) via:
```
$ export LG_CROSSBAR=ws://remote-coordinator:20408/ws LG_PLACE=myplace LG_PROXY=lxatac-00001
$ labgrid-client show
Place 'myplace':
  matches:
    lxatac-00001/dut_power/NetworkPowerPort
  acquired: example/bst
  acquired resources:
    lxatac-00001/dut_power/NetworkPowerPort/NetworkPowerPort
  created: 2022-03-06 21:47:54.977859
  changed: 2022-09-15 11:37:25.148680
Acquired resource 'NetworkPowerPort' (lxatac-00001/dut_power/NetworkPowerPort/NetworkPowerPort):
  {'acquired': 'myplace',
   'avail': True,
   'cls': 'NetworkPowerPort',
   'params': {'extra': {'proxy': 'lxatac-00001', 'proxy_required': False},
              'host': 'http://lxatac-00001/dut/enable',
              'index': '0',
              'model': 'rest'}}
$ labgrid-client -d power get
  DEBUG: Creating SSHConnection for lxatac-00001
  DEBUG: No existing control socket found
  DEBUG: ControlSocket: /tmp/labgrid-connection-129qedac/control-lxatac-00001
  DEBUG: Master Start command: ssh -x -o LogLevel=ERROR -o PasswordAuthentication=no -n -MN -o ConnectTimeout=30 -o ControlPersist=300 -o ControlMaster=yes -o ControlPath=/tmp/labgrid-connection-129qedac/control-lxatac-00001 -o StrictHostKeyChecking=yes lxatac-00001
  DEBUG: Connected to lxatac-00001
   INFO: Created new SSH connection to lxatac-00001
  DEBUG: Started keepalive for lxatac-00001
  DEBUG: Running control command: ssh -x -o LogLevel=ERROR -o PasswordAuthentication=no -o ControlMaster=no -o ControlPath=/tmp/labgrid-connection-129qedac/control-lxatac-00001 -O forward -L39453:nas:20408 lxatac-00001
  DEBUG: expanded remote resources for place myplace: [NetworkPowerPort(target=Target(name='myplace', env=None), name='NetworkPowerPort', state=<BindingState.bound: 1>, avail=True, model='rest', host='http://lxatac-00001/dut/enable', index='0')]
  DEBUG: Running control command: ssh -x -o LogLevel=ERROR -o PasswordAuthentication=no -o ControlMaster=no -o ControlPath=/tmp/labgrid-connection-129qedac/control-lxatac-00001 -O forward -L39259:lxatac-00001:80 lxatac-00001
  DEBUG: Starting new HTTP connection (1): localhost:39259
  DEBUG: http://localhost:39259 "GET /dut/enable HTTP/1.1" 200 1
power for place myplace is off
   INFO: Closing SSH connection to lxatac-00001
  DEBUG: Stopping keepalive for lxatac-00001
  DEBUG: Running control command: ssh -x -o LogLevel=ERROR -o PasswordAuthentication=no -o ControlMaster=no -o ControlPath=/tmp/labgrid-connection-129qedac/control-lxatac-00001 -O cancel lxatac-00001
  DEBUG: Running control command: ssh -x -o LogLevel=ERROR -o PasswordAuthentication=no -o ControlMaster=no -o ControlPath=/tmp/labgrid-connection-129qedac/control-lxatac-00001 -O exit lxatac-00001
```
Test cases for this were added.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested