### PR TITLE
tests: fix pytest deprecation warnings

### DIFF
--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -195,7 +195,6 @@ imports:
         """
         )
         e = Environment(str(p))
-        with pytest.warns(None) as record:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             t = e.get_target("test1")
-        for i in record.list:
-            assert i.category != 'UserWarning'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -2,6 +2,7 @@ import os.path
 import subprocess
 import socket
 import atexit
+import warnings
 
 from shutil import which
 
@@ -61,9 +62,9 @@ def test_filter_dict():
 
     d_orig = {'foo': 1, 'bar': 2, 'baz': 3}
 
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         d_filtered = filter_dict(d_orig, A)
-    assert not record
     assert d_filtered is not d_orig
     assert d_filtered == {'foo': 1}
 


### PR DESCRIPTION
**Description**
Implement non-deprecated (pytest >= 7.0.0) way of assuring no warnings in environment and util tests.

Note: preliminary work for pytest version bump or relaxed dependencies; commits taken from #891

**Checklist**
- [x] PR has been tested