### PR TITLE
requirements/setup.cfg: drop yapf

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,6 @@ pytest-isort==2.0.0
 pytest-mock==3.6.1
 pytest-pylint==0.18.0
 pytest-dependency==0.5.1
-yapf==0.31.0
 psutil==5.8.0
 -r doc-requirements.txt
 -r crossbar-requirements.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,5 @@ test = pytest
 [tool:pytest]
 testpaths = tests labgrid
 addopts = -p no:labgrid
-[yapf]
-dedent_closing_brackets = true
-coalesce_brackets = true
 [build_sphinx]
 warning-is-error = 1


### PR DESCRIPTION
**Description**
We do not use yapf in our current workflow. To improve code style consistency and reduce discussions about style, we want to switch to [black](https://github.com/psf/black) in a future PR and enforce it via CI step by step.

For now, only drop yapf.