### PR TITLE
drivers/sshdriver: add support for the SFTP protocol for file transfers

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1491,6 +1491,8 @@ Arguments:
     stdout, and an empty list as second element.
   - connection_timeout (float, default=30.0): timeout when trying to establish connection to
     target.
+  - explicit_sftp_mode (bool, default=False): if set to True, `put()` and `get()` will
+    explicitly use the SFTP protocol for file transfers instead of scp's default protocol
 
 UBootDriver
 ~~~~~~~~~~~


### PR DESCRIPTION
Recent versions of OpenSSH allow using the SFTP protocol in favor of the deprecated SCP protocol, and from OpenSSH 9, SCP will use the SFTP protocol by default. Therefore, `put()` and `get()` can now be configured to use SFTP by setting `sftp` to true for `SSHDriver`.

Signed-off-by: Emil Kronborg Andersen <emil.kronborg@protonmail.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
I tested the change locally using an image that only supports SFTP. Without this change, I am unable to transfer files using `put()` and `get()`. However, applying this change, the methods work as expect.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
