### PR TITLE
client: show names for multiple matching resources

### DIFF
--- a/labgrid/exceptions.py
+++ b/labgrid/exceptions.py
@@ -27,7 +27,10 @@ class NoDriverFoundError(NoSupplierFoundError):
 
 @attr.s(eq=False)
 class NoResourceFoundError(NoSupplierFoundError):
-    pass
+    found = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(list))
+    )
 
 
 @attr.s(eq=False)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1957,7 +1957,12 @@ def main():
                 traceback.print_exc()
             else:
                 print(f"{parser.prog}: error: {e}", file=sys.stderr)
-            print("This may be caused by disconnected exporter or wrong match entries.\nYou can use the 'show' command to review all matching resources.", file=sys.stderr)  # pylint: disable=line-too-long
+            if e.found:
+                print("Found multiple resources but no name was given, available names:")
+                for res in e.found:
+                    print(f"{res.name}")
+            else:
+                print("This may be caused by disconnected exporter or wrong match entries.\nYou can use the 'show' command to review all matching resources.", file=sys.stderr)  # pylint: disable=line-too-long
             exitcode = 1
         except NoDriverFoundError as e:
             if args.debug:

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -138,7 +138,7 @@ class Target:
             )
         elif len(found) > 1:
             raise NoResourceFoundError(
-                f"multiple resources matching {cls} found in {self}"
+                f"multiple resources matching {cls} found in {self}", found=found
             )
         if wait_avail:
             self.await_resources(found)


### PR DESCRIPTION
**Description**

When matching multiple resources but not having a name, we raise an unintuitive error about not finding a resource, but don't indicate the available names. Bubble up the found resources and provide a neat list to the user to select from the available names.

**Checklist**
- [x] PR has been tested