### PR TITLE
processwrapper: Add input argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ New Features in 0.5.0
 - Support for QEMU Q35 machine added.
 - `UBootDriver` now handles idle console, allowing driver activation on
   an interupted U-Boot.
+- ProcessWrapper now supports an "input" argument to check_output() that allows
+  a string to be passed to stdin of the process
 
 Bug fixes in 0.5.0
 ~~~~~~~~~~~~~~~~~~

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -4,6 +4,7 @@ import logging
 import pty
 import select
 import subprocess
+import errno
 from socket import socket, AF_INET, SOCK_STREAM
 from contextlib import closing
 
@@ -26,21 +27,34 @@ def get_user():
     import pwd
     return pwd.getpwuid(os.getuid())[0]
 
+def set_nonblocking(fd):
+    flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+    fcntl.fcntl(fd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+
 @attr.s
 class ProcessWrapper:
     callbacks = attr.ib(default=attr.Factory(list))
     loglevel = logging.INFO
 
     @step(args=['command'], result=True, tag='process')
-    def check_output(self, command, *, print_on_silent_log=False):
+    def check_output(self, command, *, print_on_silent_log=False, input=None): # pylint: disable=redefined-builtin
         """Run a command and supply the output to callback functions"""
         logger = logging.getLogger("Process")
         res = []
         mfd, sfd = pty.openpty()
-        flags = fcntl.fcntl(mfd, fcntl.F_GETFL)
-        fcntl.fcntl(mfd, fcntl.F_SETFL, flags | os.O_NONBLOCK)
+        set_nonblocking(mfd)
+
+        kwargs = {}
+
+        stdin_r = None
+        stdin_w = None
+        if input is not None:
+            stdin_r, stdin_w = os.pipe()
+            kwargs['stdin'] = stdin_r
+            set_nonblocking(stdin_w)
+
         process = subprocess.Popen(command, stderr=sfd,
-                                   stdout=sfd, bufsize=0)
+                                   stdout=sfd, bufsize=0, **kwargs)
 
         logger.log(ProcessWrapper.loglevel, "[%d] command: %s", process.pid, " ".join(command))
 
@@ -51,32 +65,65 @@ class ProcessWrapper:
         if print_on_silent_log and logger.getEffectiveLevel() > ProcessWrapper.loglevel:
             self.enable_print()
 
+        if stdin_r is not None:
+            os.close(stdin_r)
+
         # close sfd so we notice when the child is gone
         os.close(sfd)
         # get a file object from the fd
         buf = b""
-        while True:
-            try:
-                raw = os.read(mfd, 4096)
-            except BlockingIOError:
-                # wait for new data and retry
-                select.select([mfd], [], [mfd], 0.1)
-                continue
-            except OSError as e:
-                if e.errno == 5:
-                    break
-                raise
+        read_fds = [mfd]
+        write_fds = []
+        if stdin_w is not None:
+            write_fds.append(stdin_w)
 
-            if raw:
-                buf += raw
-                *parts, buf = buf.split(b'\r')
-                res.extend(parts)
-                for part in parts:
-                    for callback in self.callbacks:
-                        callback(part, process)
+        while True:
+            ready_r, ready_w, _ = select.select(read_fds, write_fds, [], 0.1)
+
+            if mfd in ready_r:
+                raw = None
+
+                try:
+                    raw = os.read(mfd, 4096)
+                except BlockingIOError:
+                    pass
+                except OSError as e:
+                    if e.errno == errno.EIO:
+                        break
+                    raise
+
+                if raw:
+                    buf += raw
+                    *parts, buf = buf.split(b'\r')
+                    res.extend(parts)
+                    for part in parts:
+                        for callback in self.callbacks:
+                            callback(part, process)
+
+            if stdin_w in ready_w:
+                if input:
+                    amt = 0
+                    try:
+                        amt = os.write(stdin_w, input)
+                    except BlockingIOError:
+                        pass
+                    except OSError as e:
+                        if e.errno == errno.EIO:
+                            break
+                        raise
+                    input = input[amt:]
+
+                if not input:
+                    write_fds.remove(stdin_w)
+                    os.close(stdin_w)
+                    stdin_w = None
+
             process.poll()
             if process.returncode is not None:
                 break
+
+        if stdin_w is not None:
+            os.close(stdin_w)
 
         os.close(mfd)
         process.wait()

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -54,13 +54,16 @@ class TestExternalPowerDriver:
         fdopen = mocker.patch('os.fdopen')
         close = mocker.patch('os.close')
         popen = mocker.patch('subprocess.Popen')
+        select = mocker.patch('select.select')
         fd_mock = mocker.MagicMock()
         instance_mock = mocker.MagicMock()
+        select_mock = mocker.MagicMock()
         popen.return_value = instance_mock
         fdopen.return_value = fd_mock
         pty.return_value = (instance_mock, 2)
         fd_mock.read.return_value = b'Done\nDone'
         instance_mock.returncode = 0
+        select.return_value = ([], [], [])
 
         d = ExternalPowerDriver(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
@@ -77,13 +80,16 @@ class TestExternalPowerDriver:
         fdopen = mocker.patch('os.fdopen')
         close = mocker.patch('os.close')
         popen = mocker.patch('subprocess.Popen')
+        select = mocker.patch('select.select')
         fd_mock = mocker.MagicMock()
         instance_mock = mocker.MagicMock()
+        select_mock = mocker.MagicMock()
         popen.return_value = instance_mock
         fdopen.return_value = fd_mock
         pty.return_value = (instance_mock, 2)
         fd_mock.read.return_value = b'Done\nDone'
         instance_mock.returncode = 0
+        select.return_value = ([], [], [])
 
         d = ExternalPowerDriver(
             target, 'power', cmd_on='set -1 foo-board', cmd_off='set -0 foo-board'
@@ -100,13 +106,16 @@ class TestExternalPowerDriver:
         fdopen = mocker.patch('os.fdopen')
         close = mocker.patch('os.close')
         popen = mocker.patch('subprocess.Popen')
+        select = mocker.patch('select.select')
         fd_mock = mocker.MagicMock()
         instance_mock = mocker.MagicMock()
+        select_mock = mocker.MagicMock()
         popen.return_value = instance_mock
         fdopen.return_value = fd_mock
         pty.return_value = (instance_mock, 2)
         fd_mock.read.return_value = b'Done\nDone'
         instance_mock.returncode = 0
+        select.return_value = ([], [], [])
 
         m_sleep = mocker.patch('time.sleep')
 
@@ -130,13 +139,16 @@ class TestExternalPowerDriver:
         fdopen = mocker.patch('os.fdopen')
         close = mocker.patch('os.close')
         popen = mocker.patch('subprocess.Popen')
+        select = mocker.patch('select.select')
         fd_mock = mocker.MagicMock()
         instance_mock = mocker.MagicMock()
+        select_mock = mocker.MagicMock()
         popen.return_value = instance_mock
         fdopen.return_value = fd_mock
         pty.return_value = (instance_mock, 2)
         fd_mock.read.return_value = b'Done\nDone'
         instance_mock.returncode = 0
+        select.return_value = ([], [], [])
 
         m_sleep = mocker.patch('time.sleep')
 

--- a/tests/test_processwrapper.py
+++ b/tests/test_processwrapper.py
@@ -1,0 +1,50 @@
+import pytest
+import subprocess
+import textwrap
+
+from labgrid.util.helper import processwrapper
+
+
+def test_processwrapper_passes():
+    processwrapper.check_output(["true"])
+
+
+def test_processwrapper_fails():
+    with pytest.raises(subprocess.CalledProcessError):
+        processwrapper.check_output(["false"])
+
+
+def test_processwrapper_output(tmpdir):
+    content = textwrap.dedent(
+        """\
+        A
+        B
+        C
+        """
+    )
+
+    tmpfile = tmpdir.join("output.txt")
+    tmpfile.write(content)
+
+    output = processwrapper.check_output(["cat", str(tmpfile)])
+
+    assert output.decode("utf-8") == content
+
+
+def test_processwrapper_input():
+    content = textwrap.dedent(
+        """\
+        A
+        B
+        C
+        """
+    )
+
+    output = processwrapper.check_output(["cat", "-"], input=content.encode("utf-8"))
+
+    assert output.decode("utf-8") == content
+
+
+def test_processwrapper_empty_input():
+    output = processwrapper.check_output(["cat", "-"], input=b"")
+    assert output.decode("utf-8") == ""


### PR DESCRIPTION

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Adds an input argument that allows a string to be passed as input to the process, matching subprocess.run().

Signed-off-by: Joshua Watt <Joshua.Watt@garmin.com>

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
