### PR TITLE
acquire: support automatic setting of LG_PLACE via --shell

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -159,6 +159,27 @@ used by ``wait`` and expanded via ``-p +``.
     changed: 2019-08-06 13:06:09.667682
     reservation: ZDMZJZNLBF
 
+Similarly, the ``labgrid-client lock`` command supports a ``--shell` command to
+print code for evaluation in the shell. This sets the ``LG_PLACE`` environment
+variable, which is then automatically picked up by any subcommand that expects
+the ``-p``/``--place`` command line option.
+
+.. code-block:: bash
+
+  $ eval `labgrid-client -p + lock --shell`
+  $ echo $LG_PLACE
+  board-1
+  $ labgrid-client show
+  Place 'board-1':
+    tags: bar=baz, board=imx6-foo, jlu=2, rcz=1
+    matches:
+      rettich/Testport1/NetworkSerialPort
+    acquired: rettich/jlu
+    acquired resources:
+    created: 2019-07-29 16:11:52.006269
+    changed: 2019-08-06 13:06:09.667682
+    reservation: ZDMZJZNLBF
+
 Finally, to avoid calling the ``wait`` command explicitly, you can add
 ``--wait`` to the ``reserve`` command, so it waits until the reservation is
 allocated before returning.

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -597,7 +597,10 @@ class ClientSession(ApplicationSession):
         )
 
         if res:
-            print(f"acquired place {place.name}")
+            if self.args.shell:
+                print(f"export LG_PLACE={place.name}")
+            else:
+                print(f"acquired place {place.name}")
             return
 
         # check potential failure causes
@@ -1674,6 +1677,8 @@ def main():
                                       help="acquire a place")
     subparser.add_argument('--allow-unmatched', action='store_true',
                            help="allow missing resources for matches when locking the place")
+    subparser.add_argument('--shell', action='store_true',
+                           help="format output as shell variables")
     subparser.set_defaults(func=ClientSession.acquire)
 
     subparser = subparsers.add_parser('release',


### PR DESCRIPTION
This works in exactly the same way as `labgrid-client reserve KEY=VALUE --shell`, except we export the name of place that has been acquired as LG_PLACE.

Useful in a CI setup where multiple machines could match your request for a reservation combined with using templating in your environment configuration. E.g. for use with pytest:

    targets:
      main:
        resources:
          RemotePlace:
            name: !template $LG_PLACE

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [x] Add a section on how to use the feature to doc/usage.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
