### PR TITLE
agentwrapper: Add path argument to load()

### DIFF
--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -103,13 +103,14 @@ class AgentWrapper:
 
         raise AgentError(f"unknown response from agent: {response}")
 
-    def load(self, name):
+    def load(self, name, path=None):
         if name in self.loaded:
             return self.loaded[name]
 
-        filename = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            'agents', f'{name}.py')
+        if path is None:
+            path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'agents')
+
+        filename = os.path.join(path, f'{name}.py')
         source = open(filename, 'r').read()
 
         self.call('load', name, source)


### PR DESCRIPTION
Allow users to place agent scripts in locations external to the labgrid repository.   The provided `path` should contain the desired script to load named as `{name}.py`.

Signed-off-by: Nick Potenski <nick.potenski@garmin.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
