### PR TITLE
Allow Command Wraping in NetworkResources, Use it in OpenOCDDriver

### DIFF
--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -66,7 +66,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         return ["--command", f"adapter usb location \"{self.interface.path}\""]
 
     def _run_commands(self, commands: list):
-        cmd = self.interface.command_prefix+[self.tool]
+        cmd = [self.tool]
         cmd += chain.from_iterable(("--search", path) for path in self.search)
         cmd += self._get_usb_path_cmd()
 
@@ -90,7 +90,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
 
         cmd += chain.from_iterable(("--command", f"{command}") for command in commands)
         processwrapper.check_output(
-            cmd,
+            self.interface.wrap_command(cmd),
             print_on_silent_log=True
         )
 

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -1,3 +1,4 @@
+import shlex
 from typing import Dict, Type, List
 import attr
 
@@ -28,6 +29,14 @@ class Resource(BindingMixin):
     @property
     def command_prefix(self):
         return []
+
+    def wrap_command(self, command):
+        """
+        Returns the command as-is, no need for command wrapping for local resources.
+
+        Must stay compatible with NetworkResource.wrap_command().
+        """
+        return command
 
     @property
     def parent(self):
@@ -78,6 +87,15 @@ class NetworkResource(Resource):
         prefix = conn.get_prefix()
 
         return prefix + ['--']
+
+    def wrap_command(self, command):
+        """
+        Returns shell-escaped command with prepended command_prefix.
+
+        Must stay compatible with Resource.wrap_command().
+        """
+        shargs = [shlex.quote(a) for a in command]
+        return self.command_prefix + shargs
 
 
 @attr.s(eq=False)


### PR DESCRIPTION
**Description**
Until now drivers simply prepend the command_prefix for commands that should work on local and network resources. For local resources, it is empty, for network resources, it contains `["ssh", .., "<exporter>", "--"]`.

In some cases this is not enough, because the argument separation is lost when the command is run via SSH. This means we need shell escaping, but only for network resources.

So add a `wrap_command()` method to Resource and NetworkResource. For Resources, it simply returns the passed command. For NetworkResources, the `command_prefix` property is prepended and each command component is shell-escaped.

The OpenOCDDriver is affected by this issue: It runs openocd with `--command` passing an argument containing spaces: `adapter usb location ..`. When run with the SSH prefix (`command_prefix`), the argument is not received as a single argument with spaces, but rather as multiple arguments leading ultimately to:
```
Unexpected command line argument: usb
```

This issue was hidden with additional quoting until [1]. The current state only works locally (without the SSH prefix).

To fix this issue, switch from simply prepending the command_prefix to the new `wrap_command()` method that takes care of prepending and shell escaping of the command for NetworkResources.

[1] 875e4881 ("driver/openocddriver: fix command quoting and add tests")


**Checklist**
- [ ] Tests for the feature
- [.] PR has been tested