### PR TITLE
Add NetworkInterface resource

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -663,6 +663,19 @@ Arguments:
 Used by:
   - `DFUDriver`_
 
+NetworkInterface
+~~~~~~~~~~~~~~~~
+A NetworkInterface resource describes a network adapter (such as Ethernet or
+WiFi)
+
+.. code-block:: yaml
+
+   NetworkInterface:
+     ifname: eth0
+
+Arguments:
+  - ifname (str): name of the interface
+
 USBNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~
 A USBNetworkInterface resource describes a USB network adapter (such as
@@ -679,8 +692,8 @@ Arguments:
 
 RemoteNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~~~
-A :any:`RemoteNetworkInterface` resource describes a :any:`USBNetworkInterface`
-resource available on a remote computer.
+A :any:`RemoteNetworkInterface` resource describes a :any:`NetworkInterface` or
+:any:`USBNetworkInterface` resource available on a remote computer.
 
 AlteraUSBBlaster
 ~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2710,6 +2710,7 @@ It supports:
 
 Binds to:
   iface:
+    - `NetworkInterface`_
     - `USBNetworkInterface`_
     - `RemoteNetworkInterface`_
 

--- a/labgrid/driver/networkinterfacedriver.py
+++ b/labgrid/driver/networkinterfacedriver.py
@@ -11,7 +11,7 @@ from ..resource.remote import RemoteNetworkInterface
 @attr.s(eq=False)
 class NetworkInterfaceDriver(Driver):
     bindings = {
-        "iface": {"RemoteNetworkInterface", "USBNetworkInterface"},
+        "iface": {"RemoteNetworkInterface", "NetworkInterface", "USBNetworkInterface"},
     }
 
     def __attrs_post_init__(self):

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -281,26 +281,35 @@ exports["USBSerialPort"] = SerialPortExport
 exports["RawSerialPort"] = SerialPortExport
 
 @attr.s(eq=False)
-class USBNetworkExport(ResourceExport):
-    """ResourceExport for a USB network interface"""
+class NetworkInterfaceExport(ResourceExport):
+    """ResourceExport for a network interface"""
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        from ..resource.udev import USBNetworkInterface
+        if self.cls == "NetworkInterface":
+            from ..resource.base import NetworkInterface
+            self.local = NetworkInterface(target=None, name=None, **self.local_params)
+        elif self.cls == "USBNetworkInterface":
+            from ..resource.udev import USBNetworkInterface
+            self.local = USBNetworkInterface(target=None, name=None, **self.local_params)
         self.data['cls'] = "RemoteNetworkInterface"
-        self.local = USBNetworkInterface(target=None, name=None, **self.local_params)
 
     def _get_params(self):
         """Helper function to return parameters"""
-        return {
+        params = {
             'host': self.host,
             'ifname': self.local.ifname,
-            'extra': {
+        }
+        if self.cls == "USBNetworkInterface":
+            params['extra'] = {
                 'state': self.local.if_state,
             }
-        }
 
-exports["USBNetworkInterface"] = USBNetworkExport
+        return params
+
+
+exports["USBNetworkInterface"] = NetworkInterfaceExport
+exports["NetworkInterface"] = NetworkInterfaceExport
 
 @attr.s(eq=False)
 class USBGenericExport(ResourceExport):

--- a/labgrid/resource/base.py
+++ b/labgrid/resource/base.py
@@ -15,6 +15,7 @@ class SerialPort(Resource):
     speed = attr.ib(default=115200, validator=attr.validators.instance_of(int))
 
 
+@target_factory.reg_resource
 @attr.s(eq=False)
 class NetworkInterface(Resource):
     """The basic NetworkInterface contains an interface name


### PR DESCRIPTION
**Description**
Until now only USB network interfaces are supported. The NetworkInterface class already exists, but there is no corresponding
resource export.

Change that by adding such a resource export and document the new NetworkInterface resource. Also mention that a RemoteNetworkInterface can either be a remote USBNetworkInterface or a NetworkInterface.

Now allow binding of the NetworkInterfaceDriver against it.

Note: Only tested on REPL by instantiating a NetworkInterface resource and binding a NetworkInterfaceDriver against it

**Checklist**
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested (by @nick-potenski, see below)