### PR TITLE
driver/sshdriver: add connection timeout option

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1473,6 +1473,8 @@ Arguments:
     (has precedence over `NetworkService`'s password)
   - stderr_merge (bool, default=False): set to True to make `run()` return stderr merged with
       stdout, and an empty list as second element.
+  - connection_timeout (float, default=30.0): timeout when trying to establish connection to
+      target.
 
 UBootDriver
 ~~~~~~~~~~~

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -30,6 +30,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     priorities = {CommandProtocol: 10, FileTransferProtocol: 10}
     keyfile = attr.ib(default="", validator=attr.validators.instance_of(str))
     stderr_merge = attr.ib(default=False, validator=attr.validators.instance_of(bool))
+    connection_timeout = attr.ib(default=30.0, validator=attr.validators.instance_of(float))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -63,7 +64,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def _start_own_master(self):
         """Starts a controlmaster connection in a temporary directory."""
 
-        timeout = Timeout(30.0)
+        timeout = Timeout(self.connection_timeout)
 
         # Retry start of controlmaster, to allow handle failures such as
         # connection refused during target startup


### PR DESCRIPTION
**Description**

Allows to configure a connection timeout connection to a target on ssh. 
This is relevant when having a slow booting target.

**Checklist**
- [x] Documentation for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
Did you test the change locally? If yes, best to mention how you did it in the description section.
- [x] PR has been tested
