### PR TITLE
Fix ResourceWarnings

### DIFF
--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -28,7 +28,6 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         self.logger = logging.getLogger(f"{self}({self.target})")
         self.status = 0
         self._child = None
-        self.open()
 
     def open(self):
         """Starts the subprocess, does nothing if it is already closed"""
@@ -103,6 +102,9 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         result = self._child.stdin.write(data)
         self._child.stdin.flush()
         return result
+
+    def on_activate(self):
+        self.open()
 
     def on_deactivate(self):
         self.close()

--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -54,6 +54,7 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         if not self.status:
             return
         if self._child.poll() is not None:
+            self._child.communicate()
             raise ExecutionError("child has vanished")
         self._child.terminate()
         try:

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -183,6 +183,11 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
     def on_deactivate(self):
         if self.status:
             self.off()
+        if self._clientsocket:
+            self._clientsocket.close()
+            self._clientsocket = None
+        self._socket.close()
+        self._socket = None
         shutil.rmtree(self._tempdir)
 
     @step()

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -130,7 +130,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             subprocess_timeout = timeout + 5
             return_value = self.process.wait(timeout=subprocess_timeout)
             if return_value != 0:
-                stdout = self.process.stdout.readlines()
+                stdout, _ = self.process.communicate(timeout=subprocess_timeout)
+                stdout = stdout.split("\n")
                 for line in stdout:
                     self.logger.warning("ssh: %s", line.rstrip().decode(encoding="utf-8", errors="replace"))
 
@@ -453,6 +454,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         if res != 0:
             self.logger.info("Socket already closed")
         shutil.rmtree(self.tmpdir)
+
+        self.process.communicate()
 
     def _start_keepalive(self):
         """Starts a keepalive connection via the own or external master."""

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -135,7 +135,8 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                     self.logger.warning("ssh: %s", line.rstrip().decode(encoding="utf-8", errors="replace"))
 
                 try:
-                    proxy_error = open(self.tmpdir+'/proxy-stderr').read().strip()
+                    with open(f'{self.tmpdir}/proxy-stderr') as proxy_err_fd:
+                        proxy_error = proxy_err_fd.read().strip()
                     if proxy_error:
                         raise ExecutionError(
                             f"Failed to connect to {self.networkservice.address} with {' '.join(args)}: error from SSH ProxyCommand: {proxy_error}",  # pylint: disable=line-too-long

--- a/labgrid/driver/usbaudiodriver.py
+++ b/labgrid/driver/usbaudiodriver.py
@@ -201,3 +201,6 @@ class USBAudioInputDriver(Driver):
 
         rx.terminate()
         tx.terminate()
+
+        rx.communicate()
+        tx.communicate()

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -161,3 +161,6 @@ class USBVideoDriver(Driver, VideoProtocol):
 
         rx.terminate()
         tx.terminate()
+
+        rx.communicate()
+        tx.communicate()

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1291,7 +1291,8 @@ class ClientSession(ApplicationSession):
         if action in ['show', 'save']:
             extension, data = drv.get_screenshot()
             filename = 'tmc-screen_{0:%Y-%m-%d}_{0:%H:%M:%S}.{1}'.format(datetime.now(), extension)
-            open(filename, 'wb').write(data)
+            with open(filename, 'wb') as f:
+                f.write(data)
             print(f"Saved as {filename}")
             if action == 'show':
                 subprocess.call(['xdg-open', filename])

--- a/labgrid/util/agents/network_interface.py
+++ b/labgrid/util/agents/network_interface.py
@@ -272,19 +272,20 @@ class NMDev:
 
     def get_dhcpd_leases(self):
         leases = []
-        for line in open(f"/var/lib/NetworkManager/dnsmasq-{self._interface}.leases"):
-            line = line.strip().split()
-            if line[3] == '*':
-                line[3] = None
-            if line[4] == '*':
-                line[4] = None
-            leases.append({
-                'expire': int(line[0]),
-                'mac': line[1],
-                'ip': line[2],
-                'hostname': line[3],
-                'id': line[4],
-            })
+        with open(f"/var/lib/NetworkManager/dnsmasq-{self._interface}.leases") as f:
+            for line in f:
+                line = line.strip().split()
+                if line[3] == '*':
+                    line[3] = None
+                if line[4] == '*':
+                    line[4] = None
+                leases.append({
+                    'expire': int(line[0]),
+                    'mac': line[1],
+                    'ip': line[2],
+                    'hostname': line[3],
+                    'id': line[4],
+                })
         return leases
 
 if getattr(NM.Client, '__gtype__', None):

--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -99,6 +99,7 @@ class AgentWrapper:
             raise AgentException(e)
         elif 'error' in response:
             self.agent.wait()
+            self.agent.communicate()
             self.agent = None
             raise AgentError(response['error'])
 
@@ -132,4 +133,5 @@ class AgentWrapper:
         self.agent.stdin.write(request+b'\n')
         self.agent.stdin.flush()
         self.agent.wait()
+        self.agent.communicate()
         self.agent = None

--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -46,7 +46,8 @@ class AgentWrapper:
             'agent.py')
         if host:
             # copy agent.py and run via ssh
-            agent_data = open(agent, 'rb').read()
+            with open(agent, 'rb') as agent_fd:
+                agent_data = agent_fd.read()
             agent_hash = hashlib.sha256(agent_data).hexdigest()
             agent_remote = f'.labgrid_agent_{agent_hash}.py'
             ssh_opts = 'ssh -x -o ConnectTimeout=5 -o PasswordAuthentication=no'.split()
@@ -111,7 +112,8 @@ class AgentWrapper:
             path = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'agents')
 
         filename = os.path.join(path, f'{name}.py')
-        source = open(filename, 'r').read()
+        with open(filename, 'r') as source_fd:
+            source = source_fd.read()
 
         self.call('load', name, source)
 


### PR DESCRIPTION
**Description**
Collection of fixes for various ResourceWarnings:
- unclosed files
- unclosed sockets
- unclosed pipes

Found by running labgrid-client and labgrid's pytest plugin in [Python Development Mode](https://docs.python.org/3/library/devmode.html) during day-to-day use as well as the test suite:
```
python3 -X dev -X tracemalloc=50 -m pytest
```

Test suite warnings are down from 90 warnings to 15. Only labgrid module code was touched, warnings in test code were ignored.

**Checklist**
- [.] PR has been tested (not all changes were manually tested)