### PR TITLE
Make sure PyYAML 6 can be used

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -310,7 +310,7 @@ class CoordinatorComponent(ApplicationSession):
         try:
             self.place = {}
             with open('places.yaml', 'r') as f:
-                self.places = yaml.load(f.read())
+                self.places = yaml.safe_load(f.read())
             for placename, config in self.places.items():
                 config['name'] = placename
                 # FIXME maybe recover previously acquired places here?


### PR DESCRIPTION
PyYAML 6.0's changelog says:
"always require `Loader` arg to `yaml.load()"

Use the safe_load() function instead.

Link: https://github.com/yaml/pyyaml/releases/tag/6.0
Signed-off-by: Bastian Germann <bastiangermann@fishpost.de>

- [ ] PR has been tested
