### PR TITLE
github/workflows: bump actions versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,13 +8,13 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install system dependencies
       run: |
         sudo apt install -yq python3-pip
         python3 -m pip install --upgrade pip setuptools wheel
     - name: Login to DockerHub
-      uses: docker/login-action@v1
+      uses: docker/login-action@v2
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,12 +12,12 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         experimental: [false]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('*requirements.txt') }}
@@ -58,11 +58,11 @@ jobs:
         make -C man clean
         make -C man all
         git --no-pager diff --exit-code
-    - uses: codecov/codecov-action@v1
+    - uses: codecov/codecov-action@v3
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install system dependencies
       run: |
         sudo apt install -yq python3-pip


### PR DESCRIPTION
**Description**
Bump GitHub actions used to their latest versions. Fixes various deprecation warnings [1]:

> docker:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/checkout
> 
> unit tests:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-python, actions/cache, codecov/codecov-action, actions/cache, actions/setup-python, actions/checkout

See also [2].

Since we do not rely on any action functionality that changed with in these versions, nothing else needs to be adapted.

[1] https://github.com/labgrid-project/labgrid/actions/runs/3272425683
[2] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

**Checklist**
- [x] PR has been tested
