### PR TITLE
dockerfiles: support podman/docker for build.sh

### DIFF
--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -35,6 +35,12 @@ with the included script
 
    $ ./dockerfiles/build.sh
 
+The script supports ``podman`` as well
+
+.. code-block:: bash
+  
+   $ export DOCKER=podman
+   $ ./dockerfiles/build.sh
 
 Usage
 -----

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -1,12 +1,17 @@
 #!/bin/sh
 
 set -ex
-
+if [ -z ${DOCKER} ]; then
+    command -v docker >/dev/null 2>&1 && DOCKER=docker
+fi
+if [ -z ${DOCKER} ]; then
+    command -v podman >/dev/null 2>&1 && DOCKER=podman
+fi
 export DOCKER_BUILDKIT=1
 
 VERSION="$(./setup.py --version | tail -1)"
 
 for t in client exporter coordinator; do
-    docker build --build-arg VERSION="$VERSION" \
+    ${DOCKER} build --build-arg VERSION="$VERSION" \
         --target labgrid-${t} -t labgrid-${t} -f dockerfiles/Dockerfile .
 done


### PR DESCRIPTION
Allow to force usage of podman/docker by environment variable DOCKER. Example
  export DOCKER=podman
  ./dockerfiles/build.sh
. Try to autodetect podman/docker.

Signed-off-by: Alexander Merkle <alexander.merkle@lauterbach.com>

