### PR TITLE
Rework Step information to use logging infrastructure.

### DIFF
--- a/examples/deditec-relais8/deditec.py
+++ b/examples/deditec-relais8/deditec.py
@@ -15,7 +15,7 @@ logging.basicConfig(
 )
 
 # show labgrid steps on the console
-StepReporter()
+StepReporter.start()
 
 t = labgrid.Target('main')
 r = labgrid.resource.udev.DeditecRelais8(t, name=None, index=1)

--- a/examples/deditec-relais8/deditec_remote.py
+++ b/examples/deditec-relais8/deditec_remote.py
@@ -15,7 +15,7 @@ logging.basicConfig(
 )
 
 # show labgrid steps on the console
-StepReporter()
+StepReporter.start()
 
 e = labgrid.Environment('import-dedicontrol.yaml')
 t = e.get_target()

--- a/examples/library/test.py
+++ b/examples/library/test.py
@@ -16,7 +16,7 @@ logging.basicConfig(
 )
 
 # show labgrid steps on the console
-StepReporter()
+StepReporter.start()
 
 def run_once(target):
     s = target.get_driver('BareboxStrategy')

--- a/examples/networkmanager/nm.py
+++ b/examples/networkmanager/nm.py
@@ -12,7 +12,7 @@ logging.basicConfig(
 )
 
 # show labgrid steps on the console
-StepReporter()
+StepReporter.start()
 
 
 e = Environment('nm.env')

--- a/examples/sysfsgpio/sysfsgpio.py
+++ b/examples/sysfsgpio/sysfsgpio.py
@@ -14,7 +14,7 @@ logging.basicConfig(
 )
 
 # show labgrid steps on the console
-StepReporter()
+StepReporter.start()
 
 t = labgrid.Target('main')
 r = labgrid.resource.base.SysfsGPIO(t, name=None, index=60)

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -256,6 +256,8 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             raise TIMEOUT(f"Timeout of {timeout:.2f} seconds exceeded")
         return res
 
-    @step(args=['data'])
     def _write(self, data):
         return self._clientsocket.send(data)
+
+    def __str__(self):
+        return f"QemuDriver({self.target.name})"

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -127,3 +127,6 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         if self.status:
             self.serial.close()
             self.status = 0
+
+    def __str__(self):
+        return f"SerialDriver({self.target.name})"

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -123,26 +123,27 @@ class StepFormatter:
         return f"{indent}{line}"
 
 class StepLogger:
-    instance = None
-
-    def __init__(self):
-        self.logger = logging.getLogger("StepLogger")
-        steps.subscribe(self.notify)
+    _started = False
+    _logger = None
 
     @classmethod
     def start(cls):
         """starts the StepLogger"""
-        assert cls.instance is None
-        cls.instance = cls()
+        assert not cls._started
+        if cls._logger is None:
+            cls._logger = logging.getLogger("StepLogger")
+        steps.subscribe(cls.notify)
+        cls._started = True
 
     @classmethod
     def stop(cls):
         """stops the StepLogger"""
-        assert cls.instance is not None
+        assert cls._started
         steps.unsubscribe(cls.notify)
-        cls.instance = None
+        cls._started = False
 
-    def notify(self, event):
+    @classmethod
+    def notify(cls, event):
         level = logging.INFO
         step = event.step
         extra = {"stepevent": event}
@@ -154,4 +155,4 @@ class StepLogger:
             else:
                 extra["console"] = True
 
-        self.logger.log(level, event, extra=extra)
+        cls._logger.log(level, event, extra=extra)

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -18,37 +18,18 @@ def basicConfig(**kwargs):
 
 
 
-class StepFormatter(Formatter):
+# Use composition instead of inheritance
+class StepFormatter:
 
-    def __init__(self, *args):
-        super().__init__(*args)
+    def __init__(self, *args, color=None):
+        self.formatter = Formatter(*args)
+        self.color = color
 
     def format(self, record):
         if hasattr(record, "step"):
             return self.formt_step(record)
         else:
-            return self.format_normal(record)
-
-    def format_normal(self, record):
-        record.message = record.getMessage()
-        if self.usesTime():
-            record.asctime = self.formatTime(record, self.datefmt)
-        s = self.formatMessage(record)
-        if record.exc_info:
-            # Cache the traceback text to avoid converting it multiple times
-            # (it's constant anyway)
-            if not record.exc_text:
-                record.exc_text = self.formatException(record.exc_info)
-        if record.exc_text:
-            if s[-1:] != "\n":
-                s = s + "\n"
-            s = s + record.exc_text
-        if record.stack_info:
-            if s[-1:] != "\n":
-                s = s + "\n"
-            s = s + self.formatStack(record.stack_info)
-        return s
-
+            return self.formatter.format(record)
 
     def format_step(self, record):
         return f"  {record.getMessage}"

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -92,13 +92,13 @@ class StepFormatter:
 
     def get_prefix(self, event):
         if event.step.exception:
-            return "!"
+            return "⚠"
         elif event.data.get("state") == "start":
             return "→"
         elif event.data.get("state") == "stop":
             return "←"
         elif event.data.get("skip", None):
-            return "S"
+            return "↓"
         else:
             return ""
 

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -56,7 +56,8 @@ class StepFormatter:
             dirind = ">"
             message = step.args["data"].decode('utf-8')
             message = f"␍␊\n{indent}{step.source} {dirind} ".join(message.split('\n'))
-        return f"{indent}{step.source} {dirind} {message}"
+        if message:
+            return f"{indent}{step.source} {dirind} {message}"
 
     @staticmethod
     def format_arguments(args):

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -129,6 +129,10 @@ class StepFormatter:
         if event.step.exception:
             line = f"{line} exception={event.step.exception}"
 
+        reason = event.data.get("skip", None)
+        if reason:
+            line = f"{line}skipped={reason}"
+
         return f"{indent}{line}"
 
 

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -1,0 +1,78 @@
+from logging import Formatter, StreamHandler, getLogger, BASIC_FORMAT
+
+from .step import steps
+
+
+def basicConfig(**kwargs):
+    stream = kwargs.pop("stream", None)
+    handler = StreamHandler(stream)
+    root = getLogger()
+
+    dfs = kwargs.pop("datefmt", None)
+    fs = kwargs.pop("format", BASIC_FORMAT)
+    style = kwargs.pop("style", '%')
+    if len(root.handlers) == 0:
+        formatter = StepFormatter(fs, dfs, style)
+        handler.setFormatter(formatter)
+        root.addHandler(handler)
+
+
+
+class StepFormatter(Formatter):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+    def format(self, record):
+        if hasattr(record, "step"):
+            return self.formt_step(record)
+        else:
+            return self.format_normal(record)
+
+    def format_normal(self, record):
+        record.message = record.getMessage()
+        if self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+        s = self.formatMessage(record)
+        if record.exc_info:
+            # Cache the traceback text to avoid converting it multiple times
+            # (it's constant anyway)
+            if not record.exc_text:
+                record.exc_text = self.formatException(record.exc_info)
+        if record.exc_text:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + record.exc_text
+        if record.stack_info:
+            if s[-1:] != "\n":
+                s = s + "\n"
+            s = s + self.formatStack(record.stack_info)
+        return s
+
+
+    def format_step(self, record):
+        return f"  {record.getMessage}"
+
+
+class StepLogger:
+    instance = None
+
+    def __init__(self):
+        self.logger = getLogger("StepLogger")
+        steps.subscribe(self.notify)
+
+    @classmethod
+    def start(cls):
+        """starts the StepLogger"""
+        assert cls.instance is None
+        cls.instance = cls()
+
+    @classmethod
+    def stop(cls):
+        """stops the StepLogger"""
+        assert cls.instance is not None
+        steps.unsubscribe(cls.notify)
+        cls.instance = None
+
+    def notify(self, event):
+        self.logger.log(15, event)

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -43,7 +43,7 @@ class StepFormatter:
         result = []
         for part in parts:
             result.append(self.re_vt100.sub('', part.decode("utf-8", errors="replace")))
-        return "␍␤\n".join(result)
+        return "␍␊\n".join(result)
 
     def format_console_step(self, record):
         step = record.stepevent.step
@@ -55,7 +55,7 @@ class StepFormatter:
         else:
             dirind = ">"
             message = step.args["data"].decode('utf-8')
-            message = f"␍␤\n{indent}{step.source} {dirind} ".join(message.split('\n'))
+            message = f"␍␊\n{indent}{step.source} {dirind} ".join(message.split('\n'))
         return f"{indent}{step.source} {dirind} {message}"
 
     @staticmethod

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -126,6 +126,15 @@ class StepLogger:
     _started = False
     _logger = None
 
+    def __init__(self):
+        from warnings import warn
+
+        warn(
+            "StepLogger should not be instantiated, use StepReporter.start()/.stop() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     @classmethod
     def start(cls):
         """starts the StepLogger"""

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -111,7 +111,7 @@ class StepFormatter:
         if event.data.get("state") == "start":
             return "→"
         if event.data.get("state") == "stop":
-            return "→"
+            return "←"
         if event.data.get("skip", None):
             return "⏭️"
 

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -116,7 +116,7 @@ class StepFormatter:
             return "⏭️"
 
     def _line_format(self, event):
-        indent = "  "*event.step.level if self.indent else ""
+        indent = "  " * event.step.level if self.indent else ""
         self.indent_level = event.step.level
 
         prefix = self.get_prefix(event)

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -105,14 +105,23 @@ class StepFormatter:
         else:
             return "result={:.19}… ".format(repr(result))
 
+    def get_prefix(self, event):
+        if event.step.exception:
+            return "⚠"
+        if event.data.get("state") == "start":
+            return "→"
+        if event.data.get("state") == "stop":
+            return "→"
+        if event.data.get("skip", None):
+            return "⏭️"
+
     def _line_format(self, event):
         indent = "  "*event.step.level if self.indent else ""
         self.indent_level = event.step.level
 
-        prefix = "→" if event.data.get("state") == "start" else "←"
-        if event.step.exception:
-            prefix = "⚠"
-        title = '{} {}'.format(prefix, event.step.title)
+        prefix = self.get_prefix(event)
+
+        title = '{} {}.{}'.format(prefix, event.step.source.__class__.__name__, event.step.title)
         line = "{}({}) {}{}".format(title, self.format_arguments(event.data.get('args', {})),
                                     self.format_result(event.data.get('result', None)),
                                     self.format_duration(event.data.get('duration', 0.0)))

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -195,6 +195,10 @@ class SerialLoggingReporter():
         string = self.re_vt100.sub('', buf.decode("utf-8", errors="replace"))
         string = string.replace("\r", "␍")
         string = string.replace("\n", "␤")
+        string = string.replace("\b", "␈")
+        string = string.replace("\a", "␇")
+        string = string.replace("\v", "␋")
+        string = string.replace("\f", "␌")
         return string
 
     def notify(self, event):

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -117,6 +117,9 @@ class StepFormatter:
                                     self.format_result(event.data.get('result', None)),
                                     self.format_duration(event.data.get('duration', 0.0)))
 
+        if event.step.exception:
+            line = f"{line} exception={event.step.exception}"
+
         return f"{indent}{line}"
 
 

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -1,28 +1,12 @@
-import logging
 import os
-import sys
 import warnings
 import pytest
 
 from .. import Environment
 from ..consoleloggingreporter import ConsoleLoggingReporter
 from ..util.helper import processwrapper
-from ..logging import basicConfig, StepFormatter, StepLogger
+from ..logging import StepFormatter, StepLogger
 
-from _pytest import logging as pytest_logging
-
-class StructlogLoggingPlugin(pytest_logging.LoggingPlugin):
-    """
-    Replacement logging plugin that uses our formatter
-    """
-    def _create_formatter(self, log_format,
-                          log_date_format, auto_indent) -> logging.Formatter:
-        """Patch the logger method to always return out formatter
-        Returns:
-            logging.Formatter: Our structlog enhanced formatter
-        """
-        del log_format, log_date_format, auto_indent
-        return StepFormatter()
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -13,7 +13,7 @@ def pytest_configure(config):
     StepLogger.start()
 
     logging = config.pluginmanager.getplugin('logging-plugin')
-    logging.log_cli_handler.setFormatter(StepFormatter())
+    logging.log_cli_handler.setFormatter(StepFormatter(color=config.option.lg_colored_steps))
     logging.log_file_handler.setFormatter(StepFormatter())
 
     config.addinivalue_line("markers",

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1362,8 +1362,7 @@ def main():
         stream=sys.stderr,
     )
 
-    steps = StepLogger()
-    steps.start()
+    StepLogger.start()
 
     # Support both legacy variables and properly namespaced ones
     place = os.environ.get('PLACE', None)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -662,7 +662,7 @@ class ClientSession(ApplicationSession):
             if self.args.state:
                 if self.args.verbose >= 2:
                     from .. import StepReporter
-                    StepReporter()
+                    StepReporter.start()
                 strategy = target.get_driver("Strategy")
                 print(f"Transitioning into state {self.args.state}")
                 strategy.transition(self.args.state)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1355,11 +1355,15 @@ class ExportFormat(enum.Enum):
 
 def main():
     processwrapper.enable_logging()
-    logging.basicConfig(
+    from labgrid.logging import basicConfig, StepLogger
+    basicConfig(
         level=logging.WARNING,
         format='%(levelname)7s: %(message)s',
         stream=sys.stderr,
     )
+
+    steps = StepLogger()
+    steps.start()
 
     # Support both legacy variables and properly namespaced ones
     place = os.environ.get('PLACE', None)

--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -128,6 +128,9 @@ class Step:
     def get_title(self):
         return self.title
 
+    def __str__(self):
+        return f"{self.title} [{self.level},{self.tag},{self.source}] is self.status"
+
     @property
     def duration(self):
         if self._start_ts is None:

--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -55,7 +55,7 @@ class StepEvent:
         self.stream = stream
 
     def __str__(self):
-        result = [str(self.step)]
+        result = [self.step.get_title()]
         if self.resource:
             result.append(self.resource.__class__.__name__)
         data = self.data.copy()
@@ -125,8 +125,8 @@ class Step:
         result.append(")")
         return "".join(result)
 
-    def __str__(self):
-        return f"{self.title}"
+    def get_title(self):
+        return self.title
 
     @property
     def duration(self):

--- a/labgrid/stepreporter.py
+++ b/labgrid/stepreporter.py
@@ -31,27 +31,3 @@ class StepReporter:
         step = event.step
         indent = '  '*step.level
         print(f"{indent}{event}")
-
-
-class StepLogger:
-    instance = None
-
-    def __init__(self):
-        self.logger = getLogger("StepLogger")
-        steps.subscribe(self.notify)
-
-    @classmethod
-    def start(cls):
-        """starts the StepLogger"""
-        assert cls.instance is None
-        cls.instance = cls()
-
-    @classmethod
-    def stop(cls):
-        """stops the StepLogger"""
-        assert cls.instance is not None
-        steps.unsubscribe(cls.notify)
-        cls.instance = None
-
-    def notify(self, event):
-        self.logger.log(15, event)

--- a/labgrid/stepreporter.py
+++ b/labgrid/stepreporter.py
@@ -4,23 +4,21 @@ from .step import steps
 
 
 class StepReporter:
-    instance = None
+    _started = False
 
     @classmethod
     def start(cls):
         """starts the StepReporter"""
-        assert cls.instance is None
-        cls.instance = cls()
+        assert not cls._started
+        steps.subscribe(cls.notify)
+        cls._started = True
 
     @classmethod
     def stop(cls):
         """stops the StepReporter"""
-        assert cls.instance is not None
+        assert cls._started
         steps.unsubscribe(cls.notify)
-        cls.instance = None
-
-    def __init__(self):
-        steps.subscribe(StepReporter.notify)
+        cls._started = False
 
     @staticmethod
     def notify(event):

--- a/labgrid/stepreporter.py
+++ b/labgrid/stepreporter.py
@@ -1,3 +1,5 @@
+from logging import getLogger
+
 from .step import steps
 
 
@@ -29,3 +31,27 @@ class StepReporter:
         step = event.step
         indent = '  '*step.level
         print(f"{indent}{event}")
+
+
+class StepLogger:
+    instance = None
+
+    def __init__(self):
+        self.logger = getLogger("StepLogger")
+        steps.subscribe(self.notify)
+
+    @classmethod
+    def start(cls):
+        """starts the StepLogger"""
+        assert cls.instance is None
+        cls.instance = cls()
+
+    @classmethod
+    def stop(cls):
+        """stops the StepLogger"""
+        assert cls.instance is not None
+        steps.unsubscribe(cls.notify)
+        cls.instance = None
+
+    def notify(self, event):
+        self.logger.log(15, event)

--- a/labgrid/stepreporter.py
+++ b/labgrid/stepreporter.py
@@ -6,6 +6,15 @@ from .step import steps
 class StepReporter:
     _started = False
 
+    def __init__(self):
+        from warnings import warn
+
+        warn(
+            "StepReporter should not be instantiated, use StepReporter.start()/.stop() instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
     @classmethod
     def start(cls):
         """starts the StepReporter"""


### PR DESCRIPTION
**Description**

Rough first draft of reworking the Step information to reuse the logging infrastructure. Works as expected, but still requires some polishing and replacement of existing `logging.basicConfig` usage.

Example output with `--log-cli-level=INFO`:
```
===================================== test session starts =====================================
platform linux -- Python 3.10.6, pytest-7.1.3, pluggy-1.0.0 -- /home/phoenix/work/ptx/labgrid/.venv/bin/python
cachedir: .pytest_cache
rootdir: /home/phoenix/work/ptx/git/labgrid-PTX-DistroKit
plugins: labgrid-0.4.1.dev319+g31ea71e6
collected 326 items

tests/test_barebox.py::test_barebox_log_level
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
    → transition(status=Status.off)
      → off()
      ← off()
    ← transition() [0.003s]
    → off()
    ← off()
    → on()
pulseaudio: set_sink_input_volume() failed
pulseaudio: Reason: Invalid argument
pulseaudio: set_sink_input_mute() failed
pulseaudio: Reason: Invalid argument
      → monitor_command(command=cont)
      ← monitor_command()
    ← on() [0.112s]
    → _await_prompt()
      → expect(pattern=['barebox@[^:]+:[^ ]+ ', 'stop autoboot', 'Password: ', <class 'pexpect.exceptions.TIMEOUT'>])
        QemuDriver(main) < ␍␤
        QemuDriver(main) < ␍␤
        QemuDriver(main) < barebox 2022.04.0 #1 2022-07-01T00:00:00+00:00␍␤
        QemuDriver(main) < Buildsystem version: 67de50d␍␤
        QemuDriver(main) < ␍␤
        QemuDriver(main) < Board: V2P-CA9␍␤
        QemuDriver(main) < smc911x 4e000000.ethernet@3,02000000.of: LAN911x identified, idrev: 0x01180001, generation: 1
        QemuDriver(main) < mdio_bus: miibus0: probed␍␤
        QemuDriver(main) < eth0: got preset MAC address: 52:54:00:12:34:56␍␤
        QemuDriver(main) < cfi_flash 40000000.flash@0,00000000.of: found cfi flash at 0x40000000, size 64 MiB
        QemuDriver(main) < cfi_flash 40000000.flash@0,00000000.of: found cfi flash at 0x44000000, size 64 MiB␍␤
        QemuDriver(main) < Concatenating MTD devices:␍␤
        QemuDriver(main) < (0): "40000000.flash@0,00000000.of"␍␤
        QemuDriver(main) < (1): "40000000.flash@0,00000000.of"␍␤
        QemuDriver(main) < into device "nor"␍␤
        QemuDriver(main) < WARNING: mmci-pl18x 10005000.mmci@5000.of: Failed to get 'vmmc' regulator (ignored).
        QemuDriver(main) < mmci-pl18x 10005000.mmci@5000.of: registered as mci0
        QemuDriver(main) < mci0: detected SD card version 2.0␍␤
        QemuDriver(main) < mci0: registered disk0
        QemuDriver(main) < state: New state registered 'state'␍␤
        QemuDriver(main) < state: Using bucket 0@0x00000000␍␤
        QemuDriver(main) < malloc space: 0x700f9cc0 -> 0x7fdf397f (size 253 MiB)
        QemuDriver(main) < found force-builtin environment, using defaultenv
        QemuDriver(main) <
        QemuDriver(main) <
      ← expect() result=(1, b'\r\n\r\nbareb… [0.291s]
        QemuDriver(main) > ␍␤
        QemuDriver(main) >
      → expect(pattern=['barebox@[^:]+:[^ ]+ ', 'stop autoboot', 'Password: ', <class 'pexpect.exceptions.TIMEOUT'>])
        QemuDriver(main) < Hit m for menu or any to stop autoboot:    3
      ← expect() result=(0, b':    3\r\n\x1… [0.011s]
        QemuDriver(main) > echo "PKNT""CNVYYU"␍␤
        QemuDriver(main) >
      → expect(pattern=PKNTCNVYYU)
        QemuDriver(main) < barebox@V2P-CA9:/ echo "PKNT""CNVYYU"␍␤
        QemuDriver(main) < PKNTCNVYYU
      ← expect() result=(0, b'echo "PKNT""C… [0.012s]
      → expect(pattern=barebox@[^:]+:[^ ]+ )
      ← expect() result=(0, b'\r\n\x1b[1;32…
    ← _await_prompt() [0.318s]
  ← transition() [0.437s]
  → run_check(cmd=global)
    QemuDriver(main) > echo -o /cmd global; echo "OSQI""IQZOWI"; sh /cmd; echo "OSQI""IQZOWI" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=OSQIIQZOWI(.*)OSQIIQZOWI\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd global; echo "OSQI""IQZOWI"; sh /cmd; echo "OSQI""IQZOWI" $?;␍␤
      QemuDriver(main) < OSQIIQZOWI␍␤
      QemuDriver(main) < * allow_color: 1␍␤
      QemuDriver(main) <   autoboot: countdown (values: "countdown", "abort", "menu", "boot")␍␤
      QemuDriver(main) <   autoboot_abort_key: any (values: "any", "ctrl-c")␍␤
      QemuDriver(main) < * autoboot_timeout: 3␍␤
      QemuDriver(main) <   boot.default: disk0.0 net
      QemuDriver(main) <   boot.watchdog_timeout: 0␍␤
      QemuDriver(main) <   bootm.appendroot: 0␍␤
      QemuDriver(main) <   bootm.boot_atag: 0␍␤
      QemuDriver(main) <   bootm.image: ␍␤
      QemuDriver(main) <   bootm.image.loadaddr: ␍␤
      QemuDriver(main) <   bootm.initrd: ␍␤
      QemuDriver(main) <   bootm.initrd.loadaddr: ␍␤
      QemuDriver(main) <   bootm.oftree: ␍␤
      QemuDriver(main) <   bootm.provide_machine_id: 0␍␤
      QemuDriver(main) <   bootm.root_dev: ␍␤
      QemuDriver(main) <   bootm.tee: ␍␤
      QemuDriver(main) <   bootm.verbose: 0
      QemuDriver(main) <   bootm.verify: hash (values: "none", "hash", "signature", "available")␍␤
      QemuDriver(main) <   buildsystem.version: 67de50d␍␤
      QemuDriver(main) <   console.ctrlc_allowed: 1␍␤
      QemuDriver(main) <   dhcp.bootfile: ␍␤
      QemuDriver(main) <   dhcp.client_id: ␍␤
      QemuDriver(main) <   dhcp.client_uuid: ␍␤
      QemuDriver(main) <   dhcp.hostname: ␍␤
      QemuDriver(main) <   dhcp.oftree_file: ␍␤
      QemuDriver(main) <   dhcp.option224: ␍␤
      QemuDriver(main) <   dhcp.retries: 20␍␤
      QemuDriver(main) <   dhcp.rootpath: ␍␤
      QemuDriver(main) <   dhcp.tftp_server_name: ␍␤
      QemuDriver(main) <   dhcp.user_class: ␍␤
      QemuDriver(main) <   dhcp.vendor_id: barebox
      QemuDriver(main) <   endianness: little␍␤
      QemuDriver(main) <   firmware.path: /env/firmware␍␤
      QemuDriver(main) <   hostname: vexpress-a9-legacy␍␤
      QemuDriver(main) <   linux.bootargs.base: ␍␤
      QemuDriver(main) <   linux.bootargs.console: console=ttyAMA0,115200n8␍␤
      QemuDriver(main) < * linux.bootargs.loglevel: loglevel=5 systemd.log_level=warning systemd.show_status=auto␍␤
      QemuDriver(main) <   linux.bootargs_append: 0
      QemuDriver(main) <   linux.rootnfsopts: v3,tcp␍␤
      QemuDriver(main) <   log_max_messages: 1000␍␤
      QemuDriver(main) <   loglevel: 6␍␤
      QemuDriver(main) <   model: V2P-CA9␍␤
      QemuDriver(main) <   net.domainname: ␍␤
      QemuDriver(main) <   net.gateway: 0.0.0.0␍␤
      QemuDriver(main) <   net.ifup_force_detect: 0␍␤
      QemuDriver(main) <   net.nameserver: 0.0.0.0␍␤
      QemuDriver(main) <   net.server: ␍␤
      QemuDriver(main) <   of.overlay.compatible: ␍␤
      QemuDriver(main) <   of.overlay.dir: ␍␤
      QemuDriver(main) <   of.overlay.filepattern: *␍␤
      QemuDriver(main) <   of.overlay.filter: filepattern compatible
      QemuDriver(main) <   of_partition_binding: new (values: "new", "legacy", "donttouch")␍␤
      QemuDriver(main) <   system.reset: unknown (values: "unknown", "POR", "RST", "WDG", "WKE", "JTAG", "THERM", "EXT", "BROWNOUT")␍␤
      QemuDriver(main) <   system.reset_instance: 0␍␤
      QemuDriver(main) <   usbgadget.acm: 0␍␤
      QemuDriver(main) <   usbgadget.autostart: 0␍␤
      QemuDriver(main) <   usbgadget.dfu_function: ␍␤
      QemuDriver(main) < * user: none␍␤
      QemuDriver(main) <   version: 2022.04.0
      QemuDriver(main) < OSQIIQZOWI 0
    ← expect() result=(0, b'echo -o /cmd … [0.082s]
  ← run_check() result=['* allow_color: 1'… [0.083s]
PASSED
tests/test_barebox.py::test_barebox_boot_default PASSED
tests/test_barebox.py::test_barebox_md5sum
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
  ← transition()
  ← transition()
---------------------------------------- live log call ----------------------------------------
  → run_check(cmd=echo -o md5 test)
    QemuDriver(main) > echo -o /cmd 'echo -o md5 test'; echo "PECO""ZIULDM"; sh /cmd; echo "PECO""ZIULDM" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=PECOZIULDM(.*)PECOZIULDM\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd 'echo -o md5 test'; echo "PECO""ZIULDM"; sh /cmd; echo "PECO""ZIULDM" $?;
      QemuDriver(main) < PECOZIULDM␍␤
      QemuDriver(main) < PECOZIULDM 0
    ← expect() result=(0, b'echo -o /cmd … [0.026s]
  ← run_check() result=[] [0.027s]
  → run_check(cmd=md5sum md5)
    QemuDriver(main) > echo -o /cmd 'md5sum md5'; echo "LKRC""ECMQMN"; sh /cmd; echo "LKRC""ECMQMN" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=LKRCECMQMN(.*)LKRCECMQMN\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd 'md5sum md5'; echo "LKRC""ECMQMN"; sh /cmd; echo "LKRC""ECMQMN" $?;␍␤
      QemuDriver(main) < LKRCECMQMN
      QemuDriver(main) < d8e8fca2dc0f896fd7cb4cb0031ba249  md5␍␤
      QemuDriver(main) < LKRCECMQMN 0
    ← expect() result=(0, b'echo -o /cmd … [0.026s]
  ← run_check() result=['d8e8fca2dc0f896fd… [0.027s]
PASSED
tests/test_barebox.py::test_barebox_version
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
  ← transition()
  ← transition()
---------------------------------------- live log call ----------------------------------------
  → run(cmd=version)
    QemuDriver(main) > echo -o /cmd version; echo "VZZW""RAMPXU"; sh /cmd; echo "VZZW""RAMPXU" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=VZZWRAMPXU(.*)VZZWRAMPXU\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd version; echo "VZZW""RAMPXU"; sh /cmd; echo "VZZW""RAMPXU" $?;␍␤
      QemuDriver(main) < VZZWRAMPXU␍␤
      QemuDriver(main) < ␍␤
      QemuDriver(main) < barebox 2022.04.0 #1 2022-07-01T00:00:00+00:00␍␤
      QemuDriver(main) < ␍␤
      QemuDriver(main) < VZZWRAMPXU 0
    ← expect() result=(0, b'echo -o /cmd … [0.015s]
  ← run() [0.016s]
PASSED
tests/test_barebox.py::test_barebox_true
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
  ← transition()
  ← transition()
---------------------------------------- live log call ----------------------------------------
  → run(cmd=true)
    QemuDriver(main) > echo -o /cmd true; echo "FVVR""DENNFC"; sh /cmd; echo "FVVR""DENNFC" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=FVVRDENNFC(.*)FVVRDENNFC\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd true; echo "FVVR""DENNFC"; sh /cmd; echo "FVVR""DENNFC" $?;␍␤
      QemuDriver(main) < FVVRDENNFC␍␤
      QemuDriver(main) < FVVRDENNFC 0
    ← expect() result=(0, b'echo -o /cmd … [0.014s]
  ← run() [0.016s]
PASSED
tests/test_barebox.py::test_barebox_false
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
  ← transition()
  ← transition() [0.001s]
---------------------------------------- live log call ----------------------------------------
  → run(cmd=false)
    QemuDriver(main) > echo -o /cmd false; echo "IWBS""QXBXWT"; sh /cmd; echo "IWBS""QXBXWT" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=IWBSQXBXWT(.*)IWBSQXBXWT\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd false; echo "IWBS""QXBXWT"; sh /cmd; echo "IWBS""QXBXWT" $?;␍␤
      QemuDriver(main) < IWBSQXBXWT␍␤
      QemuDriver(main) < IWBSQXBXWT 1
    ← expect() result=(0, b'echo -o /cmd … [0.014s]
  ← run() [0.016s]
PASSED
tests/test_barebox.py::test_barebox_no_err
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
  ← transition()
  ← transition()
SKIPPED (skipping tests irrelevant for qemu target)
tests/test_barebox.py::test_sleep
--------------------------------------- live log setup ----------------------------------------
  → transition(status=barebox)
  ← transition()
  ← transition()
---------------------------------------- live log call ----------------------------------------
  → run(cmd=true)
    QemuDriver(main) > echo -o /cmd true; echo "DVKP""NGUFZE"; sh /cmd; echo "DVKP""NGUFZE" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=DVKPNGUFZE(.*)DVKPNGUFZE\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd true; echo "DVKP""NGUFZE"; sh /cmd; echo "DVKP""NGUFZE" $?;␍␤
      QemuDriver(main) < DVKPNGUFZE␍␤
      QemuDriver(main) < DVKPNGUFZE 0
    ← expect() result=(0, b'echo -o /cmd … [0.014s]
  ← run() [0.016s]
  → run(cmd=sleep 10)
    QemuDriver(main) > echo -o /cmd 'sleep 10'; echo "KSBY""BOBACU"; sh /cmd; echo "KSBY""BOBACU" $?;␍␤
    QemuDriver(main) >
    → expect(pattern=KSBYBOBACU(.*)KSBYBOBACU\s+(\d+)\s+.*barebox@[^:]+:[^ ]+ )
      QemuDriver(main) <
      QemuDriver(main) < barebox@V2P-CA9:/ echo -o /cmd 'sleep 10'; echo "KSBY""BOBACU"; sh /cmd; echo "KSBY""BOBACU" $?;␍␤
      QemuDriver(main) < KSBYBOBACU
      QemuDriver(main) < KSBYBOBACU 0
    ← expect() result=(0, b'echo -o /cmd … [10.024s]
  ← run() [10.025s]
PASSED
```