### PR TITLE
Test/Announce Python 3.11 Support

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         experimental: [false]
     steps:
     - uses: actions/checkout@v3

--- a/setup.py
+++ b/setup.py
@@ -85,5 +85,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )


### PR DESCRIPTION
**Description**
Python 3.11 was released on October 24th [1]. Let's add a test job for it and announce support in the setup.py.

[1] https://blog.python.org/2022/10/python-3110-is-now-available.html

Note: Deprecation warning leading to an error of the Python 3.11 job will be fixed by #1024.