### PR TITLE
add timeout to docker-compose client, gather logs on error

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Build docker images
       run: |
         ./dockerfiles/build.sh
-        docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client
+        docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client || (docker-compose -f dockerfiles/staging/docker-compose.yml logs --timestamps && false)
         docker-compose -f dockerfiles/staging/docker-compose.yml down
     - name: Show docker images
       run: |

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     # Use wait-for-it to ensure exporter service is up, as exporter is assuming exporter to
     # Use labgrid-client r to ensure the exporter has populated the resource list in the coordinator
     # Use sleep to fix the problem that sometimes the coordinator is not ready even though the service is up
-    command: bash -c "set -e &&
+    command: timeout 60 bash -c "set -e &&
       cd /simple-test &&
       /opt/wait-for-it/wait-for-it.sh 127.0.0.1:20408 &&
       sleep 5 &&


### PR DESCRIPTION
**Description**
The docker-compose steps in the unit-tests workflow tend to run into errors once in a while, e.g. [here](https://github.com/labgrid-project/labgrid/actions/runs/3336552208/jobs/5521844726).

If something goes wrong during coordinator/exporter startup, no resources are exported. That leads to an infinite loop while waiting for resources with `labgrid-client r`. The job is then killed by GitHub Actions after 6 hours.

Add a timeout to prevent such situations. This also allows gathering logs from the services in a future commit.

In case of an error during 'docker-compose up', fetch logs with timestamps from all services. This allows us to tell at least how the services failed post-mortem.
