### PR TITLE
driver/sshdriver: fix splitting bytestring on SSH master error

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -131,7 +131,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             return_value = self.process.wait(timeout=subprocess_timeout)
             if return_value != 0:
                 stdout, _ = self.process.communicate(timeout=subprocess_timeout)
-                stdout = stdout.split("\n")
+                stdout = stdout.split(b"\n")
                 for line in stdout:
                     self.logger.warning("ssh: %s", line.rstrip().decode(encoding="utf-8", errors="replace"))
 


### PR DESCRIPTION
**Description**
`stdout` is still a bytestring at this point, so we have to also use a bytestring as delimiter.

Fixes: e874ae62 ("driver: close pipes from processes explicitly")

**Checklist**
- [x] PR has been tested

Fixes #1018