### PR TITLE
requirements: bump attrs 21.2.0 -> 21.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrs==21.2.0
+attrs==21.3.0
 jinja2==3.0.2
 packaging==21.0
 pexpect==4.8.0


### PR DESCRIPTION
**Description**
twisted 22.10.0 [1] (released on 2022-10-30) uses attrs imports such as..
```
from attrs import something
```
The new import ("attrs", not "attr") is supported since attrs 21.3.0 [2]. labgrid currently pins attrs to 21.2.0. This incompatibility causes issues such as..

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.0/x64/bin/crossbar", line 8, in <module>
    sys.exit(run())
             ^^^^^
  File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/crossbar/__init__.py", line 143, in run
    from autobahn.twisted import install_reactor
  File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/autobahn/twisted/__init__.py", line 40, in <module>
    from autobahn.twisted.websocket import \
  File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/autobahn/twisted/websocket.py", line 35, in <module>
    from twisted.internet import endpoints
  File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/twisted/internet/endpoints.py", line 63, in <module>
    from twisted.python.systemd import ListenFDs
  File "/opt/hostedtoolcache/Python/3.11.0/x64/lib/python3.11/site-packages/twisted/python/systemd.py", line 18, in <module>
    from attrs import Factory, define
ModuleNotFoundError: No module named 'attrs'
```

While this should have been a dependency resolving issue (twisted requiring a newer version than labgrid pins), it manifests itself as the error above due to an incorrectly specified attrs dependency in twisted [3].

To fix this, bump attrs to 21.3.0.

[1] https://github.com/twisted/twisted/releases/tag/twisted-22.10.0
[2] https://github.com/python-attrs/attrs/blob/965972eba3db4ed1b7eca53fa19aed1f3fcd166b/CHANGELOG.rst#2130-2021-12-28 
[3] https://github.com/twisted/twisted/issues/11737

**Checklist**
- [x] PR has been tested (via test-suite only)