### PR TITLE
driver/power: add support for Gude Expert Power Control 8225

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -172,6 +172,9 @@ Currently available are:
 ``gude8031``
   Controls a Gude Expert Power Control 8031 PDU via a simple HTTP API.
 
+``gude8225``
+  Controls a Gude Expert Power Control 8225 PDU via a simple HTTP API.
+
 ``gude8316``
   Controls a Gude Expert Power Control 8316 PDU via a simple HTTP API.
 

--- a/labgrid/driver/power/gude8225.py
+++ b/labgrid/driver/power/gude8225.py
@@ -1,0 +1,32 @@
+import requests
+
+# Driver has been tested with:
+# Gude  Expert Power Control 8225-1 - v1.0.6
+
+# HTTP-GET API is defined in the Gude EPC-HTTP-Interface specification:
+# http://wiki.gude.info/EPC_HTTP_Interface
+
+PORT = 80
+
+
+def power_set(host, port, index, value):
+    index = int(index)
+    assert 1 <= index <= 12
+
+    value = 1 if value else 0
+    r = requests.get(
+        f"http://{host}:{port}/ov.html?cmd=1&p={index}&s={value}"
+    )
+    r.raise_for_status()
+
+
+def power_get(host, port, index):
+    index = int(index)
+    assert 1 <= index <= 12
+
+    r = requests.get(f"http://{host}:{port}/statusjsn.js?components=1")
+    r.raise_for_status()
+
+    state = r.json()['outputs'][index - 1]['state']
+
+    return state


### PR DESCRIPTION
**Description**
This patch adds support for Gude Expert Power Control 8225 using the HTTP-GET API defined at wiki.gude.info/EPC_HTTP_Interface .

Signed-off-by: Alexander Merkle <alexander.merkle@lauterbach.com>

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->


**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modifiy one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
