### PR TITLE
requirements: bump attrs 21.3.0 -> 21.4.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-attrs==21.3.0
+attrs==21.4.0
 jinja2==3.0.2
 packaging==21.0
 pexpect==4.8.0


### PR DESCRIPTION
**Description**
attrs 21.3.0 is breaking code coverage [1].

To fix this, bump attrs to 21.4.0.

[1] https://github.com/python-attrs/attrs/issues/895

**Checklist**
- [x] PR has been tested (test-suite only)

See #1029 