### PR TITLE
client: fix help parser of labgrid-client tmc

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1815,9 +1815,9 @@ def main():
     subparser = subparsers.add_parser('audio', help="start a audio stream")
     subparser.set_defaults(func=ClientSession.audio)
 
-    subparser = subparsers.add_parser('tmc', help="control a USB TMC device")
-    subparser.set_defaults(func=lambda _: subparser.print_help())
-    tmc_subparsers = subparser.add_subparsers(
+    tmc_parser = subparsers.add_parser('tmc', help="control a USB TMC device")
+    tmc_parser.set_defaults(func=lambda _: tmc_parser.print_help())
+    tmc_subparsers = tmc_parser.add_subparsers(
         dest='subcommand',
         title='available subcommands',
         metavar="SUBCOMMAND",


### PR DESCRIPTION
**Description**
The command
```
  labgrid-client tmc
```
showed the help of last subparser (=export). Now it shows the help of TMC including all subcommands.

Signed-off-by: Alexander Merkle <alexander.merkle@lauterbach.com>

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
