### PR TITLE
Introduce anonymous static authentication, deprecate dynamic ticket authentication

### DIFF
--- a/.crossbar/config-anonymous.yaml
+++ b/.crossbar/config-anonymous.yaml
@@ -1,24 +1,9 @@
-# Legacy crossbar configuration with dynamic ticket authentication.
-# Please use .crossbar/config-anonymous.yaml instead.
 version: 2
 workers:
 - type: router
   realms:
   - name: realm1
     roles:
-    - name: authenticator
-      permissions:
-      - uri: org.labgrid.authenticate
-        match: exact
-        allow:
-          call: false
-          register: true
-          publish: false
-          subscribe: false
-        disclose:
-          caller: false
-          publisher: false
-        cache: true
     - name: public
       permissions:
       - uri: ''
@@ -44,14 +29,9 @@ workers:
       ws:
         type: websocket
         auth:
-          ticket:
-            type: dynamic
-            authenticator: org.labgrid.authenticate
-  components:
-  - type: class
-    classname: labgrid.remote.authenticator.AuthenticatorSession
-    realm: realm1
-    role: authenticator
+          anonymous:
+            type: static
+            role: public
 - id: coordinator
   type: guest
   executable: python3

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -164,7 +164,7 @@ extra virtualenv and install the dependencies via the crossbar `extra`.
     crossbar-venv $ cd labgrid && pip install ".[crossbar]"
 
 All necessary dependencies should be installed now, we can start the coordinator
-by running ``crossbar start`` inside of the repository.
+by running ``crossbar start --config config-anonymous.yaml`` inside the repository.
 
 .. note:: This is possible because the labgrid repository contains the crossbar
           configuration the coordinator in the ``.crossbar`` folder.
@@ -172,7 +172,7 @@ by running ``crossbar start`` inside of the repository.
           applications, which labgrid plugs into.
 
 .. note:: For long running deployments, you should copy and customize the
-	  ``.crossbar/config.yaml`` file for your use case. This includes
+	  ``.crossbar/config-anonymous.yaml`` file for your use case. This includes
 	  setting a different ``workdir`` and may include changing the running
 	  port.
 
@@ -322,8 +322,8 @@ Follow these instructions to install the systemd files on your machine(s):
    virtual environments of the coordinator and exporter.
 #. Create the coordinator configuration file referenced in the ``ExecStart``
    option of the :file:`labgrid-coordinator.service` file by using
-   :file:`.crossbar/config.yaml` as a starting point. You most likely want to
-   make sure that the ``workdir`` option matches the path given via the
+   :file:`.crossbar/config-anonymous.yaml` as a starting point. You most likely
+   want to make sure that the ``workdir`` option matches the path given via the
    ``--cbdir`` option in the service file; see
    :ref:`remote-getting-started-coordinator` for further information.
 #. Adjust the ``SupplementaryGroups`` option in the

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -47,7 +47,7 @@ VOLUME /opt/crossbar
 
 EXPOSE 20408
 
-CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]
+CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config-anonymous.yaml"]
 
 #
 # ser2net

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     tty: true
     network_mode: "host"
     command: bash -c "cp /home/root/crossbar/places_example.yaml /opt/crossbar/places.yaml &&
-      crossbar start --config /opt/labgrid/.crossbar/config.yaml"
+      crossbar start --config /opt/labgrid/.crossbar/config-anonymous.yaml"
   client:
     image: "labgrid-client"
     volumes:

--- a/examples/usbpower/README.rst
+++ b/examples/usbpower/README.rst
@@ -116,7 +116,7 @@ Remote Setup
 ------------
 
 To access resources remotely, you first need to start the coordinator::
-  $ crossbar start --logformat none
+  $ crossbar start --logformat none --config config-anonymous.yaml
   [...]
   Coordinator ready.
 

--- a/labgrid/remote/authenticator.py
+++ b/labgrid/remote/authenticator.py
@@ -1,3 +1,4 @@
+import logging
 from pprint import pprint
 from twisted.internet.defer import inlineCallbacks
 from autobahn.twisted.wamp import ApplicationSession
@@ -7,8 +8,13 @@ class AuthenticatorSession(ApplicationSession):
     @inlineCallbacks
     def onJoin(self, details):
         def authenticate(realm, authid, details):  # pylint: disable=unused-argument
+            logging.warning("%s still uses deprecated ticket authentication. Please update.", authid)
             pprint(details)
             principal = {'role': 'public', 'extra': {}}
             return principal
+
+        import warnings
+        warnings.warn("Ticket authentication is deprecated. Please switch to anonymous authentication once all your exporters/clients support it: .crossbar/config-anonymous.yaml",
+                      DeprecationWarning)
 
         yield self.register(authenticate, 'org.labgrid.authenticate')

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -68,11 +68,17 @@ class ClientSession(ApplicationSession):
         self.monitor = self.config.extra.get('monitor', False)
         enable_tcp_nodelay(self)
         self.join(
-            self.config.realm, authmethods=["ticket"],
-            authid=f"client/{self.gethostname()}/{self.getuser()}"
+            self.config.realm,
+            authmethods=["anonymous", "ticket"],
+            authid=f"client/{self.gethostname()}/{self.getuser()}",
+            authextra={"authid": f"client/{self.gethostname()}/{self.getuser()}"},
         )
 
     def onChallenge(self, challenge):
+        import warnings
+        warnings.warn("Ticket authentication is deprecated. Please update your coordinator.",
+                      DeprecationWarning)
+        logging.warning("Ticket authentication is deprecated. Please update your coordinator.")
         return "dummy-ticket"
 
     async def onJoin(self, details):

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -130,7 +130,12 @@ class CoordinatorComponent(ApplicationSession):
         self.save_later()
 
         enable_tcp_nodelay(self)
-        self.join(self.config.realm, ["ticket"], "coordinator")
+        self.join(
+            self.config.realm,
+            authmethods=["anonymous", "ticket"],
+            authid="coordinator",
+            authextra={"authid": "coordinator"},
+        )
 
     def onChallenge(self, challenge):
         return "dummy-ticket"
@@ -383,7 +388,7 @@ class CoordinatorComponent(ApplicationSession):
         print('join')
         pprint(session_details)
         session = session_details['session']
-        authid = session_details['authid']
+        authid = session_details['authextra'].get('authid') or session_details['authid']
         if authid.startswith('client/'):
             session = ClientSession(self, session, authid)
         elif authid.startswith('exporter/'):

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -716,11 +716,17 @@ class ExporterSession(ApplicationSession):
         self.groups = {}
 
         enable_tcp_nodelay(self)
-        self.join(self.config.realm, authmethods=["ticket"], authid=f"exporter/{self.name}")
+        self.join(
+            self.config.realm,
+            authmethods=["anonymous", "ticket"],
+            authid=f"exporter/{self.name}",
+            authextra={"authid": f"exporter/{self.name}"},
+        )
 
     def onChallenge(self, challenge):
         """Function invoked on received challege, returns just a dummy ticket
         at the moment, authentication is not supported yet"""
+        logging.warning("Ticket authentication is deprecated. Please update your coordinator.")
         return "dummy-ticket"
 
     async def onJoin(self, details):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def serial_driver_no_name(target, serial_port, mocker):
 
 @pytest.fixture(scope='function')
 def crossbar_config(tmpdir, pytestconfig):
-    crossbar_config = '.crossbar/config.yaml'
+    crossbar_config = '.crossbar/config-anonymous.yaml'
 
     pytestconfig.rootdir.join(crossbar_config).copy(tmpdir.mkdir('.crossbar'))
 
@@ -128,7 +128,7 @@ def crossbar(tmpdir, crossbar_config):
         pytest.skip("crossbar not found")
 
     spawn = pexpect.spawn(
-            'crossbar start --color false --logformat none',
+            'crossbar start --color false --logformat none --config config-anonymous.yaml',
             logfile=Prefixer(sys.stdout.buffer, 'crossbar'),
             cwd=str(tmpdir))
     try:


### PR DESCRIPTION
 **Description**
labgrid performs dynamic clear text challenge authentication with unchecked dummy tickets [1]. Add the anonymous static authentication method [2] and deprecate the previous one.

The only change required apart from the crossbar config is the location of the authid. Previously we could set the authid on `ApplicationSession.join()`, but with anonymous static authentication the authid is generated randomly. Since we still need a way to distinguish coordinator, exporter and client, add labgrid's authid to `authextra` [3]:

> All authenticators can return `authextra` auxiliary information that is returned both to the authenticating client, as well as clients which get disclosed the identity of a calling/publishing peer, as well as in the meta API when querying a session.

Dropping dynamic clear text challenge authentication will allow us to install crossbar in a dedicated virtualenv in the future, since `labgrid.remote.authenticator.AuthenticatorSession` is the only reference into labgrid code except for the coordinator itself, which is called with a dedicated python executable that can live inside a separate virtualenv. This again should reduce dependency conflicts caused by shared dependencies between crossbar and labgrid.

[1] https://crossbar.io/docs/Ticket-Authentication/
[2] https://crossbar.io/docs/Anonymous-Authentication/
[3] https://github.com/crossbario/crossbar/blob/ccbae0a56ef331fe00192455837aa72578eadc54/docs-old/pages/Features.md#authentication

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested