### PR TITLE
examples/ssh: add simple ssh example

### DIFF
--- a/examples/ssh/local.yaml
+++ b/examples/ssh/local.yaml
@@ -1,0 +1,10 @@
+targets:
+  main:
+    resources:
+      NetworkService:
+        address: dut.address
+        username: root
+        password: pass
+    drivers:
+      SSHDriver:
+        keyfile: ""

--- a/examples/ssh/test_ssh.py
+++ b/examples/ssh/test_ssh.py
@@ -1,0 +1,16 @@
+def test_ssh_raw(target):
+    """Simple test with SSHDriver directly executing a command on the DUT"""
+    ssh_driver = target.get_driver('SSHDriver')
+    stdout, stderr, returncode = ssh_driver.run('cat /proc/version')
+    assert returncode == 0
+    assert stdout
+    assert not stderr
+
+
+def test_ssh_command(target):
+    """Simple test running through the command protocol abstraction"""
+    command = target.get_driver('CommandProtocol')
+    stdout, stderr, returncode = command.run('cat /proc/version')
+    assert returncode == 0
+    assert stdout
+    assert not stderr


### PR DESCRIPTION
**Description**
Example that shows how the use the ssh driver in practise.
With and without the command protocol.
