### PR TITLE
CI: add scheduled tests

### DIFF
--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -1,0 +1,17 @@
+name: unit tests
+
+on: [push, pull_request]
+
+jobs:
+  push-pr-unit-tests:
+    name: unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+    uses: ./.github/workflows/reusable-unit-tests.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+  push-pr-unit-tests-docker:
+    name: Docker Unit Tests
+    uses: ./.github/workflows/reusable-unit-tests-docker.yml

--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -1,6 +1,6 @@
 name: unit tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   push-pr-unit-tests:

--- a/.github/workflows/reusable-unit-tests-docker.yml
+++ b/.github/workflows/reusable-unit-tests-docker.yml
@@ -1,0 +1,28 @@
+name: reusable docker tests
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        type: string
+        required: false
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ inputs.branch }}
+    - name: Install system dependencies
+      run: |
+        sudo apt install -yq python3-pip
+        python3 -m pip install setuptools_scm
+    - name: Build docker images
+      run: |
+        ./dockerfiles/build.sh
+        docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client || (docker-compose -f dockerfiles/staging/docker-compose.yml logs --timestamps && false)
+        docker-compose -f dockerfiles/staging/docker-compose.yml down
+    - name: Show docker images
+      run: |
+        docker images

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -1,22 +1,27 @@
-name: unit tests
+name: reusable unit tests
 
-on: [push, pull_request]
+on:
+  workflow_call:
+    inputs:
+      python-version:
+        type: string
+        required: true
+      branch:
+        type: string
+        required: false
 
 jobs:
   build:
     runs-on: ubuntu-22.04
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-        experimental: [false]
+    continue-on-error: false
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
+      with:
+        ref: ${{ inputs.branch }}
+    - name: Set up Python ${{ inputs.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ inputs.python-version }}
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip
@@ -57,19 +62,3 @@ jobs:
         make -C man all
         git --no-pager diff --exit-code
     - uses: codecov/codecov-action@v3
-  docker:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-    - name: Install system dependencies
-      run: |
-        sudo apt install -yq python3-pip
-        python3 -m pip install setuptools_scm
-    - name: Build docker images
-      run: |
-        ./dockerfiles/build.sh
-        docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client || (docker-compose -f dockerfiles/staging/docker-compose.yml logs --timestamps && false)
-        docker-compose -f dockerfiles/staging/docker-compose.yml down
-    - name: Show docker images
-      run: |
-        docker images

--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -1,0 +1,27 @@
+name: scheduled unit tests
+
+on:
+  schedule:
+    - cron: '10 8 * * *'
+
+jobs:
+  scheduled-unit-tests:
+    name: scheduled unit tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        branch: ['master']
+    uses: ./.github/workflows/reusable-unit-tests.yml
+    with:
+      python-version: ${{ matrix.python-version }}
+      branch: ${{ matrix.branch }}
+  scheduled-unit-tests-docker:
+    name: scheduled docker tests
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['master']
+    uses: ./.github/workflows/reusable-unit-tests-docker.yml
+    with:
+      branch: ${{ matrix.branch }}


### PR DESCRIPTION
**Description**
Test results may vary due to new dependency versions. Daily CI runs should help us find issues early.

This becomes especially important once all of labgrid's dependencies get unpinned.

**Checklist**
- [x] PR has been tested