### PR TITLE
Github Release workflow

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -1,0 +1,22 @@
+name: build and publish
+
+on: workflow_call
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    continue-on-error: false
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python
+      uses: actions/setup-python@v4
+    - name: Install python dependencies
+      run: |
+        python -m pip install --upgrade pip build
+    - name: Build sdist
+      run: |
+        python -m build -s
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -15,3 +15,8 @@ jobs:
   push-pr-unit-tests-docker:
     name: Docker Unit Tests
     uses: ./.github/workflows/reusable-unit-tests-docker.yml
+  build-and-release:
+    name: Release to Pypi
+    needs: push-pr-unit-tests
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    uses: ./.github/workflows/build-and-release.yml


### PR DESCRIPTION
Add a build and release workflow which runs after successful tests and if a Tag was pushed.

Depends on #1045 