### PR TITLE
config: raise proper exception on empty config

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -27,6 +27,9 @@ class Config:
         except YAMLError as err:
             raise InvalidConfigError(f"Error in configuration file: {err}")
 
+        if self.data is None:
+            raise InvalidConfigError("Configuration file is empty")
+
         substitutions = {
             'BASE': self.base,
         }


### PR DESCRIPTION
**Description**
An empty file is valid yaml, so no exception is raised by the yaml module. labgrid later relies on parsed config data to be either a list or a dict, so check for an empty config early and raise a proper exception instead of cryptic exceptions being raised later.

**Checklist**
- [x] PR has been tested