### PR TITLE
tree-wide: send error messages to stderr instead of stdout

### DIFF
--- a/labgrid/driver/httpvideodriver.py
+++ b/labgrid/driver/httpvideodriver.py
@@ -1,4 +1,5 @@
 import subprocess
+import sys
 from urllib.parse import urlsplit
 
 import attr
@@ -27,7 +28,7 @@ class HTTPVideoDriver(Driver, VideoProtocol):
         elif s.scheme == "https":
             default_port = 443
         else:
-            print(f"Unknown scheme: {s.scheme}")
+            print(f"Unknown scheme: {s.scheme}", file=sys.stderr)
             return
 
         url = proxymanager.get_url(self.video.url, default_port=default_port)

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -1,6 +1,7 @@
 """The coordinator module coordinates exported resources and clients accessing them."""
 # pylint: disable=no-member,unused-argument
 import asyncio
+import sys
 import traceback
 from collections import defaultdict
 from os import environ
@@ -592,7 +593,7 @@ class CoordinatorComponent(ApplicationSession):
                                 resource.path[1], resource.path[3], place.name)
                 acquired.append(resource)
         except:
-            print(f"failed to acquire {resource}")
+            print(f"failed to acquire {resource}", file=sys.stderr)
             # cleanup
             await self._release_resources(place, acquired)
             return False
@@ -619,7 +620,7 @@ class CoordinatorComponent(ApplicationSession):
                     await self.call(f'org.labgrid.exporter.{resource.path[0]}.release',
                                     resource.path[1], resource.path[3])
             except:
-                print(f"failed to release {resource}")
+                print(f"failed to release {resource}", file=sys.stderr)
                 # at leaset try to notify the clients
                 try:
                     self._publish_resource(resource)

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -768,7 +768,7 @@ class ExporterSession(ApplicationSession):
                     self.checkpoint = time.monotonic()
 
         except Exception:  # pylint: disable=broad-except
-            traceback.print_exc()
+            traceback.print_exc(file=sys.stderr)
             self.loop.stop()
             return
 
@@ -782,7 +782,7 @@ class ExporterSession(ApplicationSession):
         super().onLeave(details)
 
     async def onDisconnect(self):
-        print("connection lost")
+        print("connection lost", file=sys.stderr)
         global reexec
         reexec = True
         if self.poll_task:
@@ -818,7 +818,7 @@ class ExporterSession(ApplicationSession):
                     changed = resource.poll()
                 except Exception:  # pylint: disable=broad-except
                     print(f"Exception while polling {resource}", file=sys.stderr)
-                    traceback.print_exc()
+                    traceback.print_exc(file=sys.stderr)
                     continue
                 if changed:
                     await self.update_resource(group_name, resource_name)
@@ -834,10 +834,10 @@ class ExporterSession(ApplicationSession):
             except asyncio.CancelledError:
                 break
             except Exception:  # pylint: disable=broad-except
-                traceback.print_exc()
+                traceback.print_exc(file=sys.stderr)
             age = time.monotonic() - self.checkpoint
             if age > 300:
-                print(f"missed checkpoint, exiting (last was {age} seconds ago)")
+                print(f"missed checkpoint, exiting (last was {age} seconds ago)", file=sys.stderr)
                 self.disconnect()
 
     async def add_resource(self, group_name, resource_name, cls, params):

--- a/labgrid/resource/ethernetport.py
+++ b/labgrid/resource/ethernetport.py
@@ -1,5 +1,6 @@
 import logging
 import subprocess
+import sys
 from time import time
 import attr
 
@@ -246,7 +247,7 @@ class EthernetPortManager(ResourceManager):
                     break
                 except Exception:  # pylint: disable=broad-except
                     import traceback
-                    traceback.print_exc()
+                    traceback.print_exc(file=sys.stderr)
 
         self.loop = asyncio.get_event_loop()
         self.poll_tasks.append(self.loop.create_task(poll(self, poll_neighbour)))

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -1,6 +1,7 @@
 import abc
 import atexit
 import logging
+import sys
 from time import monotonic, sleep
 
 import attr
@@ -508,10 +509,10 @@ class Target:
             self.cleanup()
         except Exception as e:
             print("An exception occured during cleanup, call the cleanup() "
-                  "method on targets yourself to handle exceptions explictly.")
-            print(f"Error: {e}")
+                  "method on targets yourself to handle exceptions explictly.", file=sys.stderr)
+            print(f"Error: {e}", file=sys.stderr)
             import traceback
-            traceback.print_exc()
+            traceback.print_exc(file=sys.stderr)
 
     def export(self):
         """

--- a/labgrid/util/agents/network_interface.py
+++ b/labgrid/util/agents/network_interface.py
@@ -38,7 +38,7 @@ class BackgroundLoop(threading.Thread):
             GLib.MainLoop(None).run()
         except Exception:
             import traceback
-            traceback.print_exc()
+            traceback.print_exc(file=sys.stderr)
             sys.exit(1)
 
     def block_on(self, func, *args, **kwargs):


### PR DESCRIPTION
**Description**
Sending error messages to stderr instead of stdout allows easier output parsing, e.g. for `labgrid-client export`.

Most errors are already sent to stderr, but not everywhere. So direct the remaining errors (and tracebacks) to stderr.

**Checklist**
- [ ] PR has been tested