### PR TITLE
exporter/coordinator/client: create/set event loop explicitly

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -32,8 +32,6 @@ from ..util.proxy import proxymanager
 from ..util.helper import processwrapper
 from ..driver import Mode, ExecutionError
 
-txaio.config.loop = asyncio.get_event_loop()  # pylint: disable=no-member
-
 
 class Error(Exception):
     pass
@@ -1235,7 +1233,10 @@ class ClientSession(ApplicationSession):
 def start_session(url, realm, extra):
     from autobahn.asyncio.wamp import ApplicationRunner
 
-    loop = asyncio.get_event_loop()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    txaio.config.loop = loop  # pylint: disable=no-member
+
     ready = asyncio.Event()
 
     async def connected(session):  # pylint: disable=unused-argument

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -888,6 +888,7 @@ class CoordinatorComponent(ApplicationSession):
         return {k: v.asdict() for k, v in self.reservations.items()}
 
 if __name__ == '__main__':
+    asyncio.set_event_loop(asyncio.new_event_loop())
     runner = ApplicationRunner(
         url=environ.get("WS", "ws://127.0.0.1:20408/ws"),
         realm="realm1",

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -936,7 +936,8 @@ def main():
     print(f"exporter hostname: {extra['hostname']}")
     print(f"resource config file: {extra['resources']}")
 
-    extra['loop'] = loop = asyncio.get_event_loop()
+    extra['loop'] = loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
     if args.debug:
         loop.set_debug(True)
     runner = ApplicationRunner(url=crossbar_url, realm=crossbar_realm, extra=extra)


### PR DESCRIPTION
**Description**
Calling `asyncio.get_event_loop()` with no current event loop is deprecated since Python 3.10 and will be an error in Python >=3.12, see [docs](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.get_event_loop).

So create a new event loop explicitly and set it as the current event loop for the current OS thread.

**Checklist**
- [x] PR has been tested

Fixes #1056
