### PR TITLE
contrib/completion: try to resolve bash aliases

### DIFF
--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -13,7 +13,7 @@ _labgrid_main_opts_with_value="@(-x|--crossbar|-c|--config|-p|--place|-s|--state
 # Before calling this function, make sure arg, base_cmd and last_arg_opt_with_value are local
 _labgrid_parse_args()
 {
-    local i
+    local i cmd_type
     arg=
     base_cmd=("${COMP_WORDS[0]}")
     last_arg_opt_with_value=false
@@ -48,6 +48,13 @@ _labgrid_parse_args()
     # drop incomplete option expecting a value
     if $last_arg_opt_with_value; then
         unset 'base_cmd[-1]'
+    fi
+
+    # resolve base command aliases
+    if cmd_type=$(type -t -f "${base_cmd[0]}" 2>/dev/null); then
+        if [[ "$cmd_type" == "alias" ]]; then
+            base_cmd[0]="${BASH_ALIASES["${base_cmd[0]}"]}"
+        fi
     fi
 }
 

--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -137,8 +137,8 @@ _labgrid_client_resources()
     -*)
         local options="--acquired \
                        --exporter \
-		       --sort-by-matched-place-change \
-		       $_labgrid_shared_options"
+                       --sort-by-matched-place-change \
+                       $_labgrid_shared_options"
         COMPREPLY=( $(compgen -W "$options" -- "$cur") )
         ;;
     *)
@@ -472,11 +472,11 @@ _labgrid_client_usb_mux()
         # only complete second argument
         [ "$args" -ne 2 ] && return
 
-	actions="off \
-		dut-device \
-		host-dut \
-		host-device \
-		host-dut+host-device"
+        actions="off \
+                 dut-device \
+                 host-dut \
+                 host-device \
+                 host-dut+host-device"
         COMPREPLY=( $(compgen -W "$actions") )
         ;;
     esac
@@ -724,8 +724,8 @@ _labgrid_client()
         case "$cur" in
         --*)
             # top level args completion
-	    local options="--crossbar \
-		           --config \
+            local options="--crossbar \
+                           --config \
                            --place \
                            --state \
                            --debug \


### PR DESCRIPTION
**Description**
When labgrid-client is called via an alias like `alias lgc=labgrid-client` completion can still be enabled via:

```bash
_completion_loader labgrid-client
complete -F _labgrid_client lgc
```

In this case `${base_cmd[0]}` is "lgc". Since `base_cmd` is called for completing places/resources/matches via the complete sub command, this does not work, because "lgc" is undefined in the script's scope.

Allow this case by resolving aliases via `$BASH_ALIASES`.

While at it, use spaces consistently in the completion script.

**Checklist**
- [x] PR has been tested