### PR TITLE
remote/exporter: stop event loop when register calls fail

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -731,11 +731,11 @@ class ExporterSession(ApplicationSession):
         print(details)
 
         prefix = f'org.labgrid.exporter.{self.name}'
-        await self.register(self.acquire, f'{prefix}.acquire')
-        await self.register(self.release, f'{prefix}.release')
-        await self.register(self.version, f'{prefix}.version')
-
         try:
+            await self.register(self.acquire, f'{prefix}.acquire')
+            await self.register(self.release, f'{prefix}.release')
+            await self.register(self.version, f'{prefix}.version')
+
             config_template_env = {
                 'env': os.environ,
                 'isolated': self.isolated,


### PR DESCRIPTION
**Description**
In case an exception is raised during procedure registration, the default exception handler logs it and the event loop carries on. That means when the exporter tries to join and it fails to register, the exporter process simply hangs.

Move the register calls inside the try..except block which already handles printing the exception and stopping the loop. This way the process stops and it can be restarted (e.g. by systemd).

**Checklist**
- [x] PR has been tested