### PR TITLE
util/ssh: do not pass unexpected argument to rsync --compress

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -322,7 +322,7 @@ class SSHConnection:
     @_check_connected
     def put_file(self, local_file, remote_path):
         """Put a file onto the remote host"""
-        complete_cmd = ["rsync", "--compress=1", "--sparse", "--copy-links", "--verbose", "--progress", "--times", "-e",
+        complete_cmd = ["rsync", "--compress", "--sparse", "--copy-links", "--verbose", "--progress", "--times", "-e",
                         " ".join(['ssh'] + self._get_ssh_args())]
         complete_cmd += [
             f"{local_file}",


### PR DESCRIPTION
**Description**
On rsync v3.2.7 `--compress=1` fails with:
```
rsync: --compress=1: option does not take an argument
rsync error: syntax or usage error (code 1) at main.c(1795) [client=3.2.7]
```

rsync never expected an argument for `--compress`, but in previous versions it was ignored, now it fails.

Fix this by dropping the argument.

**Checklist**
- [x] PR has been tested

Fixes #382

/cc @a3f
