### PR TITLE
pyproject.toml: drop six, move werkzeug to crossbar extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "pyusb==1.2.1",
     "PyYAML==5.4.1",
     "requests==2.26.0",
-    "six>=1.13.0",
     "xmodem==0.4.6",
 ]
 dynamic = ["version"]  # via setuptools_scm

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "PyYAML==5.4.1",
     "requests==2.26.0",
     "six>=1.13.0",
-    "werkzeug>=0.14.1,<2.1",
     "xmodem==0.4.6",
 ]
 dynamic = ["version"]  # via setuptools_scm
@@ -52,7 +51,10 @@ dynamic = ["version"]  # via setuptools_scm
 "Bug Tracker" = "https://github.com/labgrid-project/labgrid/issues"
 
 [project.optional-dependencies]
-crossbar = ["crossbar==21.3.1"]
+crossbar = [
+    "crossbar==21.3.1",
+    "werkzeug>=0.14.1,<2.1",
+]
 doc = [
     "docutils==0.17.1",
     "Sphinx==4.2.0",
@@ -78,6 +80,7 @@ xena = ["xenavalkyrie==3.0.1"]
 deb = [
     # labgrid[crossbar]
     "crossbar==21.3.1",
+    "werkzeug>=0.14.1,<2.1",
 
     # labgrid[modbus]
     "pyModbusTCP==0.1.10",
@@ -93,6 +96,7 @@ dev = [
     # references to other optional dependency groups
     # labgrid[crossbar]
     "crossbar==21.3.1",
+    "werkzeug>=0.14.1,<2.1",
 
     # labgrid[doc]
     "docutils==0.17.1",


### PR DESCRIPTION
**Description**
The explicit six dependency with minimum version was introduced back in a540ab7a. Since we do not support Python 3.5 anymore and moved to a newer crossbar version long ago, let's drop this explicit dependency.

labgrid has no direct dependency on werkzeug. The dependency was introduced in 8c171014 to allow successful installation of crossbar 21.3.1. So move it to the crossbar dependencies for now. Once we can loosen the
dependency versions, we can drop this altogether (see #1042 for a first step towards this goal).

**Checklist**
- [x] PR has been tested (via test-suite only)