### PR TITLE
resource/remote: allow instantiation of RemotePlaces without Environment

### DIFF
--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -40,13 +40,12 @@ class RemotePlaceManager(ResourceManager):
         # be the same).
         if not self.session:
             self.env = remote_place.target.env
-            config = self.env.config
-            self.url = config.get_option(
-                'crossbar_url',
-                os.environ.get("LG_CROSSBAR", "ws://127.0.0.1:20408/ws"))
-            self.realm = config.get_option(
-                'crossbar_realm',
-                os.environ.get("LG_CROSSBAR_REALM", "realm1"))
+            self.url = os.environ.get("LG_CROSSBAR", "ws://127.0.0.1:20408/ws")
+            self.realm = os.environ.get("LG_CROSSBAR_REALM", "realm1")
+            if self.env:
+                config = self.env.config
+                self.url = config.get_option('crossbar_url', self.url)
+                self.realm = config.get_option('crossbar_realm', self.realm)
             self._start()
         place = self.session.get_place(remote_place.name)  # pylint: disable=no-member
         resource_entries = self.session.get_target_resources(place)  # pylint: disable=no-member

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -289,6 +289,13 @@ def test_remoteplace_target(place_acquire, tmpdir):
     t = e.get_target("test1")
     t.await_resources(t.resources)
 
+def test_remoteplace_target_without_env(request, place_acquire):
+    from labgrid import Target
+    from labgrid.resource import RemotePlace
+
+    t = Target(request.node.name)
+    RemotePlace(t, name="test")
+
 def test_resource_conflict(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test2 create') as spawn:
         spawn.expect(pexpect.EOF)


### PR DESCRIPTION
**Description**
While it is recommended to use an Environment config, it should still be possible to instantiate a Target and a RemotePlace without it, e.g.:

```python
import labgrid

target = labgrid.Target("main")
remote_place = labgrid.resource.RemotePlace(target, name="my-place-name")
power = labgrid.driver.powerdriver.NetworkPowerDriver(target, name=None)
target.activate(power)
power.cycle()
```

We already have a fallback for crossbar URL and realm if it's not present in the Environment, so stick to that when no Environment is present at all.

Also add a test for this.

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] PR has been tested