### PR TITLE
client: console support for --listenonly option with microcom

### DIFF
--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -347,7 +347,7 @@ _labgrid_client_console()
 
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "--loop --logfile $_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--listenonly --loop --logfile $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -775,7 +775,7 @@ class ClientSession(ApplicationSession):
         elif action == 'low':
             drv.set(False)
 
-    async def _console(self, place, target, timeout, *, logfile=None, loop=False):
+    async def _console(self, place, target, timeout, *, logfile=None, loop=False, listen_only=False):
         name = self.args.name
         from ..resource import NetworkSerialPort
         resource = target.get_resource(NetworkSerialPort, name=name, wait_avail=False)
@@ -797,6 +797,10 @@ class ClientSession(ApplicationSession):
         assert port is not None, "Port is not set"
 
         call = ['microcom', '-s', str(resource.speed), '-t', f"{host}:{port}"]
+
+        if listen_only:
+            call.append("--listenonly")
+
         if logfile:
             call.append(f"--logfile={logfile}")
         print(f"connecting to {resource} calling {' '.join(call)}")
@@ -830,7 +834,7 @@ class ClientSession(ApplicationSession):
     async def console(self, place, target):
         while True:
             res = await self._console(place, target, 10.0, logfile=self.args.logfile,
-                                      loop=self.args.loop)
+                                      loop=self.args.loop, listen_only=self.args.listenonly)
             if res or not self.args.loop:
                 break
             await asyncio.sleep(1.0)
@@ -1540,6 +1544,8 @@ def main():
                                       help="connect to the console")
     subparser.add_argument('-l', '--loop', action='store_true',
                            help="keep trying to connect if the console is unavailable")
+    subparser.add_argument('-o', '--listenonly', action='store_true',
+                           help="do not modify local terminal, do not send input from stdin")
     subparser.add_argument('name', help="optional resource name", nargs='?')
     subparser.add_argument('--logfile', metavar="FILE", help="Log output to FILE", default=None)
     subparser.set_defaults(func=ClientSession.console)


### PR DESCRIPTION
**Description**
Expose microcom --listenonly feature via labgrid-client console.
This enables a user to monitor a devices serial output without the risk of client modifying it.
Useful for multiple concurrent console invocations of same port.

Future amendments to this listenonly feature could enable the usecase of monitoring a console of a place locked by a different user.

**Checklist**
- [x] Documentation for the feature
      Since this is a new client CLI option, I believe the argparse library handles documentation / help
- [ ] Tests for the feature 
I didn't see any existing tests for basic labgrid-client features.  Can add if necessary


