### PR TITLE
Actions: build and release fixes

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -16,7 +16,14 @@ jobs:
     - name: Build sdist
       run: |
         python -m build -s
-    - name: Publish package
+    - name: Publish distribution 📦 to Test PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      if: startsWith(github.ref, 'refs/tags') != true
+      with:
+        password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+    - name: Publish distribution 📦 to PyPI
+      if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -10,6 +10,8 @@ jobs:
     - uses: actions/checkout@v3
     - name: Set up Python
       uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip build

--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -18,5 +18,5 @@ jobs:
   build-and-release:
     name: Release to Pypi
     needs: push-pr-unit-tests
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    if: github.event_name == 'push'
     uses: ./.github/workflows/build-and-release.yml

--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -20,3 +20,4 @@ jobs:
     needs: push-pr-unit-tests
     if: github.event_name == 'push'
     uses: ./.github/workflows/build-and-release.yml
+    secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -173,6 +173,7 @@ packages = [
 ]
 
 [tool.setuptools_scm]
+local_scheme = "no-local-version"
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
**Description**

Adjust the build and release workflow to work:
- upload to testpypi if it is not a tag, to ensure the release pipeline works
- set an explicit python version
- inherit secrets from the main run so API tokens can be accessed in the build and release job.
- remove local versioning for `setuptools_scm`