### PR TITLE
actions: set fetch-depth for build and release

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -8,6 +8,8 @@ jobs:
     continue-on-error: false
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
**Description**
Set the fetch-depth to 0 for the build and release workflow. This way we should have the complete tag history of the branch, which should allow setuptools_scm to calculate the correct wanted release name for the testpypi upload.