### PR TITLE
dockerfiles: revert to previous authentication

### DIFF
--- a/.crossbar/config.yaml
+++ b/.crossbar/config.yaml
@@ -44,6 +44,9 @@ workers:
       ws:
         type: websocket
         auth:
+          anonymous:
+            type: static
+            role: public
           ticket:
             type: dynamic
             authenticator: org.labgrid.authenticate

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -47,7 +47,7 @@ VOLUME /opt/crossbar
 
 EXPOSE 20408
 
-CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config-anonymous.yaml"]
+CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]
 
 #
 # ser2net

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     tty: true
     network_mode: "host"
     command: bash -c "cp /home/root/crossbar/places_example.yaml /opt/crossbar/places.yaml &&
-      crossbar start --config /opt/labgrid/.crossbar/config-anonymous.yaml"
+      crossbar start --config /opt/labgrid/.crossbar/config.yaml"
   client:
     image: "labgrid-client"
     volumes:


### PR DESCRIPTION
**Description**
Updating the docker containers breaks backwards compatibility with older clients. Revert back to ticket authentication.
