### PR TITLE
U-Boot boot commands Support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1507,6 +1507,9 @@ Implements:
 
    UBootDriver:
      prompt: 'Uboot> '
+     boot_commands:
+       net: run netboot
+       spi: run spiboot
 
 Arguments:
   - prompt (regex, default=""): U-Boot prompt to match
@@ -1518,6 +1521,7 @@ Arguments:
   - password_prompt (str, default="enter Password: "): regex to match the U-Boot password prompt
   - bootstring (str): optional, regex to match on Linux Kernel boot
   - boot_command (str, default="run bootcmd"): boot command for booting target
+  - boot_commands (dict, default={}): boot commands by name for LinuxBootProtocol boot command
   - login_timeout (int, default=30): timeout for login prompt detection in seconds
   - boot_timeout (int, default=30): timeout for initial Linux Kernel version detection
 

--- a/tests/test_ubootdriver.py
+++ b/tests/test_ubootdriver.py
@@ -18,7 +18,7 @@ class TestUBootDriver:
 
     def test_uboot_run(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
-        d = UBootDriver(t, "barebox")
+        d = UBootDriver(t, "uboot")
         d.console.rxq.append(b"U-Boot 2019\n")
         d = t.get_driver(UBootDriver)
         d._run = mocker.MagicMock(return_value=(['success'], [], 0))
@@ -32,7 +32,7 @@ class TestUBootDriver:
 
     def test_uboot_run_error(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
-        d = UBootDriver(t, "barebox")
+        d = UBootDriver(t, "uboot")
         d.console.rxq.append(b"U-Boot 2019\n")
         d = t.get_driver(UBootDriver)
         d._run = mocker.MagicMock(return_value=(['error'], [], 1))
@@ -43,3 +43,14 @@ class TestUBootDriver:
         res = d.run("test")
         assert res == (['error'], [], 1)
         d._run.assert_called_once_with("test", timeout=30)
+
+    def test_uboot_boot(self, target_with_fakeconsole):
+        t = target_with_fakeconsole
+        d = UBootDriver(t, "uboot", boot_command='run bootcmd', boot_commands = {"foo": "bar"})
+        d = t.get_driver(UBootDriver)
+        d.boot()
+        assert d.console.txq.pop() == b"run bootcmd\n"
+        d.boot('foo')
+        assert d.console.txq.pop() == b"bar\n"
+        with pytest.raises(Exception):
+            d.boot('nop')


### PR DESCRIPTION
uboot doesn't have pre defined boot sources. The "boot" command takes no parameters.
Add self.boot_commands to hold different boot_command by name.
They can be used with LinuxBootProtocol boot(name)

**Checklist**
- [X] Tests for the feature 
- [X] PR has been tested