### PR TITLE
dockerfiles: make execution of build.sh independent of cwd

### DIFF
--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -1,10 +1,14 @@
 #!/bin/sh
 
+SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE:-$0}")")"
+
+cd "${SCRIPT_DIR}/.."
+
 set -ex
-if [ -z ${DOCKER} ]; then
+if [ -z "${DOCKER}" ]; then
     command -v docker >/dev/null 2>&1 && DOCKER=docker
 fi
-if [ -z ${DOCKER} ]; then
+if [ -z "${DOCKER}" ]; then
     command -v podman >/dev/null 2>&1 && DOCKER=podman
 fi
 export DOCKER_BUILDKIT=1
@@ -13,5 +17,5 @@ VERSION="$(python -m setuptools_scm)"
 
 for t in client exporter coordinator; do
     ${DOCKER} build --build-arg VERSION="$VERSION" \
-        --target labgrid-${t} -t labgrid-${t} -f dockerfiles/Dockerfile .
+        --target labgrid-${t} -t labgrid-${t} -f "${SCRIPT_DIR}/Dockerfile" .
 done


### PR DESCRIPTION
This is just a small improvement to make the `build.sh` script for building Docker containers a bit more robust. I was confused by the fact that I couldn't execute it from its directory.