### PR TITLE
pyproject.toml: remove xena extra from dev extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,9 +134,6 @@ dev = [
     # labgrid[vxi11]
     "python-vxi11==0.9",
 
-    # labgrid[xena]
-    "xenavalkyrie==3.0.1",
-
     # additional dev dependencies
     "psutil==5.8.0",
     "pytest-cov==3.0.0",


### PR DESCRIPTION
**Description**
xenavalkyrie is EOL and pins its dependencies to versions incompatible with latest setuptools [1], so drop it from the dev extra for now (as suggested in [2]).

In the long run, the xenavalkyrie dependency should be dropped altogether. It is currently unclear if Xena support is still needed. This is issue is tracked in [1].

[1] https://github.com/labgrid-project/labgrid/issues/1084
[2] https://github.com/labgrid-project/labgrid/issues/1084#issuecomment-1409864342

**Checklist**
- [ ] PR has been tested