### PR TITLE
Use ed25519 for the SSH keyfile

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -219,7 +219,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     def _put_ssh_key(self, keyfile_path):
         """Upload an SSH Key to a target"""
         regex = re.compile(
-            r"""ssh-rsa # Only match RSA Keys
+            r"""ssh-(rsa|ed25519)
             \s+(?P<key>[a-zA-Z0-9/+=]+) # Match Keystring
             \s+(?P<comment>.*) # Match comment""", re.X
         )


### PR DESCRIPTION
**Description**
Our platform does not support RSA anymore.  
So we need to allow using ed25519 for the keyfile

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
