### PR TITLE
resource/udev: allow fastboot with adb_user=yes

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -315,6 +315,8 @@ class AndroidUSBFastboot(USBResource):
     usb_vendor_id = attr.ib(default='1d6b', validator=attr.validators.instance_of(str))
     usb_product_id = attr.ib(default='0104', validator=attr.validators.instance_of(str))
     def filter_match(self, device):
+        if device.properties.get("adb_user") == "yes":
+            return True
         if device.properties.get('ID_VENDOR_ID') != self.usb_vendor_id:
             return False
         if device.properties.get('ID_MODEL_ID') != self.usb_product_id:


### PR DESCRIPTION
**Description**
Distros which implement the android-udev-rules from github use the adb_user property to indicate that the device is valid for fastboot. Make use of this property for labgrid which removes the need for more hardcoded USB IDs.

**Checklist**
- [x] PR has been tested

Fixes #1086
