### PR TITLE
labgrid/driver/usbloader: fix uuu command

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2210,7 +2210,7 @@ Implements:
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
     of an image to bootstrap onto the target
-  - cmd (str, default="spl"): single command used for mfgtool
+  - script (str): run built-in script with "uuu -b", called with image as arg0
 
 USBStorageDriver
 ~~~~~~~~~~~~~~~~

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -153,7 +153,7 @@ class UUUDriver(Driver, BootstrapProtocol):
     }
 
     image = attr.ib(default=None)
-    cmd = attr.ib(default='spl', validator=attr.validators.instance_of(str))
+    script = attr.ib(default='', validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -177,8 +177,10 @@ class UUUDriver(Driver, BootstrapProtocol):
         mf = ManagedFile(filename, self.loader)
         mf.sync_to_resource()
 
+        cmd = ['-b', self.script] if self.script else []
+
         processwrapper.check_output(
-            self.loader.command_prefix + [self.tool, mf.get_remote_path(), self.cmd]
+            self.loader.command_prefix + [self.tool] + cmd + [mf.get_remote_path()]
         )
 
 


### PR DESCRIPTION
The current implementation adds the cmd as last arg. There it is ignored by uuu
tool. It runs in the default mode with just an image.

For CPUs relying on a special build-in run scripts it must be added with
-b before the file argument.
Removed the broken cmd and add script as config option. This way 
currently working setups should work further.
```
uuu help text (libuuu_1.4.43)

uuu [-d -m -v -V] <bootloader|cmdlists|cmd>

uuu [-d -m -v] -b[run] <emmc|emmc_all|fat_write|nand|qspi|sd|sd_all|spl> arg...
	spl	boot spl and uboot
		arg0: _flash.bin
```
**Checklist**
- [x] Documentation for the feature
- [x] Tests on i.MX6UL and i.MX8MM