### PR TITLE
dockerfiles: support for docker buildx

### DIFF
--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -28,20 +28,31 @@ Using `BuildKit <https://docs.docker.com/develop/develop-images/build_enhancemen
 is recommended to reduce build times.
 
 You can also choose to build all 3 images,
-with the included script
-(which also must be run from the root of this repository):
+with the included script.
 
 .. code-block:: bash
 
    $ pip install --upgrade setuptools_scm
    $ ./dockerfiles/build.sh
 
-The script supports ``podman`` as well
+The script supports ``podman`` as well.
 
 .. code-block:: bash
   
    $ export DOCKER=podman
    $ ./dockerfiles/build.sh
+
+It builds for the native platform by default. However, building
+for foreign platforms is also supported using `docker buildx
+<https://docs.docker.com/build/building/multi-platform/>` or `podman
+buildx <https://docs.podman.io/en/latest/markdown/podman-build.1.html>`
+by passing the platform of choice, e.g. `linux/arm64`.
+
+.. code-block:: bash
+
+   $ pip install --upgrade setuptools_scm
+   $ ./dockerfiles/build.sh linux/arm64
+
 
 Usage
 -----

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -1,21 +1,98 @@
-#!/bin/sh
+#!/bin/bash
 
-SCRIPT_DIR="$(dirname "$(realpath "${BASH_SOURCE:-$0}")")"
-
-cd "${SCRIPT_DIR}/.."
-
-set -ex
-if [ -z "${DOCKER}" ]; then
-    command -v docker >/dev/null 2>&1 && DOCKER=docker
-fi
-if [ -z "${DOCKER}" ]; then
-    command -v podman >/dev/null 2>&1 && DOCKER=podman
-fi
 export DOCKER_BUILDKIT=1
 
-VERSION="$(python -m setuptools_scm)"
+die () {
+    local msg
+    msg="${1}"
 
-for t in client exporter coordinator; do
-    ${DOCKER} build --build-arg VERSION="$VERSION" \
-        --target labgrid-${t} -t labgrid-${t} -f "${SCRIPT_DIR}/Dockerfile" .
-done
+    echo "[fatal] ${msg}" >&2
+    exit 1
+}
+
+log_info() {
+    local msg
+    msg="${1}"
+
+    echo "[info] ${msg}"
+}
+
+has_docker() {
+    command -v docker >/dev/null 2>&1
+}
+
+has_podman() {
+    command -v podman /dev/null 2>&1
+}
+
+has_buildx() {
+    local docker_cmd
+    docker_cmd="${1}"
+
+    "${docker_cmd}" buildx --help >/dev/null 2>&1
+}
+
+get_docker_cmd() {
+    local docker_cmd
+    docker_cmd="${1}"
+
+    if [ -n "${docker_cmd}" ]; then
+        echo "${docker_cmd}"
+        return
+    fi
+
+    if has_docker; then
+        echo "docker"
+    else
+        echo "podman"
+    fi
+}
+
+perform_regular_build() {
+    local docker_cmd script_dir version
+    docker_cmd="${1}"
+    script_dir="${2}"
+    version="${3}"
+
+    log_info "building for native platform only."
+
+    for t in client exporter coordinator; do
+        "${docker_cmd}" build --build-arg VERSION="${version}" \
+            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" .
+    done
+}
+
+perform_docker_buildx_build() {
+    local docker_cmd script_dir version
+    docker_cmd="${1}"
+    script_dir="${2}"
+    version="${3}"
+
+    for t in client exporter coordinator; do
+        "${docker_cmd}" buildx build --platform "${platform}" --build-arg VERSION="${version}" \
+            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" .
+    done
+}
+
+main() {
+    local platform script_dir version
+    platform="${1}"
+
+    if ! has_docker && ! has_podman; then
+        die "Neither docker nor podman could be found."
+    fi
+
+    script_dir="$(dirname "$(realpath "${BASH_SOURCE:-$0}")")"
+    version="$(python -m setuptools_scm)"
+    docker_cmd="$(get_docker_cmd "${DOCKER}")"
+
+    cd "${script_dir}/.." || die "Could not cd into repo root dir"
+
+    if has_buildx "${docker_cmd}" && [ -n "${platform}" ]; then
+        perform_docker_buildx_build "${docker_cmd}" "${script_dir}" "${version}" "${platform}"
+    else
+        perform_regular_build "${docker_cmd}" "${script_dir}" "${version}"
+    fi
+}
+
+main "${1}"


### PR DESCRIPTION
**Description**

This allows for building docker images for different platforms such as linux/arm64 .

I am using this feature because in my case the labgrid coordinator will be executed on a Raspberry Pi 4 in a `docker compose` environment.

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested manually