### PR TITLE
getting_started: add SSH requirement note

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -147,6 +147,12 @@ same machine. The client is used to access functionality provided by an
 exporter. Over the course of this tutorial we will set up a coordinator and
 exporter, and learn how to access the exporter via the client.
 
+.. Attention::
+   Labgrid requires your user to be able to connect from the client machine via
+   ssh to the exporter machine _without_ a password prompt. This means that
+   public key authentication should be configured on all involved machines for
+   your user beforehand.
+
 .. _remote-getting-started-coordinator:
 
 Coordinator


### PR DESCRIPTION
**Description**
The remote infrastructure expects a working SSH setup at least between the machine running the client and the exporter. Add a note to the documentation in the getting started section.
