### PR TITLE
Allow default configure when export same type of resources.

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3189,6 +3189,23 @@ and another :any:`USBSerialPort` as
        match:
          '@ID_PATH': pci-0000:05:00.0-usb-3-1.4
 
+Additional, you can set ``default`` parameter to specify the default resource
+which ``labgrid-client`` will use once it matches multiple resources. Otherwise,
+you need to specify resource name explicitly in client command:
+
+.. code-block:: yaml
+
+   usb-hub-in-rack12:
+     console-main:
+       cls: USBSerialPort
+       match:
+         '@ID_PATH': pci-0000:05:00.0-usb-3-1.3
+       default: true
+     console-secondary:
+       cls: USBSerialPort
+       match:
+         '@ID_PATH': pci-0000:05:00.0-usb-3-1.4
+
 Note that you could also split the resources up into distinct groups instead
 to achieve the same effect:
 

--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -45,6 +45,10 @@ class ResourceEntry:
         return self.data['cls']
 
     @property
+    def default(self):
+        return self.data['default']
+
+    @property
     def params(self):
         return self.data['params']
 
@@ -63,6 +67,7 @@ class ResourceEntry:
     def asdict(self):
         return {
             'cls': self.cls,
+            'default': self.default,
             'params': self.params,
             'acquired': self.acquired,
             'avail': self.avail,

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -760,10 +760,11 @@ class ExporterSession(ApplicationSession):
                     if params is None:
                         continue
                     cls = params.pop('cls', resource_name)
+                    default = params.pop('default', False)
 
                     # this may call back to acquire the resource immediately
                     await self.add_resource(
-                        group_name, resource_name, cls, params
+                        group_name, resource_name, cls, default, params
                     )
                     self.checkpoint = time.monotonic()
 
@@ -840,7 +841,7 @@ class ExporterSession(ApplicationSession):
                 print(f"missed checkpoint, exiting (last was {age} seconds ago)")
                 self.disconnect()
 
-    async def add_resource(self, group_name, resource_name, cls, params):
+    async def add_resource(self, group_name, resource_name, cls, default, params):
         """Add a resource to the exporter and update status on the coordinator"""
         print(
             f"add resource {group_name}/{resource_name}: {cls}/{params}"
@@ -851,6 +852,7 @@ class ExporterSession(ApplicationSession):
         config = {
             'avail': export_cls is ResourceEntry,
             'cls': cls,
+            'default': default,
             'params': params,
         }
         proxy_req = self.isolated

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -137,9 +137,13 @@ class Target:
                 f"no {cls} resource{name_msg} found in {self}"
             )
         elif len(found) > 1:
-            raise NoResourceFoundError(
-                f"multiple resources matching {cls} found in {self}", found=found
-            )
+            found_default = list(filter(lambda _:_._remote_entry.data['default'], found))
+            if len(found_default) != 1:
+                raise NoResourceFoundError(
+                    f"multiple resources matching {cls} found in {self}", found=found
+                )
+            found = found_default
+            print(f"Default resource '{found[0].name}' used")
         if wait_avail:
             self.await_resources(found)
         return found[0]


### PR DESCRIPTION
**Description**

If `labgrid-client` find multiple matched resources, currently labgrid will require user to specify the exact resource name as next:

> labgrid-client: error: multiple resources matching <class 'labgrid.resource.serialport.NetworkSerialPort'> found in Target(name='imx8mm-evk-sh99', env=None)
This may be caused by disconnected exporter or wrong match entries.

However, in our scenarios: `A core serial port` is the most frequently used resource, while `M core, Sec core & other serial port` seldom be used. So we wish `labgrid-client -p imx8mm-evk-sh99 console` can by default open the `A core serial port`. 

This PR allows admin to configure a default resource with something like next:

```
a:
  cls: NetworkSerialPort
  host: 10.192.244.104
  port: 7006
  default: true
m:
  cls: NetworkSerialPort
  host: 10.192.244.104
  port: 7005
```

Afterwards, we possible to have the `default` parameter when export that:

```
Acquired resource 'a' (shubuntu1/imx8mm-evk-sh99/NetworkSerialPort/a):
  {'acquired': 'imx8mm-evk-sh99',
   'avail': True,
   'cls': 'NetworkSerialPort',
   'default': True,
   'params': {'host': '10.192.244.104', 'port': 7006}}
Acquired resource 'm' (shubuntu1/imx8mm-evk-sh99/NetworkSerialPort/m):
  {'acquired': 'imx8mm-evk-sh99',
   'avail': True,
   'cls': 'NetworkSerialPort',
   'default': False,
   'params': {'host': '10.192.244.104', 'port': 7005}}
```

Then, the `labgrid-client` can choose the `default=True` resource even there are multiple matched resources.

**Checklist**
- [√] Documentation for the feature
- [√] PR has been tested

