### PR TITLE
ssh: Use processwrapper for rsync

### DIFF
--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -37,7 +37,7 @@ class ProcessWrapper:
     loglevel = logging.INFO
 
     @step(args=['command'], result=True, tag='process')
-    def check_output(self, command, *, print_on_silent_log=False, input=None): # pylint: disable=redefined-builtin
+    def check_output(self, command, *, print_on_silent_log=False, input=None, stdin=None): # pylint: disable=redefined-builtin
         """Run a command and supply the output to callback functions"""
         logger = logging.getLogger("Process")
         res = []
@@ -52,6 +52,8 @@ class ProcessWrapper:
             stdin_r, stdin_w = os.pipe()
             kwargs['stdin'] = stdin_r
             set_nonblocking(stdin_w)
+        elif stdin is not None:
+            kwargs['stdin'] = stdin
 
         process = subprocess.Popen(command, stderr=sfd,
                                    stdout=sfd, bufsize=0, **kwargs)

--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -11,7 +11,7 @@ from typing import Dict
 import attr
 from ..driver.exception import ExecutionError
 
-from .helper import get_free_port
+from .helper import get_free_port, processwrapper
 
 __all__ = ['sshmanager', 'SSHConnection', 'ForwardError']
 
@@ -329,9 +329,10 @@ class SSHConnection:
             f"{self.host}:{remote_path}"
         ]
         self._logger.debug("Running command: %s", complete_cmd)
-        subprocess.check_call(
+        processwrapper.check_output(
             complete_cmd,
             stdin=subprocess.DEVNULL,
+            print_on_silent_log=True
         )
 
     @_check_connected


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Switches to using the processwrapper to run the rsync command in put_file. This logs the output to the Python logging instead of stdout, which means it can be better filtered as to where it goes. In particular, it prevents writing output to stdout (unless desired) when capsys is disabled.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
