### PR TITLE
Add missing get method to sdwire driver

### DIFF
--- a/labgrid/driver/usbsdwiredriver.py
+++ b/labgrid/driver/usbsdwiredriver.py
@@ -37,3 +37,15 @@ class USBSDWireDriver(Driver):
             self.mux.control_serial,
         ]
         processwrapper.check_output(cmd)
+
+    @Driver.check_active
+    @step(title='sdmux_get')
+    def get_mode(self):
+        cmd = self.mux.command_prefix + [
+            self.tool,
+            "-e",
+            self.mux.control_serial,
+            "-u",
+        ]
+        result = processwrapper.check_output(cmd)
+        return result.split(b": ", maxsplit=1)[1].strip().decode()


### PR DESCRIPTION
**Description**

The labgrid-client tried to call the get method when using the sd-mux command with and sdwire device.  This should work since the labgrid-client sd-mux command has code to explictly support sdwire devices.

```
(labgrid-venv) Rocinante:labgrid-sandbox jpuderer$ labgrid-client -x ws://labgrid-devhost:20408/ws -c test.yaml sd-mux get 
Selected role main and place test from configuration file
Traceback (most recent call last):
  File "/Users/jpuderer/labgrid/labgrid/remote/client.py", line 1787, in main
    args.func(session)
  File "/Users/jpuderer/labgrid/labgrid/remote/client.py", line 950, in sd_mux
    print(drv.get_mode())
          ^^^^^^^^^^^^
AttributeError: 'USBSDWireDriver' object has no attribute 'get_mode'
```

**Checklist**
- [x] PR has been tested
