### PR TITLE
remote/client: allow specifying resources by name for various sub commands

### DIFF
--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -291,11 +291,15 @@ _labgrid_client_power()
     -t|--delay)
         return
         ;;
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
     esac
 
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "--delay $_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--delay --name $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args
@@ -326,9 +330,14 @@ _labgrid_client_io()
         local args
         _labgrid_count_args || return
         # only complete second argument
-        [ "$args" -ne 2 ] && return
-
-        COMPREPLY=( $(compgen -W "high low get" -- "$cur") )
+        case "$args" in
+        2)
+            COMPREPLY=( $(compgen -W "high low get" -- "$cur") )
+            ;;
+        3)
+            _labgrid_complete match-names "$cur"
+            ;;
+        esac
         ;;
     esac
 }
@@ -376,15 +385,19 @@ _labgrid_client_dfu()
     download|detach|list)
         _filedir
         ;;
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
     esac
 
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "--wait $_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--wait --name $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args
-        _labgrid_count_args "@(--wait)" || return
+        _labgrid_count_args "@(--wait|-n|--name)" || return
         # only complete second argument
         [ "$args" -ne 2 ] && return
 
@@ -395,7 +408,27 @@ _labgrid_client_dfu()
 
 _labgrid_client_fastboot()
 {
-    _labgrid_client_generic_subcommand "--wait"
+    local cur prev words cword
+    _init_completion || return
+
+    case "$prev" in
+    --wait)
+        return
+        ;;
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
+    case "$cur" in
+    -*)
+        COMPREPLY=( $(compgen -W "--wait --name $_labgrid_shared_options" -- "$cur") )
+        ;;
+    *)
+        _filedir
+        ;;
+    esac
 }
 
 _labgrid_client_flashscript()
@@ -403,13 +436,20 @@ _labgrid_client_flashscript()
     local cur prev words cword
     _init_completion || return
 
+    case "$prev" in
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "$_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--name $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args
-        _labgrid_count_args || return
+        _labgrid_count_args "@(-n|--name)" || return
         # only complete second argument
         [ "$args" -ne 2 ] && return
 
@@ -427,15 +467,19 @@ _labgrid_client_bootstrap()
     -w|--wait)
         return
         ;;
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
     esac
 
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "--wait $_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--wait --name $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args
-        _labgrid_count_args "@(-w|--wait)" || return
+        _labgrid_count_args "@(-w|--wait|-n|--name)" || return
         # only complete second argument
         [ "$args" -ne 2 ] && return
 
@@ -449,13 +493,20 @@ _labgrid_client_sd_mux()
     local cur prev words cword
     _init_completion || return
 
+    case "$prev" in
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "$_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--name $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args
-        _labgrid_count_args || return
+        _labgrid_count_args "@(-n|--name)" || return
         # only complete second argument
         [ "$args" -ne 2 ] && return
 
@@ -469,13 +520,20 @@ _labgrid_client_usb_mux()
     local cur prev words cword
     _init_completion || return
 
+    case "$prev" in
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "$_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--name $_labgrid_shared_options" -- "$cur") )
         ;;
     *)
         local args actions
-        _labgrid_count_args || return
+        _labgrid_count_args "@(-n|--name)" || return
         # only complete second argument
         [ "$args" -ne 2 ] && return
 
@@ -590,7 +648,40 @@ _labgrid_client_forward()
 
 _labgrid_client_video()
 {
-    _labgrid_client_generic_subcommand "--quality --controls"
+    local cur prev words cword
+    _init_completion || return
+
+    case "$prev" in
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
+    case "$cur" in
+    -*)
+        COMPREPLY=( $(compgen -W "--quality --controls --name $_labgrid_shared_options" -- "$cur") )
+        ;;
+    esac
+}
+
+_labgrid_client_audio()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    case "$prev" in
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
+    case "$cur" in
+    -*)
+        COMPREPLY=( $(compgen -W "--name $_labgrid_shared_options" -- "$cur") )
+        ;;
+    esac
 }
 
 _labgrid_client_tmc()
@@ -598,14 +689,21 @@ _labgrid_client_tmc()
     local args cur prev words cword
     _init_completion || return
 
+    case "$prev" in
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "$_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--name $_labgrid_shared_options" -- "$cur") )
         return
         ;;
     *)
         local args
-        _labgrid_count_args || return
+        _labgrid_count_args "@(-n|--name)" || return
         # only complete second argument
         if [ "$args" -eq 2 ]; then
             COMPREPLY=( $(compgen -W "cmd query screen channel" -- "$cur") )
@@ -649,16 +747,20 @@ _labgrid_client_write_image()
         COMPREPLY=( $( compgen -W "dd bmaptool" -- "$cur") )
         return
         ;;
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
     esac
 
     case "$cur" in
     -*)
-        local options="--wait --partition --skip --seek --mode $_labgrid_shared_options"
+        local options="--wait --partition --skip --seek --mode --name $_labgrid_shared_options"
         COMPREPLY=( $(compgen -W "$options" -- "$cur") )
         ;;
     *)
         local args
-        _labgrid_count_args "@(-w|--wait|-p|--partition|--skip|--seek|--mode)" || return
+        _labgrid_count_args "@(-w|--wait|-p|--partition|--skip|--seek|--mode|-n|--name)" || return
         # only complete second argument
         [ "$args" -ne 2 ] && return
 

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -893,8 +893,9 @@ class ClientSession(ApplicationSession):
     def flashscript(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
+        name = self.args.name
 
-        drv = self._get_driver_or_new(target, "FlashScriptDriver")
+        drv = self._get_driver_or_new(target, "FlashScriptDriver", name=name)
         drv.flash(script=self.args.script, args=self.args.script_args)
 
     def bootstrap(self):
@@ -1582,6 +1583,7 @@ def main():
     subparser.add_argument('script', help="Flashing script")
     subparser.add_argument('script_args', metavar='ARG', nargs=argparse.REMAINDER,
                            help='script arguments')
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.flashscript)
 
     subparser = subparsers.add_parser('bootstrap',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1120,8 +1120,9 @@ class ClientSession(ApplicationSession):
     def _get_tmc(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
+        name = self.args.name
 
-        return self._get_driver_or_new(target, "USBTMCDriver")
+        return self._get_driver_or_new(target, "USBTMCDriver", name=name)
 
     def tmc_command(self):
         drv = self._get_tmc()
@@ -1671,6 +1672,7 @@ def main():
     subparser.set_defaults(func=ClientSession.audio)
 
     tmc_parser = subparsers.add_parser('tmc', help="control a USB TMC device")
+    tmc_parser.add_argument('--name', '-n', help="optional resource name")
     tmc_parser.set_defaults(func=lambda _: tmc_parser.print_help())
     tmc_subparsers = tmc_parser.add_subparsers(
         dest='subcommand',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -850,9 +850,10 @@ class ClientSession(ApplicationSession):
     def dfu(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
+        name = self.args.name
         if self.args.action == 'download' and not self.args.filename:
             raise UserError('not enough arguments for dfu download')
-        drv = self._get_driver_or_new(target, "DFUDriver", activate=False)
+        drv = self._get_driver_or_new(target, "DFUDriver", activate=False, name=name)
         drv.dfu.timeout = self.args.wait
         target.activate(drv)
 
@@ -1564,6 +1565,7 @@ def main():
                            nargs='?')
     subparser.add_argument('filename', help='file to write into device (download only)', nargs='?')
     subparser.add_argument('--wait', type=float, default=10.0)
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.dfu)
 
     subparser = subparsers.add_parser('fastboot',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -712,6 +712,7 @@ class ClientSession(ApplicationSession):
         place = self.get_acquired_place()
         action = self.args.action
         delay = self.args.delay
+        name = self.args.name
         target = self._get_target(place)
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort
@@ -719,19 +720,19 @@ class ClientSession(ApplicationSession):
 
         drv = None
         try:
-            drv = target.get_driver("PowerProtocol")
+            drv = target.get_driver("PowerProtocol", name=name)
         except NoDriverFoundError:
             for resource in target.resources:
                 if isinstance(resource, NetworkPowerPort):
-                    drv = self._get_driver_or_new(target, "NetworkPowerDriver")
+                    drv = self._get_driver_or_new(target, "NetworkPowerDriver", name=name)
                 elif isinstance(resource, NetworkUSBPowerPort):
-                    drv = self._get_driver_or_new(target, "USBPowerDriver")
+                    drv = self._get_driver_or_new(target, "USBPowerDriver", name=name)
                 elif isinstance(resource, NetworkSiSPMPowerPort):
-                    drv = self._get_driver_or_new(target, "SiSPMPowerDriver")
+                    drv = self._get_driver_or_new(target, "SiSPMPowerDriver", name=name)
                 elif isinstance(resource, PDUDaemonPort):
-                    drv = self._get_driver_or_new(target, "PDUDaemonDriver")
+                    drv = self._get_driver_or_new(target, "PDUDaemonDriver", name=name)
                 elif isinstance(resource, TasmotaPowerPort):
-                    drv = self._get_driver_or_new(target, "TasmotaPowerDriver")
+                    drv = self._get_driver_or_new(target, "TasmotaPowerDriver", name=name)
                 if drv:
                     break
 
@@ -741,7 +742,7 @@ class ClientSession(ApplicationSession):
             drv.delay = delay
         res = getattr(drv, action)()
         if action == 'get':
-            print(f"power for place {place.name} is {'on' if res else 'off'}")
+            print(f"power{' ' + name if name else ''} for place {place.name} is {'on' if res else 'off'}")
 
     def digital_io(self):
         place = self.get_acquired_place()
@@ -1536,6 +1537,7 @@ def main():
     subparser.add_argument('action', choices=['on', 'off', 'cycle', 'get'])
     subparser.add_argument('-t', '--delay', type=float, default=None,
                            help='wait time in seconds between off and on during cycle')
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.power)
 
     subparser = subparsers.add_parser('io',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -754,7 +754,7 @@ class ClientSession(ApplicationSession):
 
         drv = None
         try:
-            drv = target.get_driver("DigitalOutputProtocol")
+            drv = target.get_driver("DigitalOutputProtocol", name=name)
         except NoDriverFoundError:
             for resource in target.resources:
                 if isinstance(resource, ModbusTCPCoil):

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -964,6 +964,7 @@ class ClientSession(ApplicationSession):
 
     def usb_mux(self):
         place = self.get_acquired_place()
+        name = self.args.name
         links = self.args.links
         if links == 'off':
             links = []
@@ -977,7 +978,7 @@ class ClientSession(ApplicationSession):
         drv = None
         for resource in target.resources:
             if isinstance(resource, NetworkLXAUSBMux):
-                drv = self._get_driver_or_new(target, "LXAUSBMuxDriver")
+                drv = self._get_driver_or_new(target, "LXAUSBMuxDriver", name=name)
                 break
 
         if not drv:
@@ -1608,6 +1609,7 @@ def main():
     subparser = subparsers.add_parser('usb-mux',
                                       help="switch USB Muxer")
     subparser.add_argument('links', choices=['off', 'dut-device', 'host-dut', 'host-device', 'host-dut+host-device'])
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.usb_mux)
 
     subparser = subparsers.add_parser('ssh',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -775,7 +775,7 @@ class ClientSession(ApplicationSession):
         if not drv:
             raise UserError("target has no compatible resource available")
         if action == 'get':
-            print(f"digital IO {name} for place {place.name} is {'high' if drv.get() else 'low'}")
+            print(f"digital IO{' ' + name if name else ''} for place {place.name} is {'high' if drv.get() else 'low'}")
         elif action == 'high':
             drv.set(True)
         elif action == 'low':

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1169,7 +1169,8 @@ class ClientSession(ApplicationSession):
     def write_image(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
-        drv = self._get_driver_or_new(target, "USBStorageDriver", activate=False)
+        name = self.args.name
+        drv = self._get_driver_or_new(target, "USBStorageDriver", activate=False, name=name)
         drv.storage.timeout = self.args.wait
         target.activate(drv)
 
@@ -1711,6 +1712,7 @@ def main():
     subparser.add_argument('--mode', dest='write_mode',
                            type=Mode, choices=Mode, default=Mode.DD,
                            help="Choose tool for writing images (default: %(default)s)")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.add_argument('filename', help='filename to boot on the target')
     subparser.set_defaults(func=ClientSession.write_image)
 

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1113,7 +1113,8 @@ class ClientSession(ApplicationSession):
     def audio(self):
         place = self.get_acquired_place()
         target = self._get_target(place)
-        drv = self._get_driver_or_new(target, "USBAudioInputDriver")
+        name = self.args.name
+        drv = self._get_driver_or_new(target, "USBAudioInputDriver", name=name)
         drv.play()
 
     def _get_tmc(self):
@@ -1666,6 +1667,7 @@ def main():
     subparser.set_defaults(func=ClientSession.video)
 
     subparser = subparsers.add_parser('audio', help="start a audio stream")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.audio)
 
     tmc_parser = subparsers.add_parser('tmc', help="control a USB TMC device")

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -868,8 +868,9 @@ class ClientSession(ApplicationSession):
         place = self.get_acquired_place()
         args = self.args.fastboot_args
         target = self._get_target(place)
+        name = self.args.name
 
-        drv = self._get_driver_or_new(target, "AndroidFastbootDriver", activate=False)
+        drv = self._get_driver_or_new(target, "AndroidFastbootDriver", activate=False, name=name)
         drv.fastboot.timeout = self.args.wait
         target.activate(drv)
 
@@ -1573,6 +1574,7 @@ def main():
     subparser.add_argument('fastboot_args', metavar='ARG', nargs=argparse.REMAINDER,
                            help='fastboot arguments')
     subparser.add_argument('--wait', type=float, default=10.0)
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.fastboot)
 
     subparser = subparsers.add_parser('flashscript',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -940,14 +940,15 @@ class ClientSession(ApplicationSession):
         place = self.get_acquired_place()
         action = self.args.action
         target = self._get_target(place)
+        name = self.args.name
         from ..resource.remote import NetworkUSBSDMuxDevice, NetworkUSBSDWireDevice
 
         drv = None
         for resource in target.resources:
             if isinstance(resource, NetworkUSBSDMuxDevice):
-                drv = self._get_driver_or_new(target, "USBSDMuxDriver")
+                drv = self._get_driver_or_new(target, "USBSDMuxDriver", name=name)
             elif isinstance(resource, NetworkUSBSDWireDevice):
-                drv = self._get_driver_or_new(target, "USBSDWireDriver")
+                drv = self._get_driver_or_new(target, "USBSDWireDriver", name=name)
             if drv:
                 break
 
@@ -1601,6 +1602,7 @@ def main():
     subparser = subparsers.add_parser('sd-mux',
                                       help="switch USB SD Muxer or get current mode")
     subparser.add_argument('action', choices=['dut', 'host', 'off', 'client', 'get'])
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.sd_mux)
 
     subparser = subparsers.add_parser('usb-mux',

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1084,18 +1084,19 @@ class ClientSession(ApplicationSession):
         quality = self.args.quality
         controls = self.args.controls
         target = self._get_target(place)
+        name = self.args.name
         from ..resource.httpvideostream import HTTPVideoStream
         from ..resource.udev import USBVideo
         from ..resource.remote import NetworkUSBVideo
         drv = None
         try:
-            drv = target.get_driver("VideoProtocol")
+            drv = target.get_driver("VideoProtocol", name=name)
         except NoDriverFoundError:
             for resource in target.resources:
                 if isinstance(resource, (USBVideo, NetworkUSBVideo)):
-                    drv = self._get_driver_or_new(target, "USBVideoDriver")
+                    drv = self._get_driver_or_new(target, "USBVideoDriver", name=name)
                 elif isinstance(resource, HTTPVideoStream):
-                    drv = self._get_driver_or_new(target, "HTTPVideoDriver")
+                    drv = self._get_driver_or_new(target, "HTTPVideoDriver", name=name)
                 if drv:
                     break
         if not drv:
@@ -1661,6 +1662,7 @@ def main():
                            help="select a video quality (use 'list' to show options)")
     subparser.add_argument('-c', '--controls', type=str,
                            help="configure v4l controls (such as 'focus_auto=0,focus_absolute=40')")
+    subparser.add_argument('--name', '-n', help="optional resource name")
     subparser.set_defaults(func=ClientSession.video)
 
     subparser = subparsers.add_parser('audio', help="start a audio stream")


### PR DESCRIPTION
**Description**
There might be multiple instances of a resource type in a single place (either specified via resources with names in the configuration or via named matches: `labgrid-client add-named-match`).

This allows addressing them via `-n`/`--name`. If a configuration is given, the drivers specified there will be used if they have the same name as the resource. Otherwise new driver instances will be created.

These sub commands gained the new argument:
- `power`
- `dfu`
- `flashscript`
- `bootstrap`
- `sd-mux`
- `usb-mux`
- `forward`
- `tmc`
- `write-image`

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [.] PR has been tested (tested power sub command only)

Closes #1026
Closes #1117
Fixes #1023
Fixes #364