### PR TITLE
target: make get_resource() prioritize resources named "default" on ambiguous results

### DIFF
--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -116,16 +116,25 @@ class Target:
         """
         found = []
         other_names = []
+        default = None
         if isinstance(cls, str):
             cls = target_factory.class_from_string(cls)
 
         for res in self.resources:
             if not isinstance(res, cls):
                 continue
+            if not name and res.name == "default":
+                default = res
             if name and res.name != name:
                 other_names.append(res.name)
                 continue
             found.append(res)
+
+        # if a resouce named "default" was found and either none or too many resource's names
+        # matched, use the default resource
+        if default and len(found) != 1:
+            found = [default]
+
         if not found:
             name_msg = f" named '{name}'" if name else ""
             if other_names:

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -227,6 +227,10 @@ be used to address the individual resources. In addition to the \fImatch\fP take
 client commands support the name as an optional parameter and will inform the
 user that a name is required if multiple resources are found, but no name is
 given.
+.sp
+If a target contains multiple resources and one of them should be used, even
+when not explicitly specified, it can be named \fBdefault\fP\&. If either none or
+too many resources pass the resource name check, the default resource is used.
 .SH EXAMPLES
 .sp
 To retrieve a list of places run:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -221,6 +221,10 @@ client commands support the name as an optional parameter and will inform the
 user that a name is required if multiple resources are found, but no name is
 given.
 
+If a target contains multiple resources and one of them should be used, even
+when not explicitly specified, it can be named ``default``. If either none or
+too many resources pass the resource name check, the default resource is used.
+
 EXAMPLES
 --------
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -27,6 +27,11 @@ def test_get_resource(target):
     assert target.get_resource(A) is a
     assert target.get_resource(A, name="aresource") is a
 
+    # make sure resources named "default" are prioritized
+    b = A(target, "default")
+    assert target.get_resource(A) is b
+    assert target.get_resource(A, name="aresource") is a
+
 
 def test_get_driver(target):
     class A(Driver):


### PR DESCRIPTION
**Description**
If a resource named "default" is found and either none or too many resources passed the name check, return the resource named "default".

This is a slightly simpler approach than #1026 (the other part is covered by #1111) and #1098.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested
- [x] Man pages have been regenerated

Closes #1098
Closes #582