### PR TITLE
driver/powerdriver: Properly reconstruct proxied URL

### DIFF
--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -203,7 +203,9 @@ class NetworkPowerDriver(Driver, PowerResetMixin, PowerProtocol):
         )
 
         # construct proxied host parameter
-        self._host = f'{url.scheme}://{self._host}:{self._port}{url.path}'
+        query = f'?{url.query}' if url.query else ''
+        user_pass = f'{url.netloc.split("@")[0]}@' if '@' in url.netloc else ''
+        self._host = f'{url.scheme}://{user_pass}{self._host}:{self._port}{url.path}{query}'
         self._port = None
 
         return True

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -181,6 +181,8 @@ class TestNetworkPowerDriver:
             'https://example.com/{index}',
             'http://example.com:1234/{index}',
             'https://example.com:1234/{index}',
+            'http://user:pass@example.com:1234/{index}',
+            'https://user:pass@example.com:1234/{index}',
         )
     )
     def test_create_backend_with_url_in_host(self, target, mocker, backend, host):
@@ -201,7 +203,7 @@ class TestNetworkPowerDriver:
         # index and explicit port
         expected_host = host.format(index=index)
         url = urlparse(expected_host)
-        if ':' not in url.netloc:
+        if url.port is None:
             implicit_port = 443 if url.scheme == 'https' else 80
             expected_host = expected_host.replace(url.netloc, f'{url.netloc}:{implicit_port}')
 


### PR DESCRIPTION
Some PDUs URL include username/password and query attributes, and they need to be included in the proxied URL as well.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Include URL based username, password and query attributes on proxied URL (those used when `labgrid-exporter` is started with `-i` option, making all connections go via SHH tunnerl).

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
