### PR TITLE
driver/resource: Support dediprog

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1025,6 +1025,35 @@ resource available on a remote computer
 Used by:
   - `FlashScriptDriver`_
 
+DediprogFlasher
+~~~~~~~~~~~~~~~
+A DediprogFlasher resource is used to configure the parameters to a locally installed
+dpmcd instance. It is assumed that dpcmd is installed on the host and the
+executable can be configured via:
+
+.. code-block:: yaml
+
+  tools:
+    dpcmd: '/usr/sbin/dpcmd'
+
+Arguments:
+  - vcc (str): '3.5V', '2.5V' or '1.8V'.
+
+For instance, to flash using 3.5V vcc:
+
+.. code-block:: yaml
+
+  DediprogFlasher:
+    vcc: '3.5V'
+
+
+Used by:
+  - `DediprogFlashDriver`_
+
+NetworkDediprogFlasher
+~~~~~~~~~~~~~~~~~~~~~~
+A NetworkDediprogFlasher describes a `DediprogFlasher`_ available on a remote computer.
+
 XenaManager
 ~~~~~~~~~~~
 A XenaManager resource describes a Xena Manager instance which is the instance the
@@ -2623,6 +2652,30 @@ Key        Description
 Properties of these keys can be selected using the Python format string syntax,
 e.g. ``{device.devnode}`` to select the device node path of
 :any:`USBFlashableDevice`
+
+DediprogFlashDriver
+~~~~~~~~~~~~~~~~~~~
+The :any:`DediprogFlashDriver` is used to flash an SPI device using DediprogFlasher dpcmd.
+
+.. code-block:: yaml
+
+   DediprogFlashDriver:
+     image: 'foo'
+   images:
+     foo: ../images/image_to_load.raw
+
+Binds to:
+  DediprogFlasher_resource:
+    - `DediprogFlasher`_
+    - `NetworkDediprogFlasher`_
+
+Arguments:
+  - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
+    of an image to flash onto the target
+
+The DediprogFlashDriver allows using DediprogFlasher dpcmd to flash or erase SPI
+devices. It is assumed that the device flashing is an exporter wired, via
+DediprogFlasher SF100 for instance, to the device being flashed.
 
 XenaDriver
 ~~~~~~~~~~

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -44,3 +44,4 @@ from .mqtt import TasmotaPowerDriver
 from .manualswitchdriver import ManualSwitchDriver
 from .usbtmcdriver import USBTMCDriver
 from .deditecrelaisdriver import DeditecRelaisDriver
+from .dediprogflashdriver import DediprogFlashDriver

--- a/labgrid/driver/dediprogflashdriver.py
+++ b/labgrid/driver/dediprogflashdriver.py
@@ -1,0 +1,70 @@
+import os.path
+import logging
+import attr
+
+from ..resource import NetworkDediprogFlasher
+from ..factory import target_factory
+from ..step import step
+from .common import Driver, check_file
+from ..util.managedfile import ManagedFile
+from ..util.helper import processwrapper
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class DediprogFlashDriver(Driver):
+    """ The DediprogFlashDriver uses the dediprog utility to write an image
+    to a raw rom. The driver is a pure wrapper of the dpcmd utility"""
+    bindings = {
+        'flasher': {"DediprogFlasher", NetworkDediprogFlasher},
+    }
+
+    image = attr.ib(validator=attr.validators.optional(attr.validators.instance_of(str)),
+                    default=None)
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.logger = logging.getLogger(f'{self}')
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('dpcmd')
+        else:
+            self.tool = 'dpcmd'
+
+    def _get_dediprog_prefix(self):
+        return self.flasher.command_prefix + [self.tool]
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    def map_vcc(self):
+        vcc_map = {'3.5V': '0', '2.5V': '1', '1.8V': '2'}
+        return vcc_map[self.flasher.vcc]
+
+    @Driver.check_active
+    @step(title='call', args=['args'])
+    def __call__(self, *args):
+        vcc = self.map_vcc()
+        arg_list = list(args)
+        arg_list.append('--vcc')
+        arg_list.append(vcc)
+        arg_list.append('--silent')
+        processwrapper.check_output(self._get_dediprog_prefix() + arg_list)
+
+    @Driver.check_active
+    @step(args=['filename'])
+    def flash(self, filename=None):
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        filename = os.path.abspath(filename)
+        check_file(filename)
+        mf = ManagedFile(filename, self.flasher)
+        mf.sync_to_resource()
+
+        self('--auto', mf.get_remote_path(), '--verify', '-x', 'ff')
+
+    @Driver.check_active
+    def erase(self):
+        self('--erase')

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -22,3 +22,4 @@ from .pyvisa import PyVISADevice
 from .provider import TFTPProvider
 from .mqtt import TasmotaPowerPort
 from .httpvideostream import HTTPVideoStream
+from .dediprogflasher import DediprogFlasher, NetworkDediprogFlasher

--- a/labgrid/resource/dediprogflasher.py
+++ b/labgrid/resource/dediprogflasher.py
@@ -1,0 +1,15 @@
+import attr
+
+from ..factory import target_factory
+from .common import NetworkResource, Resource
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class DediprogFlasher(Resource):
+    vcc = attr.ib(validator=attr.validators.in_(('3.5V', '2.5V', '1.8V')))
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkDediprogFlasher(NetworkResource):
+    vcc = attr.ib(validator=attr.validators.in_(('3.5V', '2.5V', '1.8V')))

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -98,6 +98,10 @@ The \fBtools:\fP top key provides paths to binaries such as fastboot.
 Path to the dfu\-util binary, used by the DFUDriver.
 See: \fI\%https://dfu\-util.sourceforge.net/\fP
 .TP
+.B \fBdpcmd\fP
+Path to the dpcmd binary, used by the DediprogFlashDriver.
+See: \fI\%https://github.com/DediProgSW/SF100Linux\fP
+.TP
 .B \fBfastboot\fP
 Path to the fastboot binary, used by the AndroidFastbootDriver.
 See: \fI\%https://developer.android.com/studio/releases/platform\-tools\fP

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -95,6 +95,10 @@ TOOLS KEYS
     Path to the dfu-util binary, used by the DFUDriver.
     See: https://dfu-util.sourceforge.net/
 
+``dpcmd``
+    Path to the dpcmd binary, used by the DediprogFlashDriver.
+    See: https://github.com/DediProgSW/SF100Linux
+
 ``fastboot``
     Path to the fastboot binary, used by the AndroidFastbootDriver.
     See: https://developer.android.com/studio/releases/platform-tools

--- a/tests/test_dediprogflasher.py
+++ b/tests/test_dediprogflasher.py
@@ -1,0 +1,31 @@
+import pytest
+
+from labgrid.resource.dediprogflasher import DediprogFlasher, NetworkDediprogFlasher
+from labgrid.driver.dediprogflashdriver import DediprogFlashDriver
+
+
+def test_dediprog_network_create(target):
+    r = NetworkDediprogFlasher(target, name=None, vcc='3.5V', host='localhost')
+    assert isinstance(r, NetworkDediprogFlasher)
+    d = DediprogFlashDriver(target, name=None)
+    assert isinstance(d, DediprogFlashDriver)
+
+
+def test_dediprog_driver_create(target):
+    r = DediprogFlasher(target, name=None, vcc='2.5V')
+    assert isinstance(r, DediprogFlasher)
+
+    d = DediprogFlashDriver(target, name=None)
+    assert isinstance(d, DediprogFlashDriver)
+
+def test_dediprog_driver_map_vcc(target):
+    r = DediprogFlasher(target, name=None, vcc='2.5V')
+    d = DediprogFlashDriver(target, name=None)
+
+    m = d.map_vcc()
+    assert isinstance(m, str)
+    assert m == '1'
+
+def test_dediprog_driver_map_vcc_inv(target):
+    with pytest.raises(ValueError):
+        r = DediprogFlasher(target, name=None, vcc='2.6V')


### PR DESCRIPTION
Akin to 'flashrom', the Dediprog resource expects 'dpcmd' to be available on the host. Currently, only parameter that can be set is VCC.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
The main advantage to use it instead of `flashrom` is that it allows for using images smaller than the SPI memory, which is then automatically filled with `0xff`. For `flashrom`, one needs the image to have the right size - although one can avoid writing the whole of it by having a layout file - which adds to the inconvenience. Using `dpcmd` is more straightforward and faster.
Tested locally using an SF100.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [X] The arguments and description in doc/configuration.rst have been updated
