### PR TITLE
target/man: rephrase default resource selection

### DIFF
--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -123,16 +123,16 @@ class Target:
         for res in self.resources:
             if not isinstance(res, cls):
                 continue
-            if not name and res.name == "default":
+            if res.name == "default":
                 default = res
             if name and res.name != name:
                 other_names.append(res.name)
                 continue
             found.append(res)
 
-        # if a resouce named "default" was found and either none or too many resource's names
-        # matched, use the default resource
-        if default and len(found) != 1:
+        # if no explicit resource name is requested and a "default" resource was saved and
+        # multiple resources were found, use the default resource
+        if not name and default and len(found) != 1:
             found = [default]
 
         if not found:

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -228,9 +228,8 @@ client commands support the name as an optional parameter and will inform the
 user that a name is required if multiple resources are found, but no name is
 given.
 .sp
-If a target contains multiple resources and one of them should be used, even
-when not explicitly specified, it can be named \fBdefault\fP\&. If either none or
-too many resources pass the resource name check, the default resource is used.
+If one of the resources should be used by default when no resource name is
+explicitly specified, it can be named \fBdefault\fP\&.
 .SH EXAMPLES
 .sp
 To retrieve a list of places run:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -221,9 +221,8 @@ client commands support the name as an optional parameter and will inform the
 user that a name is required if multiple resources are found, but no name is
 given.
 
-If a target contains multiple resources and one of them should be used, even
-when not explicitly specified, it can be named ``default``. If either none or
-too many resources pass the resource name check, the default resource is used.
+If one of the resources should be used by default when no resource name is
+explicitly specified, it can be named ``default``.
 
 EXAMPLES
 --------


### PR DESCRIPTION
**Description**
The previous comment and check regarding the selection of the resource named "default" in `get_resource()` were phrased/constructed in a confusing way. Fix that.

Also rephrase the man page section about resources named "default".

**Checklist**
- [x] PR has been tested
- [x] Man pages have been regenerated

Fixes #1112
