### PR TITLE
Add print version subcommand.

### DIFF
--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -892,6 +892,7 @@ _labgrid_client()
                                cancel-reservation \
                                wait \
                                reservations \
+                               version \
                                export"
             COMPREPLY=( $(compgen -W "$subcommands" -- "$cur") )
             return

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -27,7 +27,7 @@ from .common import (ResourceEntry, ResourceMatch, Place, Reservation, Reservati
 from .. import Environment, Target, target_factory
 from ..exceptions import NoDriverFoundError, NoResourceFoundError, InvalidConfigError
 from ..resource.remote import RemotePlaceManager, RemotePlace
-from ..util import diff_dict, flat_dict, filter_dict, dump, atomic_replace, Timeout
+from ..util import diff_dict, flat_dict, filter_dict, dump, atomic_replace, labgrid_version, Timeout
 from ..util.proxy import proxymanager
 from ..util.helper import processwrapper
 from ..driver import Mode, ExecutionError
@@ -1295,6 +1295,9 @@ class ClientSession(ApplicationSession):
             print("Exiting...\n", file=sys.stderr)
     export.needs_target = True
 
+    def print_version(self):
+        print(labgrid_version())
+
 
 def start_session(url, realm, extra):
     from autobahn.asyncio.wamp import ApplicationRunner
@@ -1786,6 +1789,9 @@ def main():
                            help="output format (default: %(default)s)")
     subparser.add_argument('filename', help='output filename')
     subparser.set_defaults(func=ClientSession.export)
+
+    subparser = subparsers.add_parser('version', help="show version")
+    subparser.set_defaults(func=ClientSession.print_version)
 
     # make any leftover arguments available for some commands
     args, leftover = parser.parse_known_args()

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -19,15 +19,10 @@ from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 
 from .config import ResourceConfig
 from .common import ResourceEntry, enable_tcp_nodelay
-from ..util import get_free_port
-
-try:
-    import pkg_resources
-    __version__ = pkg_resources.get_distribution('labgrid').version
-except pkg_resources.DistributionNotFound:
-    __version__ = "unknown"
+from ..util import get_free_port, labgrid_version
 
 
+__version__ = labgrid_version()
 exports: Dict[str, Type[ResourceEntry]] = {}
 reexec = False
 

--- a/labgrid/util/__init__.py
+++ b/labgrid/util/__init__.py
@@ -6,3 +6,4 @@ from .marker import gen_marker
 from .yaml import load, dump
 from .ssh import sshmanager
 from .helper import get_free_port, get_user, re_vt100
+from .version import labgrid_version

--- a/labgrid/util/version.py
+++ b/labgrid/util/version.py
@@ -3,11 +3,10 @@ This module contains helper functions for working with version.
 """
 
 
-import contextlib
-from importlib.metadata import PackageNotFoundError, version
-
-
 def labgrid_version():
+    import contextlib
+    from importlib.metadata import PackageNotFoundError, version
+
     lg_version = "unknown"
 
     with contextlib.suppress(PackageNotFoundError):

--- a/labgrid/util/version.py
+++ b/labgrid/util/version.py
@@ -1,0 +1,16 @@
+"""
+This module contains helper functions for working with version.
+"""
+
+
+import contextlib
+from importlib.metadata import PackageNotFoundError, version
+
+
+def labgrid_version():
+    lg_version = "unknown"
+
+    with contextlib.suppress(PackageNotFoundError):
+        lg_version = version("labgrid")
+
+    return lg_version

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -230,6 +230,8 @@ not at all.
 \fBreservations\fP                List current reservations
 .sp
 \fBexport\fP filename             Export driver information to file (needs environment with drivers)
+.sp
+\fBversion\fP                     Print the labgrid version
 .SH ADDING NAMED RESOURCES
 .sp
 If a target contains multiple Resources of the same type, named matches need to

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -223,6 +223,8 @@ LABGRID-CLIENT COMMANDS
 
 ``export`` filename             Export driver information to file (needs environment with drivers)
 
+``version``                     Print the labgrid version
+
 ADDING NAMED RESOURCES
 ----------------------
 If a target contains multiple Resources of the same type, named matches need to


### PR DESCRIPTION
This PR allows user to check client version when issue happens, so we possible to know if the issue happens due to old install?

It looks something as next:

```
root@a598f07a4a9e:~# labgrid-client version
0.4.0
```
