### PR TITLE
Add support for removing remote files when no longer needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Release 23.0 (unreleased)
 
 - `ManagedFile` now has the ability to remove the file from the remote exporter
   when longer needed
+- `FlashScriptDriver` now has the ability to remote the flash script from the
+  remote exporter when flashing is complete
 
 New Features in 23.0
 ~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,9 @@
 Release 23.0 (unreleased)
 -------------------------
 
+- `ManagedFile` now has the ability to remove the file from the remote exporter
+  when longer needed
+
 New Features in 23.0
 ~~~~~~~~~~~~~~~~~~~~
 - Exporter config templates now have access to the following new variables:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2583,6 +2583,8 @@ Arguments:
   - script (str): optional, key in :ref:`images <labgrid-device-config-images>`
     containing the script to execute for writing of the flashable device
   - args (list of str): optional, list of arguments for flash script execution
+  - cleanup (bool): optional, remove flash script from remote exporter after
+    flashing.
 
 The FlashScriptDriver allows running arbitrary programs to flash a device.
 Some SoC or devices may require custom, one-off, or proprietary programs to

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2598,6 +2598,17 @@ These arguments will be expanded as `Python format strings
 <https://docs.python.org/3/library/string.html#format-string-syntax>`_ with the
 following keys:
 
+========== =========================================================
+Key        Description
+========== =========================================================
+``device`` The :any:`Resource` bound to the driver
+``file``   The :any:`ManagedFile` used to track the flashable script
+========== =========================================================
+
+Properties of these keys can be selected using the Python format string syntax,
+e.g. ``{device.devnode}`` to select the device node path of
+:any:`USBFlashableDevice`
+
 HTTPVideoDriver
 ~~~~~~~~~~~~~~~
 The :any:`HTTPVideoDriver` is used to show a video stream over HTTP or HTTPS
@@ -2613,18 +2624,6 @@ Implements:
 Although the driver can be used from Python code by calling the `stream()`
 method, it is currently mainly useful for the ``video`` subcommand of
 ``labgrid-client``.
-
-
-========== =========================================================
-Key        Description
-========== =========================================================
-``device`` The :any:`Resource` bound to the driver
-``file``   The :any:`ManagedFile` used to track the flashable script
-========== =========================================================
-
-Properties of these keys can be selected using the Python format string syntax,
-e.g. ``{device.devnode}`` to select the device node path of
-:any:`USBFlashableDevice`
 
 XenaDriver
 ~~~~~~~~~~

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -588,6 +588,16 @@ To use it in conjunction with a `Resource` and a file:
    >>> mf.sync_to_resource()
    >>> path = mf.get_remote_path()
 
+`ManagedFile` also provides a context manager via the `remote_path()` API, so
+the above code could also be written as:
+
+.. doctest:: managed-file
+
+   from labgrid.util.managedfile import ManagedFile
+   mf = ManagedFile(your_file, your_resource)
+   with mf.remote_path() as path:
+       pass
+
 Unless constructed with `ManagedFile(..., detect_nfs=False)`, ManagedFile
 employs the following heuristic to check if a file is stored on a NFS share
 available both locally and remotely via the same path:
@@ -599,6 +609,9 @@ available both locally and remotely via the same path:
 
 If this is the case the actual file transfer in ``sync_to_resource`` is
 skipped.
+
+It is also possible to remove the remote file by calling `cleanup_resource()`,
+or passing ``cleanup=True`` to `remote_path()`.
 
 ProxyManager
 ------------


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Files controlled with `ManagedFile` can sometimes be quite large and consume a large amount of space on the exporter, potentially causing it to run out and fail tests. In these cases, it is preferred to transfer the files every time they are needed instead of keeping them around in the cache.

This adds a new `cleanup` API to `ManagedFile` to allow the remote file to be cleaned up manually when no longer required. The `FlashScriptDriver` has been extended to support this new API as well

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
