### PR TITLE
Drop support for Python 3.7, bump docker base image to bullseye

### DIFF
--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
         branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -50,54 +50,6 @@ EXPOSE 20408
 CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]
 
 #
-# ser2net
-#
-# These have to be built from source to bring in a newer version that has a
-# needed bugfix. This can be removed once the images are switched to
-# debian:bullseye, as it has a new enough version
-#
-FROM debian:bullseye-slim AS ser2net
-
-RUN apt update && \
-    apt install --yes --no-install-recommends \
-        build-essential \
-        cmake \
-        python3-dev \
-        wget \
-        ca-certificates \
-        libsctp-dev \
-        libssl-dev \
-        pkg-config \
-        file \
-        libyaml-dev \
-    && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /src
-
-RUN cd /src && \
-    wget https://downloads.sourceforge.net/project/ser2net/ser2net/gensio-2.2.4.tar.gz && \
-    tar -xvzf gensio-2.2.4.tar.gz && \
-    cd gensio-2.2.4 && \
-    mkdir build && \
-    cd build && \
-    ../configure --prefix=/usr && \
-    make && \
-    make install && \
-    make install DESTDIR=/opt/ser2net
-
-RUN cd /src && \
-    wget https://downloads.sourceforge.net/project/ser2net/ser2net/ser2net-4.3.3.tar.gz && \
-    tar -xvzf ser2net-4.3.3.tar.gz -C /src && \
-    cd /src/ser2net-4.3.3 && \
-    mkdir build && \
-    cd build && \
-    ../configure --prefix=/usr && \
-    make && \
-    make install DESTDIR=/opt/ser2net
-
-#
 # Exporter
 #
 FROM labgrid-base AS labgrid-exporter
@@ -109,14 +61,9 @@ RUN set -e ;\
     cd /opt/labgrid ;\
     SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --no-cache-dir . ;\
     apt update -q=2 ;\
-    apt install -q=2 --yes --no-install-recommends \
-        libyaml-0-2 \
-        libsctp1 \
-    ; \
+    apt install -q=2 --yes --no-install-recommends ser2net ;\
     apt clean ;\
     rm -rf /var/lib/apt/lists/*
-
-COPY --from=ser2net /opt/ser2net /
 
 VOLUME /opt/conf
 

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim AS labgrid-base
+FROM debian:bullseye-slim AS labgrid-base
 
 LABEL maintainer="eha@deif.com"
 
@@ -56,7 +56,7 @@ CMD ["crossbar", "start", "--config", "/opt/labgrid/.crossbar/config.yaml"]
 # needed bugfix. This can be removed once the images are switched to
 # debian:bullseye, as it has a new enough version
 #
-FROM debian:buster-slim AS ser2net
+FROM debian:bullseye-slim AS ser2net
 
 RUN apt update && \
     apt install --yes --no-install-recommends \

--- a/dockerfiles/staging/dut/Dockerfile
+++ b/dockerfiles/staging/dut/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 MAINTAINER "Kasper Revsbech" <mail@krevsbech.dk>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ requires = [
     "setuptools>=47.2.0",
     "wheel",
     "setuptools_scm[toml]",
-    "fastentrypoints; python_version=='3.7'",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -17,12 +16,11 @@ authors = [
 description = "embedded systems control library for development, testing and installation"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 classifiers = [
     "Topic :: Software Development :: Testing",
     "Framework :: Pytest",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
**Description**
Python 3.7 will be [EOL on 2023-06-27](https://devguide.python.org/versions/).

This is a preparation for determining labgrid's version (#1125).

> Use of pkg_resources is deprecated in favor of [...] importlib.metadata [...]"

[Source](https://setuptools.pypa.io/en/latest/pkg_resources.html) - see also [importlib.metadata](https://docs.python.org/3/library/importlib.metadata.html#module-importlib.metadata).

There is also a [backport of this functionality](https://pypi.org/project/importlib-metadata/), but since the EOL date is not too far away, dropping support for Python 3.7 seems to be the easiest way.

Our docker images are still based on Debian buster, but that ships Python 3.7, so bump the base image version to the next stable release "bullseye" and drop building ser2net which is not needed anymore on bullseye.

**Checklist**
- [ ] PR has been tested (CI only)

I guess this shouldn't be merged into v23.0, but the release after that.