### PR TITLE
Improve Debian Dependencies

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -330,7 +330,7 @@ out to be quite helpful.
 On Debian it comes with the ``devscripts`` package and you can install it
 with::
 
-  $ apt-get install devscripts
+  $ sudo apt install devscripts
 
 To use it, run::
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -9,8 +9,8 @@ For an overview about the basic design and components of `labgrid`, read the
 Installation
 ------------
 
-Depending on your distribution you need some dependencies. On Debian stretch
-and buster these usually are:
+Depending on your distribution you need some dependencies. On Debian these
+usually are:
 
 .. code-block:: bash
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -208,7 +208,13 @@ For example, to export a ``USBSerialPort`` with ``ID_SERIAL_SHORT`` of
           :ref:`resources sections <overview-resources>` for a description of
           different resource types.
 
-The exporter can now be started by running:
+The exporter requires additional dependencies:
+
+.. code-block:: bash
+
+    $ sudo apt install ser2net
+
+It can now be started by running:
 
 .. code-block:: bash
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -14,7 +14,7 @@ and buster these usually are:
 
 .. code-block:: bash
 
-   $ apt-get install python3 python3-virtualenv python3-pip python3-setuptools virtualenv
+   $ sudo apt install python3 python3-virtualenv python3-pip python3-setuptools virtualenv
 
 
 In many cases, the easiest way is to install labgrid into a virtualenv:


### PR DESCRIPTION
**Description**
- doc: use `sudo`/`apt` consistently
- do not mention explicit Debian releases
- mention exporter `ser2net` dependency