### PR TITLE
github: reusable-unit-tests: do not install codecov/coveralls

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -42,7 +42,7 @@ jobs:
         ssh -o StrictHostKeyChecking=no localhost echo OK
     - name: Install python dependencies
       run: |
-        python -m pip install --upgrade pip codecov coveralls
+        python -m pip install --upgrade pip
     - name: Install labgrid
       run: |
         pip install -e ".[dev]"


### PR DESCRIPTION
**Description**
These coverage upload tools are not required any longer: coveralls is not used since 2018 [1], codecov is used via `codecov/codecov-action@v3` [2].

codecov deprecated its previous uploader [3] and removed it from PyPI [4]. This makes labgrid's CI tests fail [5].

So do not install codecov and coveralls any longer.

[1] https://coveralls.io/github/labgrid-project/labgrid
[2] https://github.com/codecov/codecov-action
[3] https://github.com/codecov/codecov-python
[4] https://pypi.org/project/codecov/
[5] https://github.com/labgrid-project/labgrid/actions/runs/4679950048

**Checklist**
- [x] PR has been tested