### PR TITLE
Allow setting initial Strategy state in client

### DIFF
--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -2,7 +2,7 @@
 
 # options top level and subcommands support
 _labgrid_shared_options="--help"
-_labgrid_main_opts_with_value="@(-x|--crossbar|-c|--config|-p|--place|-s|--state|-P|--proxy)"
+_labgrid_main_opts_with_value="@(-x|--crossbar|-c|--config|-p|--place|-s|--state|-i|--initial-state|-P|--proxy)"
 
 # Parses labgrid-client arguments
 # Sets arg to subcommand, excluding options and their values.
@@ -837,6 +837,7 @@ _labgrid_client()
                            --config \
                            --place \
                            --state \
+                           --initial-state \
                            --debug \
                            --verbose \
                            --proxy \

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -61,6 +61,10 @@ set the configuration file
 set an initial state before executing a command, requires a configuration
 file and strategy
 .TP
+.BI \-i \ INITIAL_STATE\fR,\fB \ \-\-initial\-state \ INITIAL_STATE
+strategy state to force into before switching to desired state, requires a
+desired state (\fB\-s\fP/\fB\-\-state\fP/\fBLG_STATE\fP)
+.TP
 .B  \-d\fP,\fB  \-\-debug
 enable debugging
 .TP
@@ -88,6 +92,13 @@ for the \fB+\fP place expansion.
 This variable can be used to specify a state which the device transitions into
 before executing a command. Requires a configuration file and a Strategy
 specified for the device.
+.SS LG_INITIAL_STATE
+.sp
+This variable can be used to specify an initial state the device is known to
+be in.
+This is useful during development. The Strategy used must implement the
+\fBforce()\fP method.
+A desired state must be set using \fBLG_STATE\fP or \fB\-s\fP/\fB\-\-state\fP\&.
 .SS LG_ENV
 .sp
 This variable can be used to specify the configuration file to use without

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -45,6 +45,9 @@ OPTIONS
 -s STATE, --state STATE
     set an initial state before executing a command, requires a configuration
     file and strategy
+-i INITIAL_STATE, --initial-state INITIAL_STATE
+    strategy state to force into before switching to desired state, requires a
+    desired state (``-s``/``--state``/``LG_STATE``)
 -d, --debug
     enable debugging
 -v, --verbose
@@ -74,6 +77,14 @@ LG_STATE
 This variable can be used to specify a state which the device transitions into
 before executing a command. Requires a configuration file and a Strategy
 specified for the device.
+
+LG_INITIAL_STATE
+~~~~~~~~~~~~~~~~
+This variable can be used to specify an initial state the device is known to
+be in.
+This is useful during development. The Strategy used must implement the
+``force()`` method.
+A desired state must be set using ``LG_STATE`` or ``-s``/``--state``.
 
 LG_ENV
 ~~~~~~


### PR DESCRIPTION
**Description**
This is the equivalent of the pytest plugin's `--lg-initial-state` option. It can be used to specify an initial state the device is known to be in. This is useful during development. The Strategy used must implement the `force()` method.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] PR has been tested
- [x] Man pages have been regenerated