### PR TITLE
Unpin labgrid's dependencies

### DIFF
--- a/doc/RELEASE.rst
+++ b/doc/RELEASE.rst
@@ -15,22 +15,7 @@ Check your commit mail and name:
    git config --get user.name
    git config --get user.email
 
-1. Freeze Dependencies
-======================
-
-Freeze the dependencies into the `pyproject.toml` file and update the separate
-feature requirements files.
-This ensures that known good dependencies are available for every release.
-
-2. Update setup.py Dependencies
-===============================
-
-Update the minimum required dependencies in the `setup.py` file.
-These are intentionally non restrictive, see `PYPA Discussion
-<https://packaging.python.org/discussions/install-requires-vs-requirements/>`_.
-A frozen environment is already created in the previous step.
-
-3. Update CHANGES.rst
+1. Update CHANGES.rst
 =====================
 
 Update the `CHANGES.rst` file.
@@ -38,12 +23,12 @@ Ensure that no incompatiblities are unlisted and that all major features are
 described in a separate section.
 It's best to compare against the git log.
 
-4. Bump Version Number
+2. Bump Version Number
 ======================
 
 Bump the version number in `CHANGES.rst`.
 
-5. Create a signed Tag
+3. Create a signed Tag
 ======================
 
 Create a signed tag of the new release.
@@ -53,7 +38,7 @@ Your PGP-key has to be available on the computer.
 
     git tag -s <your-version-number>
 
-6. Create sdist
+4. Create sdist
 ===============
 
 Run the following command:
@@ -65,7 +50,7 @@ Run the following command:
 
 The sdist file will be available in the `dist/` directory.
 
-7. Test upload to pypi dev
+5. Test upload to pypi dev
 ==========================
 
 Test the upload by using twine to upload to pypi test service
@@ -74,7 +59,7 @@ Test the upload by using twine to upload to pypi test service
 
    twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
-8. Test download from pypi dev
+6. Test download from pypi dev
 ==============================
 
 Test the upload by using pypi dev as a download source
@@ -97,7 +82,7 @@ And optionally run the tests:
    pip install ".[dev]"
    pytest tests --crossbar-venv labgrid-crossbar-release-<your-version-number>
 
-9. Upload to pypi
+7. Upload to pypi
 =================
 
 Upload the tested dist file to pypi.
@@ -106,8 +91,8 @@ Upload the tested dist file to pypi.
 
    twine upload dist/*
 
-10. Upload the signed tag
-==========================
+8. Upload the signed tag
+========================
 
 Upload the signed tag to the upstream repository
 

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -280,7 +280,7 @@ $ labgrid\-client \-p <placename> console
 .UNINDENT
 .UNINDENT
 .sp
-Add all resources with the group "example\-group" to the place example\-place:
+Add all resources with the group \(dqexample\-group\(dq to the place example\-place:
 .INDENT 0.0
 .INDENT 3.5
 .sp

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -82,8 +82,8 @@ Two configured images, one for the root filesystem, one for the bootloader:
 .nf
 .ft C
 images:
-  root: "platform\-v7a/images/root.img"
-  boot: "platform\-v7a/images/barebox.img"
+  root: \(dqplatform\-v7a/images/root.img\(dq
+  boot: \(dqplatform\-v7a/images/barebox.img\(dq
 .ft P
 .fi
 .UNINDENT
@@ -174,7 +174,7 @@ Configure the tool path for \fBimx\-usb\-loader\fP:
 .nf
 .ft C
 tools:
-  imx\-usb\-loader: "/opt/labgrid\-helper/imx\-usb\-loader"
+  imx\-usb\-loader: \(dq/opt/labgrid\-helper/imx\-usb\-loader\(dq
 .ft P
 .fi
 .UNINDENT
@@ -213,7 +213,7 @@ targets:
   main:
     resources:
       RawSerialPort:
-        port: "/dev/ttyUSB0"
+        port: \(dq/dev/ttyUSB0\(dq
     drivers:
       SerialDriver: {}
       ShellDriver:
@@ -247,7 +247,7 @@ targets:
       IMXUSBDriver: {}
       MyStrategy: {}
 tools:
-  imx\-usb\-loader: "/opt/lg\-tools/imx\-usb\-loader"
+  imx\-usb\-loader: \(dq/opt/lg\-tools/imx\-usb\-loader\(dq
 imports:
   \- mystrategy.py
 .ft P

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -79,7 +79,7 @@ It defaults to the system hostname.
 .SS \-\-hostname
 .sp
 For resources like USBSerialPort, USBGenericExport or USBSigrokExport, the
-exporter needs to provide a host name to set the exported value of the "host"
+exporter needs to provide a host name to set the exported value of the \(dqhost\(dq
 key.
 If the system hostname is not resolvable via DNS, this option can be used to
 override this default with another name (or an IP address).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,18 +27,18 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
 ]
 dependencies = [
-    "ansicolors==1.1.8",
-    "attrs==21.4.0",
-    "autobahn==21.3.1",
-    "jinja2==3.0.2",
-    "pexpect==4.8.0",
+    "ansicolors>=1.1.8",
+    "attrs>=21.4.0",
+    "autobahn>=21.3.1",
+    "jinja2>=3.0.2",
+    "pexpect>=4.8.0",
     "pyserial-labgrid>=3.4.0.1",
-    "pytest==7.2.2",
-    "pyudev==0.22.0",
-    "pyusb==1.2.1",
-    "PyYAML==5.4.1",
-    "requests==2.26.0",
-    "xmodem==0.4.6",
+    "pytest>=7.0.0",
+    "pyudev>=0.22.0",
+    "pyusb>=1.2.1",
+    "PyYAML>=5.4.1",
+    "requests>=2.26.0",
+    "xmodem>=0.4.6",
 ]
 dynamic = ["version"]  # via setuptools_scm
 
@@ -47,85 +47,79 @@ dynamic = ["version"]  # via setuptools_scm
 "Bug Tracker" = "https://github.com/labgrid-project/labgrid/issues"
 
 [project.optional-dependencies]
-doc = [
-    "docutils==0.17.1",
-    "Sphinx==4.2.0",
-    "sphinx_rtd_theme==1.0.0",
-]
-docker = ["docker==5.0.2"]
-graph = ["graphviz==0.17.0"]
-kasa = ["python-kasa==0.4.0"]
-modbus = ["pyModbusTCP==0.1.10"]
-modbusrtu = ["minimalmodbus==1.0.2"]
-mqtt = ["paho-mqtt==1.5.1"]
-onewire = ["onewire==0.2"]
+doc = ["sphinx_rtd_theme>=1.0.0"]
+docker = ["docker>=5.0.2"]
+graph = ["graphviz>=0.17.0"]
+kasa = ["python-kasa>=0.4.0"]
+modbus = ["pyModbusTCP>=0.1.10"]
+modbusrtu = ["minimalmodbus>=1.0.2"]
+mqtt = ["paho-mqtt>=1.5.1"]
+onewire = ["onewire>=0.2"]
 pyvisa = [
-    "pyvisa==1.11.3",
-    "PyVISA-py==0.5.2",
+    "pyvisa>=1.11.3",
+    "PyVISA-py>=0.5.2",
 ]
 snmp = [
-    "pysnmp==4.4.12",
-    "pysnmp-mibs==0.1.6",
+    "pysnmp>=4.4.12",
+    "pysnmp-mibs>=0.1.6",
 ]
-vxi11 = ["python-vxi11==0.9"]
-xena = ["xenavalkyrie==3.0.1"]
+vxi11 = ["python-vxi11>=0.9"]
+xena = ["xenavalkyrie>=3.0.1"]
 deb = [
     # labgrid[modbus]
-    "pyModbusTCP==0.1.10",
+    "pyModbusTCP>=0.1.10",
 
     # labgrid[onewire]
-    "onewire==0.2",
+    "onewire>=0.2",
 
     # labgrid[snmp]
-    "pysnmp==4.4.12",
-    "pysnmp-mibs==0.1.6",
+    "pysnmp>=4.4.12",
+    "pysnmp-mibs>=0.1.6",
 ]
 dev = [
     # references to other optional dependency groups
     # labgrid[doc]
-    "docutils==0.17.1",
-    "Sphinx==4.2.0",
-    "sphinx_rtd_theme==1.0.0",
+    "sphinx_rtd_theme>=1.0.0",
 
     # labgrid[docker]
-    "docker==5.0.2",
+    "docker>=5.0.2",
 
     # labgrid[graph]
-    "graphviz==0.17.0",
+    "graphviz>=0.17.0",
 
     # labgrid[kasa]
-    "python-kasa==0.4.0",
+    "python-kasa>=0.4.0",
 
     # labgrid[modbus]
-    "pyModbusTCP==0.1.10",
+    "pyModbusTCP>=0.1.10",
 
     # labgrid[modbusrtu]
-    "minimalmodbus==1.0.2",
+    "minimalmodbus>=1.0.2",
 
     # labgrid[mqtt]
-    "paho-mqtt==1.5.1",
+    "paho-mqtt>=1.5.1",
 
     # labgrid[onewire]
-    "onewire==0.2",
+    "onewire>=0.2",
 
     # labgrid[pyvisa]
-    "pyvisa==1.11.3",
-    "PyVISA-py==0.5.2",
+    "pyvisa>=1.11.3",
+    "PyVISA-py>=0.5.2",
 
     # labgrid[snmp]
-    "pysnmp==4.4.12",
-    "pysnmp-mibs==0.1.6",
+    "pysnmp>=4.4.12",
+    "pysnmp-mibs>=0.1.6",
 
     # labgrid[vxi11]
-    "python-vxi11==0.9",
+    "python-vxi11>=0.9",
 
     # additional dev dependencies
-    "psutil==5.8.0",
-    "pytest-cov==3.0.0",
-    "pytest-dependency==0.5.1",
-    "pytest-isort==2.0.0",
-    "pytest-mock==3.6.1",
-    "pytest-pylint==0.18.0",
+    "psutil>=5.8.0",
+    "pytest-cov>=3.0.0",
+    "pytest-dependency>=0.5.1",
+    "pytest-isort>=2.0.0",
+    "pytest-mock>=3.6.1",
+    "pytest-pylint>=0.18.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
**Description**
With #1079, crossbar is no longer installed in the same virtualenv as labgrid and its dependencies. We can now loosen labgrid's dependencies.

Use the known-good previously pinned versions as minimum versions.

We cannot unpin crossbar's version because of continuing issues: [dependencies being incompatible with Python > 3.11](https://github.com/erikrose/parsimonious/issues/225), [PyPI packages depending on non-PyPI packages](https://github.com/crossbario/crossbar/issues/2069) etc.

Based on #1079.

**Checklist**
- [ ] PR has been tested (CI only)
- [x] Man pages have been regenerated

Closes #1153