### PR TITLE
remote/client: return exit code for ssh/scp/rsync/telnet/video/audio/console

### DIFF
--- a/labgrid/driver/httpvideodriver.py
+++ b/labgrid/driver/httpvideodriver.py
@@ -45,4 +45,5 @@ class HTTPVideoDriver(Driver, VideoProtocol):
             "sync=false",
         ]
 
-        subprocess.run(pipeline)
+        sub = subprocess.run(pipeline)
+        return sub.returncode

--- a/labgrid/driver/usbaudiodriver.py
+++ b/labgrid/driver/usbaudiodriver.py
@@ -204,3 +204,5 @@ class USBAudioInputDriver(Driver):
 
         rx.communicate()
         tx.communicate()
+
+        return tx.returncode or rx.returncode


### PR DESCRIPTION
**Description**
Correctly set the exitcode for these subcommands. For this we introduce an InteractiveCommandError, which only sets the exitcode to the one received from the program.

**Checklist**
- [x] PR has been tested

Fixes #660
Supersedes #662