### PR TITLE
labgrid: util: marker: use safe marker

### DIFF
--- a/labgrid/util/marker.py
+++ b/labgrid/util/marker.py
@@ -2,5 +2,8 @@ import random
 import string
 
 
+# Remove RID to avoid markers containing substrings like ERROR, FAIL, WARN, INFO or DEBUG
+MARKER_POOL = tuple(c for c in string.ascii_uppercase if c not in 'RID')
+
 def gen_marker():
-    return ''.join(random.choice(string.ascii_uppercase) for i in range(10))
+    return ''.join(random.choice(MARKER_POOL) for i in range(10))


### PR DESCRIPTION
The marker can randomly contain some key words. As they show up in the serial logs they may trigger false positive hits while searching.

Remove the character R, I and D to avoid substrings like ERROR, FAIL, WARN, INFO or DEBUG