### PR TITLE
driver/sigrok: Add sigrok driver for DMMs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2444,6 +2444,40 @@ Arguments:
   - max_current (float): optional, maximum allowed current for protection against
     accidental damage (in ampere)
 
+SigrokDmmDriver
+~~~~~~~~~~~~~~~
+The `SigrokDmmDriver` uses a  `SigrokDevice` resource to record samples from a digital multimeter (DMM) and provides
+them during test runs.
+
+It is known to work with Unit-T `UT61B` and `UT61C` devices but should also work with other DMMs supported by *sigrok*.
+
+Binds to:
+  sigrok:
+    - `SigrokUSBDevice`_
+    - `SigrokUSBSerialDevice`_
+    - `NetworkSigrokUSBDevice`_
+    - NetworkSigrokUSBSerialDevice
+
+Implements:
+  - None yet
+
+Arguments:
+  - None
+
+Sampling can be started calling `capture(samples, timeout=None)`.
+It sets up sampling and returns immediately.
+The default timeout has been chosen to work with Unit-T `UT61B`.
+Other devices may require a different timeout setting.
+
+Samples can be obtained using `stop()`.
+`stop()` will block until either *sigrok* terminates or `timeout` is reached.
+This method returns a `(unit, samples)` tuple:
+`unit` is the physical unit reported by the DMM;
+samples is an iterable of samples.
+
+This driver relies on buffering of the subprocess call.
+Reading a few samples will very likely work - but obtaining a lot of samples may stall.
+
 USBSDMuxDriver
 ~~~~~~~~~~~~~~
 The :any:`USBSDMuxDriver` uses a USBSDMuxDevice resource to control a

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -23,7 +23,7 @@ from .common import Driver
 from .qemudriver import QEMUDriver
 from .modbusdriver import ModbusCoilDriver
 from .modbusrtudriver import ModbusRTUDriver
-from .sigrokdriver import SigrokDriver, SigrokPowerDriver
+from .sigrokdriver import SigrokDriver, SigrokPowerDriver, SigrokDmmDriver
 from .usbstoragedriver import USBStorageDriver, NetworkUSBStorageDriver, Mode
 from .resetdriver import DigitalOutputResetDriver
 from .gpiodriver import GpioDigitalOutputDriver


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
The ``SigrokDmmDriver`` wraps around a single channel DMM controlled by sigrok. It has been tested with Unit-T UT61C and UT61B devices but probably also works with other single chnnel DMMs.

This driver binds to a SigrokUsbDevice.
Make sure to select the correct driver for your DMM there.

Example usage:
```
resources:
  - SigrokUSBDevice:
      driver: uni-t-ut61c
      match:
        'ID_PATH': pci-0000:07:00.4-usb-0:2:1.0
drivers:
  - SigrokUt61DmmDriver: {}
```

Args:
    bindings (dict): driver to use with sigrok

I'm already using this driver to read values from two DMMs in parallel during hardware testing:
```
volt_dmm = target.get_driver("SigrokDmmDriver", name="volt_dmm")
curr_dmm = target.get_driver("SigrokDmmDriver", name="curr_dmm")
volt_dmm.start(5)
curr_dmm.start(5)
dmm_volt = dmm_voltage_measure(self.volt_dmm.get_samples())
dmm_curr = dmm_current_measure(self.curr_dmm.get_samples())
```
Where the helper `dmm_*_measure()`  makes sure the correct physical unit has been returned by the DMM, does averaging, etc.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
