### PR TITLE
Support remote controlling Ykush devices

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -270,7 +270,7 @@ A YKUSHPowerPort describes a YEPKIT YKUSH USB (HID) switchable USB hub.
 
 The example describes port 1 on the YKUSH USB hub with the
 serial "YK12345".
-(use "pykush -l" to get your serial...)
+(use "ykushcmd -l" to get your serial...)
 
 Arguments:
   - serial (str): serial number of the YKUSH hub
@@ -278,6 +278,10 @@ Arguments:
 
 Used by:
   - `YKUSHPowerDriver`_
+
+NetworkYKUSHPowerPort
++++++++++++++++++++++
+A NetworkYKUSHPowerPort describes a `YKUSHPowerPort`_ available on a remote computer.
 
 USBPowerPort
 ++++++++++++

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -732,6 +732,8 @@ class ClientSession(ApplicationSession):
             drv = target.get_driver("PowerProtocol", name=name)
         except NoDriverFoundError:
             for resource in target.resources:
+                if name and resource.name != name:
+                    continue
                 if isinstance(resource, NetworkPowerPort):
                     drv = self._get_driver_or_new(target, "NetworkPowerDriver", name=name)
                 elif isinstance(resource, NetworkUSBPowerPort):

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -725,7 +725,7 @@ class ClientSession(ApplicationSession):
         target = self._get_target(place)
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort
-        from ..resource import TasmotaPowerPort
+        from ..resource import TasmotaPowerPort, NetworkYKUSHPowerPort
 
         drv = None
         try:
@@ -744,6 +744,8 @@ class ClientSession(ApplicationSession):
                     drv = self._get_driver_or_new(target, "PDUDaemonDriver", name=name)
                 elif isinstance(resource, TasmotaPowerPort):
                     drv = self._get_driver_or_new(target, "TasmotaPowerDriver", name=name)
+                elif isinstance(resource, NetworkYKUSHPowerPort):
+                    drv = self._get_driver_or_new(target, "YKUSHPowerDriver", name=name)
                 if drv:
                     break
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -695,6 +695,26 @@ class AndroidNetFastbootExport(ResourceExport):
 
 exports["AndroidNetFastboot"] = AndroidNetFastbootExport
 
+@attr.s(eq=False)
+class YKUSHPowerPortExport(ResourceExport):
+    """ResourceExport for YKUSHPowerPort devices"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        local_cls_name = self.cls
+        self.data['cls'] = f"Network{local_cls_name}"
+        from ..resource import ykushpowerport
+        local_cls = getattr(ykushpowerport, local_cls_name)
+        self.local = local_cls(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        return {
+            "host": self.host,
+            **self.local_params
+        }
+
+exports["YKUSHPowerPort"] = YKUSHPowerPortExport
+
 class ExporterSession(ApplicationSession):
     def onConnect(self):
         """Set up internal datastructures on successful connection:

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -13,7 +13,7 @@ from .udev import USBSDWireDevice
 from .udev import USBPowerPort
 from .udev import SiSPMPowerPort
 from .common import Resource, ResourceManager, ManagedResource
-from .ykushpowerport import YKUSHPowerPort
+from .ykushpowerport import YKUSHPowerPort, NetworkYKUSHPowerPort
 from .xenamanager import XenaManager
 from .flashrom import Flashrom, NetworkFlashrom
 from .docker import DockerManager, DockerDaemon, DockerConstants

--- a/labgrid/resource/ykushpowerport.py
+++ b/labgrid/resource/ykushpowerport.py
@@ -1,13 +1,25 @@
 import attr
 
 from ..factory import target_factory
-from .common import Resource
+from .common import NetworkResource, Resource
 
 
 @target_factory.reg_resource
 @attr.s(eq=False)
 class YKUSHPowerPort(Resource):
     """This resource describes a YEPKIT YKUSH switchable USB hub.
+
+    Args:
+        serial (str): serial of the YKUSH device
+        index (int): port index"""
+    serial = attr.ib(validator=attr.validators.instance_of(str))
+    index = attr.ib(validator=attr.validators.instance_of(int),
+                    converter=int)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkYKUSHPowerPort(NetworkResource):
+    """"This resource describes a remote YEPKIT YKUSH switchable USB hub.
 
     Args:
         serial (str): serial of the YKUSH device


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Currently, ykush devices can only be controlled 'locally'. This PR adds support to control them on remote devices. It is based on the seemingly abandoned https://github.com/labgrid-project/labgrid/pull/953 - I basically updated it with the comments there plus a minor fix - first patch, that could go on a different PR if deemed best.

Note that I also removed the 'Export' class created because I'm still figuring out its need - and the commentary for it. If it's deemed necessary, I can bring it back.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
<!---
If you add a driver/resource or modify one:
--->
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
