### PR TITLE
remote/client: ssh command: first look for SSHDriver

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1024,17 +1024,21 @@ class ClientSession(ApplicationSession):
         place = self.get_acquired_place()
         target = self._get_target(place)
 
-        from ..resource import NetworkService
         try:
-            resource = target.get_resource(NetworkService, name=self.args.name)
-        except NoResourceFoundError:
-            ip = self._get_ip(place)
-            if not ip:
-                return
-            resource = NetworkService(target, address=str(ip), username='root')
+            drv = target.get_driver("SSHDriver", name=self.args.name)
+            return drv
+        except NoDriverFoundError:
+            from ..resource import NetworkService
+            try:
+                resource = target.get_resource(NetworkService, name=self.args.name)
+            except NoResourceFoundError:
+                ip = self._get_ip(place)
+                if not ip:
+                    return
+                resource = NetworkService(target, address=str(ip), username='root')
 
-        drv = self._get_driver_or_new(target, "SSHDriver", name=resource.name)
-        return drv
+            drv = self._get_driver_or_new(target, "SSHDriver", name=resource.name)
+            return drv
 
     def ssh(self):
         drv = self._get_ssh()


### PR DESCRIPTION
**Description**
When using multiple `NetworkService` resources, `labgrid-client ssh` returns an error even if the binding is set in the environment file:
```
labgrid-client: error: multiple resources matching <class 'labgrid.resource.networkservice.NetworkService'> found in Target(name='essential', env=Environment(config_file='/tmp/boards.yaml'))
Found multiple resources but no name was given, available names:
ip-board
ip-extention
```
resources:
```
slot0:
  ip-board:
    cls: 'NetworkService'
    address: '192.168.0.1'
  ip-extention:
    cls: 'NetworkService'
    address: '192.168.0.11'
```

environment file:
```
    drivers:
      SSHDriver:
        bindings:
          networkservice: 'ip-board'
```

The propose change is to first try to get the SSHDriver and if that fails continue with what is currently done.
This makes it possible to use bindings on SSHDriver from the environment file.

I tested this in my setup and `labgrid-client ssh` correctly connects to 192.168.0.1.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
  I think it's more a bugfix that doesn't require documentation
- [X] Tests for the feature
  manual test
- [X] PR has been tested
  manual test