### PR TITLE
driver/serialdriver: drop handling of legacy pyserial 3.2.1

### DIFF
--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -1,7 +1,6 @@
 import logging
 
 import attr
-from packaging import version
 from pexpect import TIMEOUT
 import serial
 import serial.rfc2217
@@ -20,12 +19,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     """
     Driver implementing the ConsoleProtocol interface over a SerialPort connection
     """
-    # pyserial 3.2.1 does not support RFC2217 under Python 3
-    # https://github.com/pyserial/pyserial/pull/183
-    if version.parse(serial.__version__) <= version.Version('3.2.1'):
-        bindings = {"port": "SerialPort", }
-    else:
-        bindings = {"port": {"SerialPort", "NetworkSerialPort"}, }
+    bindings = {"port": {"SerialPort", "NetworkSerialPort"}, }
 
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
     timeout = attr.ib(default=3.0, validator=attr.validators.instance_of(float))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "attrs==21.4.0",
     "autobahn==21.3.1",
     "jinja2==3.0.2",
-    "packaging==21.0",
     "pexpect==4.8.0",
     "pyserial-labgrid>=3.4.0.1",
     "pytest==7.2.2",


### PR DESCRIPTION
**Description**
pyserial 3.2.1 was released more than six years ago, even Debian buster (currently oldstable) contains pyserial 3.4 [1]. It is very unlikely that this is still in use anywhere with a recent labgrid version, especially since we already dropped support for Python 3.7 [2].

This was the only user for the packaging dependency, so drop it.

[1] https://packages.debian.org/source/buster/pyserial
[2] https://github.com/labgrid-project/labgrid/pull/1129

**Checklist**
- [x] PR has been tested (CI only)