### PR TITLE
pyproject.toml: Accept newer versions of PyYAML

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "pytest==7.2.2",
     "pyudev==0.22.0",
     "pyusb==1.2.1",
-    "PyYAML==5.4.1",
+    "PyYAML>=5.4.1",
     "requests==2.26.0",
     "xmodem==0.4.6",
 ]


### PR DESCRIPTION
Instead of requiring exactly PyYAML 5.4.1, use that version as the minimum requirement. This will help avoid conflicts with other packages that usually require a newer version of PyYAML.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Requiring an specific version of PyYAML is causing conflicts with other project requirements, that are requiring PyYAML 6.0 (released on October 2021) as minimum. Running the tests, I didn't see any issue, and https://github.com/labgrid-project/labgrid/pull/1019 also increases the confidence that there are no issues.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [X] Tests for the feature 
- [X] PR has been tested
