### PR TITLE
PDUDaemonDriver improvements

### DIFF
--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -411,4 +411,4 @@ class PDUDaemonDriver(Driver, PowerResetMixin, PowerProtocol):
 
     @Driver.check_active
     def get(self):
-        return None
+        raise NotImplementedError("pdudaemon does not support retrieving the port's state")

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -396,21 +396,18 @@ class PDUDaemonDriver(Driver, PowerResetMixin, PowerProtocol):
     def on(self):
         r = self._requests.get(self._build_url('on'))
         r.raise_for_status()
-        time.sleep(1)  # give pdudaemon some time to execute the request
 
     @Driver.check_active
     @step()
     def off(self):
         r = self._requests.get(self._build_url('off'))
         r.raise_for_status()
-        time.sleep(1)  # give pdudaemon some time to execute the request
 
     @Driver.check_active
     @step()
     def cycle(self):
         r = self._requests.get(self._build_url('reboot'))
         r.raise_for_status()
-        time.sleep(self.delay + 1)  # give pdudaemon some time to execute the request
 
     @Driver.check_active
     def get(self):


### PR DESCRIPTION
**Description**
Now that [1] is merged, we can drop the sleeps that waited for pdudaemon to execute the request. Note that [1] is not part of a release, yet.

pdudaemon does not implement port state retrieval. PDUDaemonDriver.get() returns None. This leads to cases where None is interpreted as "off", i.e. with constructs relying on `bool(drv.get())`. `labgrid-client power get` is one of those cases.

[1] https://github.com/pdudaemon/pdudaemon/pull/78

**Checklist**
- [x] PR has been tested
