### PR TITLE
driver/power: add raritan pdu network power driver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -195,6 +195,9 @@ Currently available are:
 ``netio_kshell``
   Controls a NETIO 4C PDU via a Telnet interface.
 
+``raritan``
+  Controls Raritan PDUs via SNMP.
+
 ``rest``
   This is a generic backend for PDU implementations which can be controlled via
   HTTP PUT and GET requests.

--- a/labgrid/driver/power/eaton.py
+++ b/labgrid/driver/power/eaton.py
@@ -1,44 +1,15 @@
-from pysnmp import hlapi
 from ..exception import ExecutionError
+from ...util.snmp import SimpleSNMP
 
 
 OID = ".1.3.6.1.4.1.534.6.6.7.6.6.1"
 NUMBER_OF_OUTLETS = 16
 
 
-class _Snmp:
-    """A class that helps wrap pysnmp"""
-    def __init__(self, host, community, port=161):
-        if port is None:
-            port = 161
-
-        self.engine = hlapi.SnmpEngine()
-        self.transport = hlapi.UdpTransportTarget((host, port))
-        self.community = hlapi.CommunityData(community, mpModel=0)
-        self.context = hlapi.ContextData()
-
-    def get(self, oid):
-        g = hlapi.getCmd(self.engine, self.community, self.transport,
-            self.context, hlapi.ObjectType(hlapi.ObjectIdentity(oid)),
-            lookupMib=False)
-
-        error_indication, error_status, _, res = next(g)
-        if error_indication or error_status:
-            raise ExecutionError("Failed to get SNMP value")
-        return res[0][1]
-
-    def set(self, oid, value):
-        identify = hlapi.ObjectType(hlapi.ObjectIdentity(oid),
-                   hlapi.Integer(value))
-        g = hlapi.setCmd(self.engine, self.community, self.transport,
-            self.context, identify, lookupMib=False)
-        next(g)
-
-
 def power_set(host, port, index, value):
     assert 1 <= int(index) <= NUMBER_OF_OUTLETS
 
-    _snmp = _Snmp(host, 'public', port=port)
+    _snmp = SimpleSNMP(host, 'public', port=port)
     cmd_id = 4 if int(value) else 3
     outlet_control_oid = "{}.{}.0.{}".format(OID, cmd_id, index)
 
@@ -48,7 +19,7 @@ def power_set(host, port, index, value):
 def power_get(host, port, index):
     assert 1 <= int(index) <= NUMBER_OF_OUTLETS
 
-    _snmp = _Snmp(host, 'public', port=port)
+    _snmp = SimpleSNMP(host, 'public', port=port)
     output_status_oid = "{}.2.0.{}".format(OID, index)
 
     value = _snmp.get(output_status_oid)

--- a/labgrid/driver/power/raritan.py
+++ b/labgrid/driver/power/raritan.py
@@ -1,0 +1,38 @@
+"""Driver for the Raritan PDUs
+
+Documentation sources:
+* https://www.circitor.fr/Mibs/Html/P/PDU2-MIB.php
+* http://support.raritan.com/px3/version-3.0.3/user-guides/PX3-0B-v3.0-E.pdf
+* https://cdn1.raritan.com/download/pdu-g2/4.0.20/MIB_Usage_4.0.20_49038.pdf
+"""
+from ..exception import ExecutionError
+from ...util.snmp import SimpleSNMP
+
+
+OID = ".1.3.6.1.4.1.13742.6.4.1.2.1"
+NUMBER_OF_OUTLETS = 16
+
+
+def power_set(host, port, index, value):
+    assert 1 <= int(index) <= NUMBER_OF_OUTLETS
+
+    _snmp = SimpleSNMP(host, 'private', port=port)
+    outlet_control_oid = "{}.2.1.{}".format(OID, index)
+
+    _snmp.set(outlet_control_oid, str(int(value)))
+
+
+def power_get(host, port, index):
+    assert 1 <= int(index) <= NUMBER_OF_OUTLETS
+
+    _snmp = SimpleSNMP(host, 'public', port=port)
+    output_status_oid = "{}.3.1.{}".format(OID, index)
+
+    value = _snmp.get(output_status_oid)
+
+    if value == 7:  # On
+        return True
+    if value == 8:  # Off
+        return False
+
+    raise ExecutionError("failed to get SNMP value")

--- a/labgrid/util/snmp.py
+++ b/labgrid/util/snmp.py
@@ -1,0 +1,31 @@
+from pysnmp import hlapi
+from ..driver.exception import ExecutionError
+
+
+class SimpleSNMP:
+    """A class that helps wrap pysnmp"""
+    def __init__(self, host, community, port=161):
+        if port is None:
+            port = 161
+
+        self.engine = hlapi.SnmpEngine()
+        self.transport = hlapi.UdpTransportTarget((host, port))
+        self.community = hlapi.CommunityData(community, mpModel=0)
+        self.context = hlapi.ContextData()
+
+    def get(self, oid):
+        g = hlapi.getCmd(self.engine, self.community, self.transport,
+            self.context, hlapi.ObjectType(hlapi.ObjectIdentity(oid)),
+            lookupMib=False)
+
+        error_indication, error_status, _, res = next(g)
+        if error_indication or error_status:
+            raise ExecutionError("Failed to get SNMP value.")
+        return res[0][1]
+
+    def set(self, oid, value):
+        identify = hlapi.ObjectType(hlapi.ObjectIdentity(oid),
+                   hlapi.Integer(value))
+        g = hlapi.setCmd(self.engine, self.community, self.transport,
+            self.context, identify, lookupMib=False)
+        next(g)


### PR DESCRIPTION
Based on the Eaton PDU NetworkPowerDriver implementation, uses PySNMP.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

This PR adds `raritan` as a possible PDU NetworkPowerPort model by adding an appropriate NetworkPowerDriver using SNMP via PySNMP.

The feature has been tested on our Raritan PDU. Changing the power state for an outlet via labgrid has worked properly with this change.

Documentation sources for Raritan PDU, i.a. its SNMP protocol OIDs:
  * http://support.raritan.com/px3/version-3.0.3/user-guides/PX3-0B-v3.0-E.pdf 
  * https://cdn1.raritan.com/download/pdu-g2/4.0.20/MIB_Usage_4.0.20_49038.pdf
  * https://www.circitor.fr/Mibs/Html/P/PDU2-MIB.php#switchingOperation

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature - I feel that the `configuration.rst` change is sufficient

- [ ] Tests for the feature - May benefit from being included in the test_powerdriver.test_import_backend_eaton(), as it uses the same backend (PySNMP).
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
