### PR TITLE
readthedocs: specify Python version and OS

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,3 +6,8 @@ python:
       path: .
       extra_requirements:
         - doc
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"


### PR DESCRIPTION
**Description**
Currently, readthedocs uses Python 3.7.9 by default. labgrid dropped Python 3.7 support in #1129. Since this PR was merged, the readthedocs builds fail [1]. This is especially annoying since #1079 was merged afterwards, changing labgrid's setup and its documentation significantly, meaning latest master and the docs hosted on readthedocs differ in incompatible ways. labgrid users already stumbled upon this.

It is not really clear why this Python version is used, though: The docs don't specify a default for build.tools.python [2], the legacy option python.version [3] uses "3" as default, which seems to correlate with the value documented in [2] meaning "last stable CPython version". But 3.7.9 is not the "last stable CPython version".

To fix this, configure all required options (including build.os) to allow setting the Python version. Set the Python version to the latest stable version 3.11 and the OS version to the latest available value ubuntu-22.04.

[1] https://readthedocs.org/projects/labgrid/builds/
[2] https://docs.readthedocs.io/en/stable/config-file/v2.html#build-tools-python
[3] https://docs.readthedocs.io/en/stable/config-file/v2.html#python-version-legacy

**Checklist**
- [x] PR has been tested