### PR TITLE
doc/conf: add sphinx_rtd_theme to extensions to fix jQuery loading

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,7 +40,8 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.coverage',
               'sphinx.ext.viewcode',
-              'sphinx.ext.autosectionlabel']
+              'sphinx.ext.autosectionlabel',
+              'sphinx_rtd_theme']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']


### PR DESCRIPTION
**Description**
jQuery is used to expand the menu in the mobile view and for the search functionality. With Sphinx 6.2.1, jQuery is not loaded. The sphinx-rtd-theme docs suggest adding `sphinx_rtd_theme` to `extensions` as a workaround [1]. Do that.

[1] https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#known-issues

**Checklist**
- [x] PR has been tested (tested on fork with rtd)