### PR TITLE
README: use anonymous reference for doc link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ automated testing, several planned features are not yet implemented and the APIs
 may be changed as more use-cases appear.
 We appreciate code contributions and feedback on using labgrid on other
 environments (see `Contributing
-<https://labgrid.readthedocs.io/en/latest/development.html#contributing>`_ for
+<https://labgrid.readthedocs.io/en/latest/development.html#contributing>`__ for
 details).
 Please consider contacting us (via a GitHub issue) before starting larger
 changes, so we can discuss design trade-offs early and avoid redundant work.


### PR DESCRIPTION
**Description**
Contributing exists as a section heading and a link, which introduces both as a target. Make the link use an anonymous reference instead which should fix the duplication error.

Should fix the pypi upload issue:
```
  Checking dist/labgrid-23.1a3.dev11-py3-none-any.whl: FAILED
  ERROR    `long_description` has syntax errors in markup and would not be
           rendered on PyPI.
           line 6: Warning: Duplicate explicit target name: "contributing".
  Checking dist/labgrid-23.1a3.dev11.tar.gz: FAILED
  ERROR    `long_description` has syntax errors in markup and would not be
           rendered on PyPI.
           line 6: Warning: Duplicate explicit target name: "contributing".
```


**Checklist**
- [ ] PR has been tested

