### PR TITLE
target: make _get_driver() prioritize drivers named "default"

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3162,6 +3162,9 @@ To bind the correct driver to the correct resource, explicit ``name`` and
 The property name for the binding (e.g. `port` in the example above) is
 documented for each individual driver in this chapter.
 
+If name is set to "default", this resource/driver will be used when no
+specific constraint is given.
+
 The YAML configuration file also supports templating for some substitutions,
 these are:
 

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -159,18 +159,27 @@ class Target:
 
         found = []
         other_names = []
+        default = None
         if isinstance(cls, str):
             cls = target_factory.class_from_string(cls)
 
         for drv in self.drivers:
             if not isinstance(drv, cls):
                 continue
+            if drv.name == "default":
+                default = drv
             if name and drv.name != name:
                 other_names.append(drv.name)
                 continue
             if active and drv.state != BindingState.active:
                 continue
             found.append(drv)
+
+        # if no explicit driver name is requested and a "default" driver was saved and
+        # multiple drivers were found, use the default driver
+        if not name and default and len(found) != 1:
+            found = [default]
+
         if not found:
             name_msg = f" named '{name}'" if name else ""
             if other_names:

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -50,6 +50,19 @@ def test_get_driver(target):
     assert target.get_driver(A) is a
     assert target.get_driver(A, name="adriver") is a
 
+    # make sure drivers named "default" are prioritized
+    b = A(target, "default")
+    assert target.get_driver(A) is b
+    assert target.get_driver(A, name="adriver") is a
+
+def test_get_driver_multiple_no_default(target):
+    class A(Driver):
+        pass
+
+    a = A(target, "adriver")
+    b = A(target, "default")
+    with pytest.raises(NoDriverFoundError) as excinfo:
+        target.get_driver(A, name="nosuchdriver")
 
 def test_getitem(target):
     class AProtocol(abc.ABC):


### PR DESCRIPTION
**Description**
Implement the same behavior as `get_resource()`

This make writing configuration files easier when having multiple drivers.
I updated the tests and they run OK. I my setup this feature runs as expected.

**Checklist**
- [X] Documentation for the feature
  In doc/configuration.rst
- [X] Tests for the feature 
  Tests updated
- [X] The arguments and description in doc/configuration.rst have been updated
  I added a description of the "default" value for the name property
- [X] PR has been tested
- [ ] Man pages have been regenerated
  No impact on man pages
