### PR TITLE
 config: return passed in tool by default 

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -98,9 +98,14 @@ class Config:
         """
         try:
             path = str(self.data['tools'][tool])
-            return self.resolve_path(path)
         except KeyError:
-            return None
+            return tool
+
+        resolved = self.resolve_path(path)
+        if os.path.exists(resolved):
+            return resolved
+
+        return path
 
     def get_image_path(self, kind):
         """Retrieve an entry from the images subkey

--- a/labgrid/driver/dfudriver.py
+++ b/labgrid/driver/dfudriver.py
@@ -18,7 +18,7 @@ class DFUDriver(Driver):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('dfu-util') or 'dfu-util'
+            self.tool = self.target.env.config.get_tool('dfu-util')
         else:
             self.tool = 'dfu-util'
 

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -36,7 +36,7 @@ class AndroidFastbootDriver(Driver):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('fastboot') or 'fastboot'
+            self.tool = self.target.env.config.get_tool('fastboot')
         else:
             self.tool = 'fastboot'
 

--- a/labgrid/driver/lxausbmuxdriver.py
+++ b/labgrid/driver/lxausbmuxdriver.py
@@ -19,7 +19,7 @@ class LXAUSBMuxDriver(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('usbmuxctl') or 'usbmuxctl'
+            self.tool = self.target.env.config.get_tool('usbmuxctl')
         else:
             self.tool = 'usbmuxctl'
 

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -51,7 +51,7 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
 
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('openocd') or 'openocd'
+            self.tool = self.target.env.config.get_tool('openocd')
             self.config = self.target.env.config.resolve_path_str_or_list(self.config)
             self.search = self.target.env.config.resolve_path_str_or_list(self.search)
         else:

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -69,7 +69,7 @@ class SiSPMPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('sispmctl') or 'sispmctl'
+            self.tool = self.target.env.config.get_tool('sispmctl')
         else:
             self.tool = 'sispmctl'
 
@@ -316,7 +316,7 @@ class USBPowerDriver(Driver, PowerResetMixin, PowerProtocol):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('uhubctl') or 'uhubctl'
+            self.tool = self.target.env.config.get_tool('uhubctl')
         else:
             self.tool = 'uhubctl'
 

--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -32,8 +32,8 @@ class QuartusHPSDriver(Driver):
 
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('quartus_hps') or 'quartus_hps'
-            self.jtag_tool = self.target.env.config.get_tool('jtagconfig') or 'jtagconfig'
+            self.tool = self.target.env.config.get_tool('quartus_hps')
+            self.jtag_tool = self.target.env.config.get_tool('jtagconfig')
         else:
             self.tool = 'quartus_hps'
             self.jtag_tool = 'jtagconfig'

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -23,7 +23,7 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('mxs-usb-loader') or 'mxs-usb-loader'
+            self.tool = self.target.env.config.get_tool('mxs-usb-loader')
         else:
             self.tool = 'mxs-usb-loader'
 
@@ -60,7 +60,7 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('imx-usb-loader') or 'imx-usb-loader'
+            self.tool = self.target.env.config.get_tool('imx-usb-loader')
         else:
             self.tool = 'imx-usb-loader'
 
@@ -99,7 +99,7 @@ class RKUSBDriver(Driver, BootstrapProtocol):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('rk-usb-loader') or 'rk-usb-loader'
+            self.tool = self.target.env.config.get_tool('rk-usb-loader')
         else:
             self.tool = 'rk-usb-loader'
 
@@ -163,7 +163,7 @@ class UUUDriver(Driver, BootstrapProtocol):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('uuu-loader') or 'uuu-loader'
+            self.tool = self.target.env.config.get_tool('uuu-loader')
         else:
             self.tool = 'uuu-loader'
 
@@ -208,7 +208,7 @@ class BDIMXUSBDriver(Driver, BootstrapProtocol):
         super().__attrs_post_init__()
         # FIXME make sure we always have an environment or config
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('imx_usb') or 'imx_usb'
+            self.tool = self.target.env.config.get_tool('imx_usb')
         else:
             self.tool = 'imx_usb'
 

--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -25,7 +25,7 @@ class USBSDMuxDriver(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('usbsdmux') or 'usbsdmux'
+            self.tool = self.target.env.config.get_tool('usbsdmux')
         else:
             self.tool = 'usbsdmux'
 

--- a/labgrid/driver/usbsdwiredriver.py
+++ b/labgrid/driver/usbsdwiredriver.py
@@ -21,7 +21,7 @@ class USBSDWireDriver(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('sd-mux-ctrl') or 'sd-mux-ctrl'
+            self.tool = self.target.env.config.get_tool('sd-mux-ctrl')
         else:
             self.tool = 'sd-mux-ctrl'
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -100,3 +100,30 @@ def test_template_bad_key(tmpdir):
     with pytest.raises(InvalidConfigError) as excinfo:
         Config(str(p))
     assert "unknown variable" in excinfo.value.msg
+
+def test_tool(tmpdir):
+    t = tmpdir.join("testtool")
+    t.write("content")
+    p = tmpdir.join("config.yaml")
+    p.write(
+        """
+        tools:
+          testtool: {}
+        """.format(t)
+    )
+    c = Config(str(p))
+
+    assert c.get_tool("testtool") == t
+
+def test_tool_no_explicit_tool(tmpdir):
+    t = tmpdir.join("testtool")
+    t.write("content")
+    p = tmpdir.join("config.yaml")
+    p.write(
+        """
+        dict: {}
+        """
+    )
+    c = Config(str(p))
+
+    assert c.get_tool("testtool") == "testtool"


### PR DESCRIPTION
**Description**
The tools in the tools key can either be a single string with the binary
name or a complete path to a binary. This works for every tool expect
for qemu since drivers can provide a fallback to the default tool.
However qemu currently requires the user to supply the full binary path,
which is unintuitive.

Instead return the originally requested tool-name instead if no
specialized path is found. And return the simple unexpanded path if a
local tool with the same name can't be found.

**Checklist**
- [x] PR has been tested

