### PR TITLE
contrib/systemd: improve exporter/coordinator services

### DIFF
--- a/contrib/systemd/labgrid-coordinator.service
+++ b/contrib/systemd/labgrid-coordinator.service
@@ -3,9 +3,11 @@ Description=Labgrid Coordinator
 After=network.target
 
 [Service]
+Environment="PYTHONUNBUFFERED=1"
+# labgrid's .crossbar/config-anonymous.yaml serves as an example
 ExecStart=/path/to/labgrid-coordinator/venv/bin/crossbar start --logformat=syslogd --cbdir /var/lib/labgrid-coordinator --config /etc/labgrid/coordinator.yaml
 ExecStop=/usr/bin/labgrid-coordinator stop --cbdir /var/lib/labgrid-coordinator
-Restart=on-abort
+Restart=on-failure
 DynamicUser=yes
 StateDirectory=labgrid-coordinator
 

--- a/contrib/systemd/labgrid-exporter.service
+++ b/contrib/systemd/labgrid-exporter.service
@@ -1,16 +1,19 @@
 [Unit]
 Description=Labgrid Exporter
-After=network.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
+Environment="PYTHONUNBUFFERED=1"
+# Should contain LG_CROSSBAR configuration
+EnvironmentFile=-/etc/environment
 ExecStart=/path/to/labgrid/venv/bin/labgrid-exporter /etc/labgrid/exporter.yaml
-Restart=on-abort
-User=labgrid
-Group=labgrid
+Restart=on-failure
+RestartForceExitStatus=100
+RestartSec=30
+DynamicUser=yes
 # Adjust to your distribution (most often "dialout" or "tty")
 SupplementaryGroups=dialout
-CacheDirectory=labgrid
-CacheDirectoryMode=1775
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
**Description**
The labgrid exporter needs to talk to the coordinator (crossbar), so start after the network-online.target instead of after the network.target. Also add a weak requirement for that target to make sure it is actually started.

Adding `PYTHONUNBUFFERED=1` [1] to the environment forces the stdout and stderr streams to be unbuffered, so all logs end up in the journal instantly.

Try to read environment variables from `/etc/environment`. This is the place where `LG_CROSSBAR` should be defined. Don't fail if that file does not exist, though.

Soften the restart criteria by using `on-failure` instead of `on-abort`, which covers more failure scenarios, see [2]. The exporter exits with exit code 100 if it loses the connection to the coordinator. While this is already covered by `on-failure`, add it nonetheless for documentation purposes and users that might adjust `Restart=`. Also increase the time to sleep before restarting the exporter on failure to prevent system load on failure loops.

Replace explicit `User=`/`Group=` by `DynamicUser=yes`. The labgrid user might not exist and there is no requirement for a specific user anyway. Since the exporter does not write any state, drop `CacheDirectory=`/`CacheDirectoryMode=` altogether. The caching directories on the exporter host are created by labgrid's `contrib/systemd/tmpfiles.d/labgrid.conf`. This directory is used by labgrid's ManagedFile, which is not part of the exporter.

Finally, add a hint where to get the crossbar config template from.

[1] https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUNBUFFERED
[2] https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=


**Checklist**
- [x] PR has been tested