### PR TITLE
util/atomic: fix UnboundLocalError in atomic_replace()

### DIFF
--- a/labgrid/util/atomic.py
+++ b/labgrid/util/atomic.py
@@ -2,6 +2,7 @@ import os
 import tempfile
 
 def atomic_replace(filename, data):
+    f = None
     try:
         with tempfile.NamedTemporaryFile(
                 mode='wb',
@@ -12,7 +13,8 @@ def atomic_replace(filename, data):
             os.fsync(f.fileno())
         os.replace(f.name, filename)
     finally:
-        try:
-            os.unlink(f.name)
-        except FileNotFoundError:
-            pass
+        if f is not None:
+            try:
+                os.unlink(f.name)
+            except FileNotFoundError:
+                pass


### PR DESCRIPTION
**Description**
If the temporary file cannot get created..

```
Traceback (most recent call last):
  File "labgrid/util/atomic.py", line 6, in atomic_replace
    with tempfile.NamedTemporaryFile(
  File "/usr/lib/python3.9/tempfile.py", line 680, in NamedTemporaryFile
    (fd, name) = _mkstemp_inner(dir, prefix, suffix, flags, output_type)
  File "/usr/lib/python3.9/tempfile.py", line 390, in _mkstemp_inner
    fd = _os.open(file, flags, 0o600)
OSError: [Errno 30] Read-only file system: 'tmpgvplm6ok'
```

..the variable `f` is not assigned..

```
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "labgrid/remote/coordinator.py", line 292, in poll
    await self._poll_step()
  File "labgrid/remote/coordinator.py", line 258, in _poll_step
    await self.save()
  File "labgrid/remote/coordinator.py", line 312, in save
    await loop.run_in_executor(None, atomic_replace, 'resources.yaml', resources)
  File "/usr/lib/python3.9/concurrent/futures/thread.py", line 52, in run
    result = self.fn(*self.args, **self.kwargs)
  File "labgrid/util/atomic.py", line 16, in atomic_replace
    os.unlink(f.name)
UnboundLocalError: local variable 'f' referenced before assignment
```

While this situation stems from a configuration error, we should still avoid UnboundLocalErrors. Fix this by setting f initially to None and check for this in the finally clause.

**Checklist**
- [x] PR has been tested

Fixes #480