### PR TITLE
sshdriver: Fix control socket cleanup race

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -480,9 +480,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         if res != 0:
             self.logger.info("Socket already closed")
-        shutil.rmtree(self.tmpdir)
 
         self.process.communicate()
+
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def _start_keepalive(self):
         """Starts a keepalive connection via the own or external master."""


### PR DESCRIPTION

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Cleanup of the temporary directory should not occur until after SSH has
exited, as SSH will delete the control socket which can race with the
shutil.rmtree() and result in strange errors like:

    tools/labgrid/venv/lib/python3.10/site-packages/labgrid/environment.py:65: in cleanup
        self.targets[target].cleanup()
    tools/labgrid/venv/lib/python3.10/site-packages/labgrid/target.py:555: in cleanup
        self.deactivate_all_drivers()
    tools/labgrid/venv/lib/python3.10/site-packages/labgrid/target.py:505: in deactivate_all_drivers
        self.deactivate(drv)
    tools/labgrid/venv/lib/python3.10/site-packages/labgrid/target.py:498: in deactivate
        client.on_deactivate()
    tools/labgrid/venv/lib/python3.10/site-packages/labgrid/driver/sshdriver.py:65: in on_deactivate
        self._cleanup_own_master()
    tools/labgrid/venv/lib/python3.10/site-packages/labgrid/driver/sshdriver.py:483: in _cleanup_own_master
        shutil.rmtree(self.tmpdir)
    /usr/lib/python3.10/shutil.py:724: in rmtree
        _rmtree_safe_fd(fd, path, onerror)
    /usr/lib/python3.10/shutil.py:680: in _rmtree_safe_fd
        onerror(os.unlink, fullname, sys.exc_info())

    ...

    FileNotFoundError: [Errno 2] No such file or directory: 'control-172.16.6.0%enx5c857e32b0e4'

Also ignore errors while running shutil.rmtree() since it a best effort
cleanup

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
