### PR TITLE
contrib/systemd/labgrid-exporter: add plugdev to SupplementaryGroups

### DIFF
--- a/contrib/systemd/labgrid-exporter.service
+++ b/contrib/systemd/labgrid-exporter.service
@@ -13,7 +13,7 @@ RestartForceExitStatus=100
 RestartSec=30
 DynamicUser=yes
 # Adjust to your distribution (most often "dialout" or "tty")
-SupplementaryGroups=dialout
+SupplementaryGroups=dialout plugdev
 
 [Install]
 WantedBy=multi-user.target

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -384,7 +384,8 @@ Follow these instructions to install the systemd files on your machine(s):
 #. Adjust the ``SupplementaryGroups`` option in the
    :file:`labgrid-exporter.service` file to your distribution so that the
    exporter gains read and write access on TTY devices (for ``ser2net``); most
-   often, this group is called ``dialout`` or ``tty``.
+   often, these groups are called ``dialout``, ``plugdev`` or ``tty``.
+   Depending on your udev configuration, you may need multiple groups.
 #. Set the coordinator URL the exporter should connect to by overriding the
    exporter service file; i.e. execute ``systemctl edit
    labgrid-exporter.service`` and add the following snippet:


### PR DESCRIPTION
**Description**
Some USB TTY use group dailout, while others use plugdev. Allow access to both.

**Checklist**
- [x] PR has been tested