### PR TITLE
Unique resource name per resource class

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -630,17 +630,17 @@ class ClientSession(ApplicationSession):
         resources = {}
         for resource_path in place.acquired_resources:
             match = place.getmatch(resource_path)
-            (exporter, group_name, _, resource_name) = resource_path
+            (exporter, group_name, cls, resource_name) = resource_path
             name = resource_name
             if match.rename:
                 name = match.rename
-            resources[name] = self.resources[exporter][group_name][resource_name]
+            resources[(name, cls)] = self.resources[exporter][group_name][resource_name]
         return resources
 
     def get_target_config(self, place):
         config = {}
         resources = config['resources'] = []
-        for name, resource in self.get_target_resources(place).items():
+        for (name, _), resource in self.get_target_resources(place).items():
             args = OrderedDict()
             if name != resource.cls:
                 args['name'] = name

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -50,7 +50,7 @@ class RemotePlaceManager(ResourceManager):
         place = self.session.get_place(remote_place.name)  # pylint: disable=no-member
         resource_entries = self.session.get_target_resources(place)  # pylint: disable=no-member
         expanded = []
-        for resource_name, resource_entry in resource_entries.items():
+        for (resource_name, _), resource_entry in resource_entries.items():
             new = target_factory.make_resource(
                 remote_place.target, resource_entry.cls, resource_name, resource_entry.args)
             new.parent = remote_place

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -168,6 +168,13 @@ def exporter(tmpdir, crossbar):
     Broken:
         RawSerialPort:
           port: 'none'
+    Many:
+        NetworkSerialPort:
+          host: 'localhost'
+          port: 4000
+        NetworkService:
+          address: "192.168.0.1"
+          username: "root"
     """
     )
     spawn = pexpect.spawn(

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -464,3 +464,31 @@ def test_reservation_custom_config(place, exporter, tmpdir):
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
+
+def test_same_name_resources(place, exporter, tmpdir):
+    with pexpect.spawn('python -m labgrid.remote.client -p test add-named-match "testhost/Many/NetworkService" "samename"') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test add-named-match "testhost/Many/NetworkSerialPort" "samename"') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test env') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        assert "NetworkService".encode("utf-8") in spawn.before.replace(b'\r\n', b'\n'), spawn.before.strip()
+        assert "NetworkSerialPort".encode("utf-8") in spawn.before.replace(b'\r\n', b'\n'), spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()


### PR DESCRIPTION
**Description**
Allow using the same resource name across classes.
I tested it in my setup and created a test that fails without this fix.

**Checklist**
- [ ] Documentation for the feature
  - No documentation on this fix
- [X] Tests for the feature 
- [X] PR has been tested

Fixes #1173
