### PR TITLE
remote/client: print full resource identifier on monitor

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -117,13 +117,13 @@ class ClientSession(ApplicationSession):
             group[resource_name].data = resource
         if self.monitor:
             if resource and not old:
-                print(f"Resource {exporter}/{group_name}/{resource_name} created: {resource}")
+                print(f"Resource {exporter}/{group_name}/{resource['cls']}/{resource_name} created: {resource}")
             elif resource and old:
-                print(f"Resource {exporter}/{group_name}/{resource_name} changed:")
+                print(f"Resource {exporter}/{group_name}/{resource['cls']}/{resource_name} changed:")
                 for k, v_old, v_new in diff_dict(flat_dict(old), flat_dict(resource)):
                     print(f"  {k}: {v_old} -> {v_new}")
             else:
-                print(f"Resource {exporter}/{group_name}/{resource_name} deleted")
+                print(f"Resource {exporter}/{group_name}/{resource['cls']}/{resource_name} deleted")
 
     async def on_place_changed(self, name, config):
         if not config:


### PR DESCRIPTION
**Description**
`labgrid-client monitor` prints resources as `<exporter>/<group>/<name>`, while the resource match pattern has the format `<exporter>/<group>/<class>/<name>`. The `/<name>` is optional.

So in `labgrid-client monitor`, the class name is missing. This is confusing. Resource match patterns cannot be copy/pasted into `labgrid-client add-match` or `labgrid-client add-named-match`.

Fix that by printing the full resource identifier for the monitor subcommand.

I've checked all code locations in labgrid using resource identifiers, everything else uses the correct notation. This shouldn't break anything.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] PR has been tested

Fixes #1177