### PR TITLE
driver/usbloader: enable print_on_silent_log for subprocess calls

### DIFF
--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -42,7 +42,8 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
         mf.sync_to_resource()
 
         processwrapper.check_output(
-            self.loader.command_prefix + [self.tool, "0", mf.get_remote_path()]
+            self.loader.command_prefix + [self.tool, "0", mf.get_remote_path()],
+            print_on_silent_log=True
         )
 
 
@@ -79,7 +80,8 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
 
         processwrapper.check_output(
             self.loader.command_prefix +
-            [self.tool, "-p", str(self.loader.path), "-c", mf.get_remote_path()]
+            [self.tool, "-p", str(self.loader.path), "-c", mf.get_remote_path()],
+            print_on_silent_log=True
         )
 
 
@@ -120,7 +122,8 @@ class RKUSBDriver(Driver, BootstrapProtocol):
             try:
                 processwrapper.check_output(
                     self.loader.command_prefix +
-                    [self.tool, 'db', mf.get_remote_path()]
+                    [self.tool, 'db', mf.get_remote_path()],
+                    print_on_silent_log=True
                 )
                 break
             except subprocess.CalledProcessError:
@@ -137,7 +140,8 @@ class RKUSBDriver(Driver, BootstrapProtocol):
             try:
                 processwrapper.check_output(
                     self.loader.command_prefix +
-                    [self.tool, 'wl', '0x40', mf.get_remote_path()]
+                    [self.tool, 'wl', '0x40', mf.get_remote_path()],
+                    print_on_silent_log=True
                 )
                 break
             except subprocess.CalledProcessError:
@@ -180,7 +184,8 @@ class UUUDriver(Driver, BootstrapProtocol):
         cmd = ['-b', self.script] if self.script else []
 
         processwrapper.check_output(
-            self.loader.command_prefix + [self.tool] + cmd + [mf.get_remote_path()]
+            self.loader.command_prefix + [self.tool] + cmd + [mf.get_remote_path()],
+            print_on_silent_log=True
         )
 
 
@@ -225,5 +230,6 @@ class BDIMXUSBDriver(Driver, BootstrapProtocol):
                 f"--bus={self.loader.busnum}",
                 f"--device={self.loader.devnum}",
                 mf.get_remote_path(),
-            ]
+            ],
+            print_on_silent_log=True
         )


### PR DESCRIPTION
The diagnostic output of these tools is often useful for development and debugging.
