### PR TITLE
drivers, resource: implement get_bound_resources()

### DIFF
--- a/labgrid/binding.py
+++ b/labgrid/binding.py
@@ -85,6 +85,12 @@ class BindingMixin:
         """
         pass
 
+    def get_bound_resources(self):
+        """
+        Called by the Target to find the correct driver corresponding to a resource
+        """
+        raise NotImplementedError("get_bound_resources not implemented!")
+
     @classmethod
     def check_active(cls, func):
         @wraps(func)

--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -67,6 +67,16 @@ class Driver(BindingMixin):
         """
         return False
 
+    def get_bound_resources(self):
+        """Return the bound resources for a driver
+
+        This recursively calls all suppliers and combines the sets of returned resources.
+        """
+        res = set()
+        for supplier in self.suppliers:
+            res |= supplier.get_bound_resources()
+        return res
+
 def check_file(filename, *, command_prefix=[]):
     if subprocess.call(command_prefix + ['test', '-r', filename]) != 0:
         raise ExecutionError(f"File {filename} is not readable")

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -61,6 +61,12 @@ class Resource(BindingMixin):
         if managed_parent:
             managed_parent.poll()
 
+    def get_bound_resources(self):
+        """
+        Resources only return themselves in a set, drivers will combine those sets.
+        """
+        return {self}
+
 
 @attr.s(eq=False)
 class NetworkResource(Resource):

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -154,7 +154,7 @@ class Target:
             self.await_resources(found)
         return found[0]
 
-    def _get_driver(self, cls, *, name=None, activate=True, active=False):
+    def _get_driver(self, cls, *, name=None, resource=None, activate=True, active=False):
         assert not (activate is True and active is True)
 
         found = []
@@ -164,6 +164,8 @@ class Target:
 
         for drv in self.drivers:
             if not isinstance(drv, cls):
+                continue
+            if resource and resource not in drv.get_bound_resources():
                 continue
             if name and drv.name != name:
                 other_names.append(drv.name)
@@ -206,7 +208,7 @@ class Target:
             self.activate(found[0])
         return found[0]
 
-    def get_active_driver(self, cls, *, name=None):
+    def get_active_driver(self, cls, *, name=None, resource=None):
         """
         Helper function to get the active driver of the target.
         Returns the active driver found, otherwise None.
@@ -214,10 +216,11 @@ class Target:
         Arguments:
         cls -- driver-class to return as a resource
         name -- optional name to use as a filter
+        resource -- optional resource to use as a filter
         """
-        return self._get_driver(cls, name=name, activate=False, active=True)
+        return self._get_driver(cls, name=name, resource=resource, activate=False, active=True)
 
-    def get_driver(self, cls, *, name=None, activate=True):
+    def get_driver(self, cls, *, name=None, resource=None, activate=True):
         """
         Helper function to get a driver of the target.
         Returns the first valid driver found, otherwise None.
@@ -225,9 +228,10 @@ class Target:
         Arguments:
         cls -- driver-class to return as a resource
         name -- optional name to use as a filter
+        resource -- optional resource to use as a filter
         activate -- activate the driver (default True)
         """
-        return self._get_driver(cls, name=name, activate=activate)
+        return self._get_driver(cls, name=name, resource=resource, activate=activate)
 
     def get_strategy(self):
         """

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -527,3 +527,67 @@ def test_allow_optional_no_double_same_protocol_by_different_protocols(target):
     assert s.b is None
     assert s.c == d1
     assert s.d == d2
+
+def test_get_bound_resources(target):
+    class AResource(Resource):
+        pass
+
+    class ADriver(Driver):
+        bindings = {
+            "a": AResource,
+        }
+
+    class BDriver(Driver):
+        bindings = {
+            "a": ADriver,
+        }
+
+    aresource = AResource(target, "aresource")
+    adriver = ADriver(target, "adriver")
+    bdriver = BDriver(target, "bdriver")
+
+    assert bdriver.get_bound_resources() == {aresource}
+    assert adriver.get_bound_resources() == {aresource}
+
+    assert target.get_driver(ADriver, resource=aresource) 
+
+def test_get_bound_multiple_resources(target):
+    class AResource(Resource):
+        pass
+
+    class BResource(Resource):
+        pass
+
+    class ADriver(Driver):
+        bindings = {
+            "a": AResource,
+        }
+
+    class BDriver(Driver):
+        bindings = {
+            "b": BResource,
+        }
+
+    class CDriver(Driver):
+        bindings = {
+            "a": ADriver,
+            "b": BDriver,
+        }
+
+    aresource = AResource(target, "aresource")
+    bresource = BResource(target, "bresource")
+    adriver = ADriver(target, "adriver")
+    bdriver = BDriver(target, "bdriver")
+    cdriver = CDriver(target, "bdriver")
+
+    assert adriver.get_bound_resources() == {aresource}
+    assert bdriver.get_bound_resources() == {bresource}
+    assert cdriver.get_bound_resources() == {aresource, bresource}
+
+    assert target.get_driver(ADriver, resource=aresource) 
+    assert target.get_driver(BDriver, resource=bresource) 
+    assert target.get_driver(CDriver, resource=aresource) 
+
+    assert target.get_active_driver(ADriver, resource=aresource) 
+    assert target.get_active_driver(BDriver, resource=bresource) 
+    assert target.get_active_driver(CDriver, resource=aresource) 


### PR DESCRIPTION
**Description**
Implement a new get_bound_resources() function which returns the underlying resources a driver is bound to. This can also be called on Resources, but they will just return themselves in a set.

Add a new keyword argument to get_driver/get_active_driver(), which allows the user to retrieve a driver using a specific resource it's bound to.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested