### PR TITLE
pyproject.toml: move pysnmp -> pysnmp-lextudio, drop unnecessary pysnmp-mibs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,10 +63,7 @@ pyvisa = [
     "pyvisa>=1.11.3",
     "PyVISA-py>=0.5.2",
 ]
-snmp = [
-    "pysnmp>=4.4.12",
-    "pysnmp-mibs>=0.1.6",
-]
+snmp = ["pysnmp-lextudio>=4.4.12"]
 vxi11 = ["python-vxi11>=0.9"]
 xena = ["xenavalkyrie>=3.0.1"]
 deb = [
@@ -77,8 +74,7 @@ deb = [
     "onewire>=0.2",
 
     # labgrid[snmp]
-    "pysnmp>=4.4.12",
-    "pysnmp-mibs>=0.1.6",
+    "pysnmp-lextudio>=4.4.12",
 ]
 dev = [
     # references to other optional dependency groups
@@ -111,8 +107,7 @@ dev = [
     "PyVISA-py>=0.5.2",
 
     # labgrid[snmp]
-    "pysnmp>=4.4.12",
-    "pysnmp-mibs>=0.1.6",
+    "pysnmp-lextudio>=4.4.12",
 
     # labgrid[vxi11]
     "python-vxi11>=0.9",


### PR DESCRIPTION
**Description**
The original author of pysnmp passed away and the lextudio folks took over maintenance [1]. A request to take over the pysnmp PyPi project is pending [2]. Let's move the the maintained fork rather now than later.

While at it, drop the pysnmp-mibs dependency altogether, because this is no longer required for pysnmp>=4.3 [3].

[1] https://github.com/etingof/pysnmp/issues/429
[2] https://github.com/pypi/support/issues/2420
[3] https://github.com/lextudio/pysnmp-mibs/blob/master/README.md

**Checklist**
- [ ] PR has been tested (CI only)