### PR TITLE
ubootstrategy: add support for initial state

### DIFF
--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -57,3 +57,16 @@ class UBootStrategy(Strategy):
         else:
             raise StrategyError(f"no transition found from {self.status} to {status}")
         self.status = status
+
+    def force(self, status):
+        if not isinstance(status, Status):
+            status = Status[status]
+        if status == Status.off:
+            self.target.activate(self.power)
+        elif status == Status.uboot:
+            self.target.activate(self.uboot)
+        elif status == Status.shell:
+            self.target.activate(self.shell)
+        else:
+            raise StrategyError("can not force state {}".format(status))
+        self.status = status


### PR DESCRIPTION
**Description**

Update the uboot strategy to feature initial state, usable from pytest and labgrid-client.
Unnecessary actions to reach the requested state are not performed.

Tested with labgrid-client in my setup, transitioning:
- from off to uboot with initial state: off
- from uboot to shell with initial state: uboot

**Checklist**
- [ ] Documentation for the feature
Documentation already present
- [X] PR has been tested
Manual tests in my setup
- [ ] Man pages have been regenerated
No man page impacted, this can serve as an example to implement a strategy with initial state support

