### PR TITLE
bootloader: detect boot

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1789,11 +1789,15 @@ Arguments:
   - init_commands (tuple): optional, tuple of commands to execute after matching the
     prompt
   - password_prompt (str, default="enter Password: "): regex to match the U-Boot password prompt
+  - boot_expression (regex, default="[\n]U-Boot 20\\d+"): regex to match the U-Boot start string
   - bootstring (str): optional, regex to match on Linux Kernel boot
   - boot_command (str, default="run bootcmd"): boot command for booting target
   - boot_commands (dict, default={}): boot commands by name for LinuxBootProtocol boot command
   - login_timeout (int, default=30): timeout for login prompt detection in seconds
   - boot_timeout (int, default=30): timeout for initial Linux Kernel version detection
+
+Attribute:
+  - boot_detected (bool, defaul=False): boot_expression seen after driver activation
 
 SmallUBootDriver
 ~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1872,8 +1872,13 @@ Arguments:
   - interrupt (str, default="\\n"): string to interrupt autoboot (use "\\x03" for CTRL-C)
   - bootstring (regex, default="Linux version \\d"): regex that indicating that the Linux Kernel is
     booting
+  - boot_expression (regex, default="[\n]barebox 20\d+"): string that indicates that Barebox is
+    starting
   - password (str): optional, password to use for access to the shell
   - login_timeout (int, default=60): timeout for access to the shell
+
+Attribute:
+  - boot_detected (bool, defaul=False): boot_expression seen after driver activation
 
 ExternalConsoleDriver
 ~~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_bareboxdriver.py
+++ b/tests/test_bareboxdriver.py
@@ -7,6 +7,16 @@ from labgrid.protocol import CommandProtocol, LinuxBootProtocol
 from labgrid.driver import ExecutionError
 
 
+def _get_active_barebox(target_with_fakeconsole, mocker):
+    t = target_with_fakeconsole
+    d = BareboxDriver(t, "barebox")
+    d = t.get_driver(BareboxDriver, activate=False)
+    # mock for d._run('echo $global.loglevel')
+    d._run = mocker.MagicMock(return_value=(['7'], [], 0))
+    t.activate(d)
+    return d
+
+
 class TestBareboxDriver:
     def test_create(self):
         t = Target('dummy')
@@ -17,12 +27,7 @@ class TestBareboxDriver:
         assert (isinstance(d, LinuxBootProtocol))
 
     def test_barebox_run(self, target_with_fakeconsole, mocker):
-        t = target_with_fakeconsole
-        d = BareboxDriver(t, "barebox")
-        d = t.get_driver(BareboxDriver, activate=False)
-        # mock for d._run('echo $global.loglevel')
-        d._run = mocker.MagicMock(return_value=(['7'], [], 0))
-        t.activate(d)
+        d = _get_active_barebox(target_with_fakeconsole, mocker)
         d._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = d.run_check("test")
         assert res == ['success']
@@ -30,14 +35,27 @@ class TestBareboxDriver:
         assert res == (['success'], [], 0)
 
     def test_barebox_run_error(self, target_with_fakeconsole, mocker):
-        t = target_with_fakeconsole
-        d = BareboxDriver(t, "barebox")
-        d = t.get_driver(BareboxDriver, activate=False)
-        # mock for d._run('echo $global.loglevel')
-        d._run = mocker.MagicMock(return_value=(['7'], [], 0))
-        t.activate(d)
+        d = _get_active_barebox(target_with_fakeconsole, mocker)
         d._run = mocker.MagicMock(return_value=(['error'], [], 1))
         with pytest.raises(ExecutionError):
             res = d.run_check("test")
         res = d.run("test")
         assert res == (['error'], [], 1)
+
+    def test_barebox_reset(self, target_with_fakeconsole, mocker):
+        d = _get_active_barebox(target_with_fakeconsole, mocker)
+
+        d.boot_expression = "[\n]barebox 2345"
+        d.prompt = prompt = ">="
+        d._check_prompt = mocker.MagicMock()
+        d.console.rxq.extend([prompt.encode(), b"\nbarebox 2345"])
+        d.reset()
+
+        assert d.console.txq.pop() == b"reset\n"
+        assert d._status == 1
+        assert d.boot_detected
+
+        d.console.rxq.append(prompt.encode())
+        with pytest.raises(ExecutionError):
+            d.reset()
+


### PR DESCRIPTION
The boot_expression feature for u-boot was deprecated to sync barebox with features and to allow to connect to a running bootloader.

Readd the feature for both bootloaders and use the check only to set the `boot_detected` flag.
So after getting a prompt we can check if the bootloader runs trough a reboot.
Show this in the 'reset' method.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [X] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [X] PR has been tested on uboot
- [ ] PR has been tested on barebox
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
