### PR TITLE
qemudriver: Handle Virtio GL change in 6.1.0

### DIFF
--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -60,14 +60,20 @@ def qemu_mock(mocker):
     socket_mock = mocker.patch('socket.socket')
     socket_mock.return_value.accept.return_value = mocker.MagicMock(), ''
 
+@pytest.fixture
+def qemu_version_mock(mocker):
+    run_mock = mocker.patch('subprocess.run')
+    run_mock.return_value.returncode = 0
+    run_mock.return_value.stdout = "QEMU emulator version 4.2.1"
+
 def test_qemu_instance(qemu_target, qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
 
-def test_qemu_activate_deactivate(qemu_target, qemu_driver):
+def test_qemu_activate_deactivate(qemu_target, qemu_driver, qemu_version_mock):
     qemu_target.activate(qemu_driver)
     qemu_target.deactivate(qemu_driver)
 
-def test_qemu_on_off(qemu_target, qemu_driver, qemu_mock):
+def test_qemu_on_off(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
     qemu_target.activate(qemu_driver)
 
     qemu_driver.on()
@@ -75,7 +81,7 @@ def test_qemu_on_off(qemu_target, qemu_driver, qemu_mock):
 
     qemu_target.deactivate(qemu_driver)
 
-def test_qemu_read_write(qemu_target, qemu_driver, qemu_mock):
+def test_qemu_read_write(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
     qemu_target.activate(qemu_driver)
 
     qemu_driver.on()


### PR DESCRIPTION
Starting with version 6.1.0, the QEMU command line argument to enable virtio with VirGL support was changed from "-vga virtio" to "-device virtio-vgal-gl". To correctly handle this, scrape the QEMU version number from the command output and use it to pass the correct arguments.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
