### PR TITLE
Fix stat command for MacOS

### DIFF
--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -2,6 +2,7 @@ import hashlib
 import logging
 import os
 import subprocess
+import platform
 
 import attr
 
@@ -88,8 +89,15 @@ class ManagedFile:
         self._on_nfs_cached = False
 
         fmt = "inode=%i,size=%s,modified=%Y"
-        local = subprocess.run(["stat", "--format", fmt, self.local_path],
-                               stdout=subprocess.PIPE)
+        # The stat command is very different on MacOs
+        if platform.system() == 'Darwin':
+            darwin_fmt = "inode=%i,size=%z,modified=%m"
+            local = subprocess.run(["stat", "-f", darwin_fmt, self.local_path],
+                                   stdout=subprocess.PIPE)
+        else:
+            local = subprocess.run(["stat", "--format", fmt, self.local_path],
+                                   stdout=subprocess.PIPE)
+
         if local.returncode != 0:
             self.logger.debug("local: stat: unsuccessful error code %d", local.returncode)
             return False

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -2,7 +2,7 @@ import hashlib
 import logging
 import os
 import subprocess
-import platform
+from importlib import import_module
 
 import attr
 
@@ -90,6 +90,7 @@ class ManagedFile:
 
         fmt = "inode=%i,size=%s,modified=%Y"
         # The stat command is very different on MacOs
+        platform = import_module('platform')
         if platform.system() == 'Darwin':
             darwin_fmt = "inode=%i,size=%z,modified=%m"
             local = subprocess.run(["stat", "-f", darwin_fmt, self.local_path],


### PR DESCRIPTION
**Description**

The managedfile class uses the 'stat' command locally, which has a different syntax on MacOS.  Everything otherwise seems to work quite well on MacOS.  Just added different arguments when using MacOS.

**Checklist**
- [x] PR has been tested