### PR TITLE
remote: Expose tags in RemotePlace

### DIFF
--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import attr
@@ -62,6 +63,7 @@ class RemotePlaceManager(ResourceManager):
             expanded.append(new)
         self.logger.debug("expanded remote resources for place %s: %s", remote_place.name, expanded)
         remote_place.avail = True
+        remote_place.tags = copy.deepcopy(place.tags)
 
     def poll(self):
         import asyncio
@@ -97,6 +99,7 @@ class RemotePlace(ManagedResource):
 
     def __attrs_post_init__(self):
         self.timeout = 10.0
+        self.tags = {}
         super().__attrs_post_init__()
 
 @attr.s(eq=False)

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -286,12 +286,16 @@ def test_remoteplace_target(place_acquire, tmpdir):
     t = e.get_target("test1")
     t.await_resources(t.resources)
 
+    remote_place = t.get_resource("RemotePlace")
+    assert remote_place.tags == {"board": "bar"}
+
 def test_remoteplace_target_without_env(request, place_acquire):
     from labgrid import Target
     from labgrid.resource import RemotePlace
 
     t = Target(request.node.name)
-    RemotePlace(t, name="test")
+    remote_place = RemotePlace(t, name="test")
+    assert remote_place.tags == {"board": "bar"}
 
 def test_resource_conflict(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test2 create') as spawn:


### PR DESCRIPTION
Exposes the place tags in the RemotePlace. This allows persistent data to be stored in the tags and retrieved by tests, for example unique MAC address that need to be programmed to a device after flashing

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
