### PR TITLE
fix sftp option for scp

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Bug fixes in 23.1
   ERROR, INFO and similar log notifiers.
 - Fix named SSH lookups in conjunction with an environment file in
   labgrid-client.
+- Fix sftp option issue in SSH driver that caused sftp to only work once per
+  test run.
 
 Breaking changes in 23.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
The option to use sftp was added multiple times when using SSHDriver::put() and SSHDriver::get() causing them to only work one time. Also adds the sftp option to SSHDriver::scp().

**Description**

The issue was tested on local test site, where multiple files are copied back and forth where "-s" option is required.

The feature works as already described in the documentation.
