### PR TITLE
remote/client: support token with template RemotePlace

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1342,13 +1342,16 @@ def start_session(url, realm, extra):
     return session[0]
 
 def find_role_by_place(config, place):
+    token_role = None
     for role, role_config in config.items():
         resources, _ = target_factory.normalize_config(role_config)
         remote_places = resources.get('RemotePlace', {})
         remote_place = remote_places.get(place)
         if remote_place:
             return role
-    return None
+        if any(remote_place.startswith('+') for remote_place in remote_places.keys()):
+            token_role = role
+    return token_role
 
 def find_any_role_with_place(config):
     for role, role_config in config.items():


### PR DESCRIPTION
**Description**
Using a template for RemotePlace is very useful to avoid repetition.
This change adds support for token, when LG_PLACE == + or +TOKEN.
```
      RemotePlace:
        name: !template $LG_PLACE
```

The role containing the `!template $LG_PLACE` will be used if no other match is found.

It's a first step, one can imagine supporting more complex patterns like (see #1194):
```
      RemotePlace:
        name: !template "$LG_PLACE-bbb"
```

**Checklist**
- [ ] Documentation for the feature
- [X] Tests for the feature 
 - test added in tests/test_crossbar.py
- [X] PR has been tested
 - I tested local with the setup described in #1194

Partially fixes #1194
