### PR TITLE
Fix handling disabled pytest logging plugin

### DIFF
--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -60,7 +60,8 @@ def pytest_configure(config):
     config.add_cleanup(StepLogger.stop)
 
     logging_plugin = config.pluginmanager.getplugin('logging-plugin')
-    configure_pytest_logging(config, logging_plugin)
+    if logging_plugin:
+        configure_pytest_logging(config, logging_plugin)
 
     config.addinivalue_line("markers",
                             "lg_feature: marker for labgrid feature flags")

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -13,7 +13,10 @@ def pytest_cmdline_main(config):
     def set_cli_log_level(level):
         nonlocal config
 
-        current_level = config.getoption("log_cli_level") or config.getini("log_cli_level")
+        try:
+            current_level = config.getoption("log_cli_level") or config.getini("log_cli_level")
+        except ValueError:
+            return
         print(f"current_level: {current_level}")
 
         if isinstance(current_level, str):

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -41,6 +41,11 @@ def test_env_fixture(short_env, short_test):
         spawn.close()
         assert spawn.exitstatus == 0
 
+def test_env_fixture_no_logging(short_env, short_test):
+    with pexpect.spawn(f'pytest -p no:logging --lg-env {short_env} {short_test}') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before
 
 def test_env_old_fixture(short_env, short_test):
     with pexpect.spawn(f'pytest --env-config {short_env} {short_test}') as spawn:


### PR DESCRIPTION
**Description**

Adjust our pytestplugin to handle the case where the logging plugin is disabled.

**Checklist**
- [x] PR has been tested


Fixes #1209 
