### PR TITLE
qemudriver: support looking up qemu executable in PATH

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2378,7 +2378,7 @@ Implements:
   - :any:`PowerProtocol`
 
 Arguments:
-  - qemu_bin (str): reference to the tools key for the QEMU binary
+  - qemu_bin (str): reference to the tools key for the QEMU binary or executable name
   - machine (str): QEMU machine type
   - cpu (str): QEMU cpu type
   - memory (str): QEMU memory size (ends with M or G)

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -129,6 +129,8 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
 
         qemu_bin = self.target.env.config.get_tool(self.qemu_bin)
         if qemu_bin is None:
+            qemu_bin = shutil.which(self.qemu_bin)
+        if qemu_bin is None:
             raise KeyError(
                 "QEMU Binary Path not configured in tools configuration key")
         self._cmd = [qemu_bin]

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -163,7 +163,7 @@ Path to the uuu\-loader binary, used by the UUUDriver.
 See: \fI\%https://github.com/nxp\-imx/mfgtools\fP
 .UNINDENT
 .sp
-The QEMUDriver expects a custom key set via its \fBqemu_bin\fP argument.
+The QEMUDriver accepts a custom key set via its \fBqemu_bin\fP argument.
 See \fI\%https://www.qemu.org/\fP
 .SS TOOLS EXAMPLE
 .sp

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -159,7 +159,7 @@ TOOLS KEYS
     Path to the uuu-loader binary, used by the UUUDriver.
     See: https://github.com/nxp-imx/mfgtools
 
-The QEMUDriver expects a custom key set via its ``qemu_bin`` argument.
+The QEMUDriver accepts a custom key set via its ``qemu_bin`` argument.
 See https://www.qemu.org/
 
 TOOLS EXAMPLE


### PR DESCRIPTION
We currently mandate that a tools key records the full path to the Qemu binary to use. This is unfortunate as not all distros may install e.g. qemu-system-arm into the same location. Resolve this by looking up the qemu_bin key in $PATH if no tools key was found.

**- what do you use the feature for?** Use same YAML across distros
**- how does labgrid benefit as a testing library from the feature?** YAMLs are directly usable on NixOS (which doesn't place Qemu in `/usr/bin`.
**- how did you verify the feature works?** I tested it with tools key, without tools key and with invalid qemu_bin.

**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated