### PR TITLE
Pr changes to support acquisition during test execution

### DIFF
--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -120,6 +120,8 @@ class SerialLoggingReporter:
             "step": self.lastevent.step,
         }
         for source, logger in self.loggers.items():
+            if source not in self.bufs.keys():
+                continue
             data = self.vt100_replace_cr_nl(self.bufs[source])
             if data:
                 logger.log(logging.CONSOLE, self._create_message(self.lastevent, data), extra=extra)

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -48,6 +48,8 @@ class RemotePlaceManager(ResourceManager):
                 self.url = config.get_option('crossbar_url', self.url)
                 self.realm = config.get_option('crossbar_realm', self.realm)
             self._start()
+        else:
+            self.poll()
         place = self.session.get_place(remote_place.name)  # pylint: disable=no-member
         resource_entries = self.session.get_target_resources(place)  # pylint: disable=no-member
         expanded = []

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -293,7 +293,7 @@ def test_remoteplace_target_without_env(request, place_acquire):
     from labgrid import Target
     from labgrid.resource import RemotePlace
 
-    t = Target(request.node.name)
+    t = Target("test")
     remote_place = RemotePlace(t, name="test")
     assert remote_place.tags == {"board": "bar"}
 


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
We want to be able to acquire remote resource during test executions. This PR accommodate to that in repolling the state of the exporters, when a session already exists. 
Additionally this PR modifies the SerialLoggingReporter.flush() method, so it won't throw an exception, when later added serial connections are being tried to flush, but not yet added to the dictionary.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
<!---
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
<!---
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
<!---
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
<!---
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
<!---
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
