### PR TITLE
man/labgrid-device-config: add ykushcmd

### DIFF
--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -161,6 +161,10 @@ See: \fI\%https://github.com/linux\-automation/usbsdmux\fP
 .B \fBuuu\-loader\fP
 Path to the uuu\-loader binary, used by the UUUDriver.
 See: \fI\%https://github.com/nxp\-imx/mfgtools\fP
+.TP
+.B \fBykushcmd\fP
+Path to the ykushcmd binary, used by the YKUSHPowerDriver.
+See: \fI\%https://github.com/Yepkit/ykush\fP
 .UNINDENT
 .sp
 The QEMUDriver expects a custom key set via its \fBqemu_bin\fP argument.

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -159,6 +159,10 @@ TOOLS KEYS
     Path to the uuu-loader binary, used by the UUUDriver.
     See: https://github.com/nxp-imx/mfgtools
 
+``ykushcmd``
+    Path to the ykushcmd binary, used by the YKUSHPowerDriver.
+    See: https://github.com/Yepkit/ykush
+
 The QEMUDriver expects a custom key set via its ``qemu_bin`` argument.
 See https://www.qemu.org/
 


### PR DESCRIPTION
**Description**
The YKUSHPowerDriver uses the ykushcmd binary since #1143.

**Checklist**
- [x] Man pages have been regenerated