### PR TITLE
pytest.stash instead of protected member

### DIFF
--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -7,6 +7,7 @@ from ..remote.client import UserError
 from ..resource.remote import RemotePlace
 from ..util.ssh import sshmanager
 from ..logging import DEFAULT_FORMAT
+from .hooks import LABGRID_ENV_KEY
 
 # pylint: disable=redefined-outer-name
 
@@ -60,7 +61,7 @@ def env(request, record_testsuite_property):
     """Return the environment configured in the supplied configuration file.
     It contains the targets contained in the configuration file.
     """
-    env = request.config._labgrid_env
+    env = request.config.stash[LABGRID_ENV_KEY]
 
     if not env:
         pytest.skip("missing environment config (use --lg-env)")

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -8,6 +8,9 @@ from ..consoleloggingreporter import ConsoleLoggingReporter
 from ..util.helper import processwrapper
 from ..logging import StepFormatter, StepLogger
 
+LABGRID_ENV_KEY = pytest.StashKey[Environment]()
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_cmdline_main(config):
     def set_cli_log_level(level):
@@ -89,7 +92,7 @@ def pytest_configure(config):
         env = Environment(config_file=lg_env)
         if lg_coordinator is not None:
             env.config.set_option('crossbar_url', lg_coordinator)
-    config._labgrid_env = env
+    config.stash[LABGRID_ENV_KEY] = env
 
     processwrapper.enable_logging()
 
@@ -97,7 +100,7 @@ def pytest_configure(config):
 def pytest_collection_modifyitems(config, items):
     """This function matches function feature flags with those found in the
     environment and disables the item if no match is found"""
-    env = config._labgrid_env
+    env = config.stash[LABGRID_ENV_KEY]
 
     if not env:
         return


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
Since pytest 7.0 stash is suggested to be used for storing private information from a plugin.
https://docs.pytest.org/en/7.0.x/how-to/writing_hook_functions.html#storing-data-on-items-across-hook-functions

Tested by running tests using env fixture.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---

<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [X] PR has been tested
