### PR TITLE
remote/client: implement udisks2-using write-files command 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ New Features in 24.0
   to the serial console during testing.
 - The `QEMUDriver` now has an additional ``disk_opts`` property which can be
   used to pass additional options for the disk directly to QEMU
+- labgrid-client now has a ``write-files`` subcommand to copy files onto mass
+  storage devices.
 
 Bug fixes in 24.0
 ~~~~~~~~~~~~~~~~~

--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -769,6 +769,40 @@ _labgrid_client_write_image()
     esac
 }
 
+_labgrid_client_write_files()
+{
+    local cur prev words cword
+    _init_completion || return
+
+    case "$prev" in
+    -w|--wait)
+        ;&
+    -p|--partition)
+        ;&
+    -t|--target-directory)
+        ;&
+    -T)
+        ;&
+    -n|--name)
+        _labgrid_complete match-names "$cur"
+        return
+        ;;
+    esac
+
+    case "$cur" in
+    -*)
+        local options="--wait --partition --target-directory --name $_labgrid_shared_options"
+        COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+        ;;
+    *)
+        local args
+        _labgrid_count_args "@(-w|--wait|-p|--partition|-t|--target-directory|-T|-n|--name)" || return
+
+        _filedir
+        ;;
+    esac
+}
+
 _labgrid_client_reserve()
 {
     _labgrid_client_generic_subcommand "--wait --shell --prio"
@@ -888,6 +922,7 @@ _labgrid_client()
                                audio \
                                tmc \
                                write-image \
+                               write-files \
                                reserve \
                                cancel-reservation \
                                wait \

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -630,7 +630,7 @@ A :any:`NetworkUSBMassStorage` resource describes a USB memory stick or similar
 device available on a remote computer.
 
 The NetworkUSBMassStorage can be used in test cases by calling the
-``write_image()``, and ``get_size()`` functions.
+``write_files()``, ``write_image()``, and ``get_size()`` functions.
 
 SigrokDevice
 ~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -610,6 +610,14 @@ device.
      match:
        ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0-scsi-0:0:0:3'
 
+Writing images to disk requires installation of ``dd`` or optionally
+``bmaptool`` on the same system as the block device.
+
+For mounting the file system and writing into it,
+`PyGObject <https://pygobject.readthedocs.io/>`_ must be installed.
+For Debian, the necessary packages are `python3-gi` and `gir1.2-udisks-2.0`.
+This is not required for writing images to disks.
+
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 

--- a/labgrid/util/agents/udisks2.py
+++ b/labgrid/util/agents/udisks2.py
@@ -1,0 +1,102 @@
+"""
+This module implements mounting file systems via communication with udisksd.
+"""
+import logging
+import time
+
+import gi
+gi.require_version('UDisks', '2.0')
+from gi.repository import GLib, UDisks
+
+class UDisks2Device:
+    UNMOUNT_MAX_RETRIES = 5
+    UNMOUNT_BUSY_WAIT = 3 # s
+
+    def __init__(self, devpath):
+        self._logger = logging.getLogger("Device: ")
+        self.devpath = devpath
+        client = UDisks.Client.new_sync(None)
+
+        manager = client.get_object_manager()
+        for obj in manager.get_objects():
+            block = obj.get_block()
+            if not block:
+                continue
+
+            device_path = block.get_cached_property("Device").get_bytestring().decode('utf-8')
+            if device_path == devpath:
+                self.fs = obj.get_filesystem()
+                if self.fs is None:
+                    raise ValueError(f"no filesystem found on {devpath}")
+
+                return
+
+        raise ValueError(f"No udisks2 device found for {devpath}")
+
+    def mount(self, readonly=False):
+        opts = GLib.Variant('a{sv}', {'options': GLib.Variant('s', 'ro' if readonly else 'rw')})
+
+        try:
+            mountpoint = self.fs.call_mount_sync(opts, None)
+        except GLib.GError as err:
+            if not err.matches(UDisks.error_quark(), UDisks.Error.ALREADY_MOUNTED):
+                raise err
+
+            self._logger.warning('Unmounting lazily and remounting %s...', self.devpath)
+            self._unmount_lazy()
+
+            mountpoint = self.fs.call_mount_sync(opts, None)
+
+        return mountpoint
+
+    def _unmount_lazy(self):
+        opts = GLib.Variant('a{sv}', {'force': GLib.Variant('b', True)})
+
+        try:
+            self.fs.call_unmount_sync(opts, None)
+        except GLib.GError as err:
+            if not err.matches(UDisks.error_quark(), UDisks.Error.NOT_MOUNTED):
+                raise err
+
+    def _unmount(self):
+        opts = GLib.Variant('a{sv}', {'force': GLib.Variant('b', False)})
+
+        for _ in range(self.UNMOUNT_MAX_RETRIES):
+            try:
+                self.fs.call_unmount_sync(opts, None)
+                return
+            except GLib.GError as err:
+                if not err.matches(UDisks.error_quark(), UDisks.Error.DEVICE_BUSY):
+                    raise err
+
+                self._logger.warning('waiting %s s for busy %s',
+                                     self.UNMOUNT_BUSY_WAIT, self.devpath)
+                time.sleep(self.UNMOUNT_BUSY_WAIT)
+
+        raise TimeoutError("Timeout waiting for device to become non-busy")
+
+    def unmount(self, lazy=False):
+        if lazy:
+            self._unmount_lazy()
+        else:
+            self._unmount()
+
+_devs = {}
+
+def _get_udisks2_dev(devpath):
+    if devpath not in _devs:
+        _devs[devpath] = UDisks2Device(devpath=devpath)
+    return _devs[devpath]
+
+def handle_mount(devpath):
+    dev = _get_udisks2_dev(devpath)
+    return dev.mount()
+
+def handle_unmount(devpath, lazy=False):
+    dev = _get_udisks2_dev(devpath)
+    return dev.unmount(lazy=lazy)
+
+methods = {
+    'mount': handle_mount,
+    'unmount': handle_unmount,
+}

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -219,6 +219,8 @@ not at all.
 .sp
 \fBtmc\fP command                 Control a USB TMC device
 .sp
+\fBwrite\-files\fP filename(s)     Copy files onto mass storage device
+.sp
 \fBwrite\-image\fP                 Write images onto block devices (USBSDMux, USB Sticks, …)
 .sp
 \fBreserve\fP filter              Create a reservation

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -211,6 +211,8 @@ LABGRID-CLIENT COMMANDS
 
 ``tmc`` command                 Control a USB TMC device
 
+``write-files`` filename(s)     Copy files onto mass storage device
+
 ``write-image``                 Write images onto block devices (USBSDMux, USB Sticks, …)
 
 ``reserve`` filter              Create a reservation


### PR DESCRIPTION
 **Description**
 
Adds a `write-files` client command to copy files onto mass storage. This is useful for bootloader development for processors with bootroms that load code from file systems (e.g. EFI system partition, OMAP, AT91, Zynq, Raspberry ... etc.). The user interface tries to reproduce the semantics of the UNIX `cp` command as much as possible.
 
 As of now, we can only copy individual files, but not recursively on directories; in the future we might want to extend the `ManagedFile` class to support this use case as well.

This is mostly based on @sephalon's #548, with some sprinkles of my #820, but with `udisksctl` instead of `pmount`.

**How to test**
```
labgrid-client write-files a b      # writes files a, b into /mnt/
labgrid-client write-files -t a b c # writes files b, c into /mnt/a/
labgrid-client write-files -T a b   # writes file  b      to /mnt/a

```

 
 **Checklist**

- [x] Documentation for the feature
- [ ] Tests for the feature
- [x] <s>The arguments and description in</s> doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested
- [x] Man pages have been regenerated