### PR TITLE
driver/bareboxdriver: silence barebox in _await_prompt() and unsilence on boot()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -56,6 +56,8 @@ Breaking changes in 23.1
   slightly. ``-vv`` is now an alias for ``--log-cli-level=INFO`` (effectively
   unchanged), ``-vvv`` is an alias for ``--log-cli-level=CONSOLE``, and
   ``-vvvv`` is an alias for ``--log-cli-level=DEBUG``.
+- The `BareboxDriver` now remembers the log level, sets it to ``0`` on initial
+  activation/reset and recovers it on ``boot()``.
 
 Known issues in 23.1
 ~~~~~~~~~~~~~~~~~~~~

--- a/tests/test_bareboxdriver.py
+++ b/tests/test_bareboxdriver.py
@@ -19,7 +19,10 @@ class TestBareboxDriver:
     def test_barebox_run(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
         d = BareboxDriver(t, "barebox")
-        d = t.get_driver(BareboxDriver)
+        d = t.get_driver(BareboxDriver, activate=False)
+        # mock for d._run('echo $global.loglevel')
+        d._run = mocker.MagicMock(return_value=(['7'], [], 0))
+        t.activate(d)
         d._run = mocker.MagicMock(return_value=(['success'], [], 0))
         res = d.run_check("test")
         assert res == ['success']
@@ -29,7 +32,10 @@ class TestBareboxDriver:
     def test_barebox_run_error(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
         d = BareboxDriver(t, "barebox")
-        d = t.get_driver(BareboxDriver)
+        d = t.get_driver(BareboxDriver, activate=False)
+        # mock for d._run('echo $global.loglevel')
+        d._run = mocker.MagicMock(return_value=(['7'], [], 0))
+        t.activate(d)
         d._run = mocker.MagicMock(return_value=(['error'], [], 1))
         with pytest.raises(ExecutionError):
             res = d.run_check("test")


### PR DESCRIPTION
**Description**
Log messages such as..
```
eth0: 1000Mbps full duplex link detected
```
..are logged asynchronously. This confuses the BareboxDriver.

To fix that, set the log level to "emerg" (0) right after a prompt is detected and recover the previous log level right before booting.

To make the tests run successfully, mock the _run() method before driver activation to act as if `echo $global.loglevel` was run.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested