### PR TITLE
remote/coordinator: fix resetting places to an empty set

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -314,7 +314,7 @@ class CoordinatorComponent(ApplicationSession):
 
     def load(self):
         try:
-            self.place = {}
+            self.places = {}
             with open('places.yaml', 'r') as f:
                 self.places = yaml.load(f.read())
             for placename, config in self.places.items():


### PR DESCRIPTION
**Description**
Fix the typo, so the actually used attribute is reset.

**Checklist**
- [ ] PR has been tested

Fixes 80067be