### PR TITLE
driver/shelldriver: fix status attribute setting

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -143,7 +143,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                 else:
                     # we got a prompt. no need for any further action to
                     # activate this driver.
-                    self.status = 1
+                    self._status = 1
                     break
 
             elif index == 1:


### PR DESCRIPTION
**Description**
Since `_check_prompt()` sets the correct `_status` attribute anyway when a login prompt is detected, this only is a problem for cases without login (either because no login is required or it happened before). `get_status()` returns 0 instead of 1 then until `run()` is executed the first time.

Fix this by setting the correct attribute.

**Checklist**
- [ ] PR has been tested

Fixes 822abb3
