### PR TITLE
client: Allow NetworkService to be manually specified

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,8 @@
 Release 23.1 (unreleased)
 ------------------------------------
+- ``labgrid-client (ssh|scp|sshfs|rsync|forward)`` now accept a ``--host`` and
+  ``--password`` argument to allow the user to connect if the place has no
+  NetworkService
 
 New Features in 23.1
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
If a place doesn't have a NetworkService (commonly when the device does some sort of dynamic IP addressing and tests get the IP address at runtime), the user needs to manually specify the username, hostname, port, and password required to SSH into the device. To facilitate this, add a `--host` and `--password` to the labgrid-client command.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
