### PR TITLE
github/workflows: add scheduled test jobs for stable branch

### DIFF
--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        branch: ['master']
+        branch: ['master', 'stable-23.0']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       python-version: ${{ matrix.python-version }}
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master']
+        branch: ['master', 'stable-23.0']
     uses: ./.github/workflows/reusable-unit-tests-docker.yml
     with:
       branch: ${{ matrix.branch }}


### PR DESCRIPTION
**Description**
The stable branch is typically close to the latest release (i.e. what the user will see on `pip install labgrid`). Testing this regularly allows us to notice issues early.
