### PR TITLE
dockerfiles: bump base image bullseye -> bookworm

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim AS labgrid-base
+FROM debian:bookworm-slim AS labgrid-base
 
 LABEL maintainer="eha@deif.com"
 
@@ -9,7 +9,7 @@ COPY ./ /opt/labgrid/
 RUN set -e ;\
     apt update -q=2 ;\
     apt install -q=2 --yes --no-install-recommends python3 python3-dev python3-pip python3-setuptools git build-essential libsnappy-dev ;\
-    pip3 install -U pip;\
+    pip3 install --break-system-packages -U pip;\
     apt clean ;\
     rm -rf /var/lib/apt/lists/* ;\
     git clone https://github.com/vishnubob/wait-for-it.git opt/wait-for-it && cd opt/wait-for-it  && git reset --hard 54d1f0bfeb6557adf8a3204455389d0901652242
@@ -22,8 +22,8 @@ ARG VERSION
 
 RUN set -e ;\
     cd /opt/labgrid ;\
-    pip3 install yq ;\
-    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --no-cache-dir . ;\
+    pip3 install --break-system-packages yq ;\
+    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --break-system-packages --no-cache-dir . ;\
     apt update -q=2 ;\
     apt install -q=2 --yes --no-install-recommends microcom openssh-client rsync jq qemu-system qemu-utils ;\
     apt clean ;\
@@ -41,10 +41,10 @@ ENV CROSSBAR_DIR=/opt/crossbar
 
 RUN set -e ;\
     cd /opt/labgrid ;\
-    pip3 install virtualenv ;\
-    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --no-cache-dir . ;\
+    pip3 install --break-system-packages virtualenv ;\
+    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --break-system-packages --no-cache-dir . ;\
     virtualenv -p python3 crossbar-venv ;\
-    crossbar-venv/bin/pip3 install -r crossbar-requirements.txt ;\
+    crossbar-venv/bin/pip3 install --break-system-packages -r crossbar-requirements.txt ;\
     sed -i "s#^  executable: .*\$#  executable: python3#" .crossbar/config-anonymous.yaml
 
 VOLUME /opt/crossbar
@@ -63,7 +63,7 @@ COPY dockerfiles/exporter/entrypoint.sh /entrypoint.sh
 
 RUN set -e ;\
     cd /opt/labgrid ;\
-    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --no-cache-dir . ;\
+    SETUPTOOLS_SCM_PRETEND_VERSION="$VERSION" pip3 install --break-system-packages --no-cache-dir . ;\
     apt update -q=2 ;\
     apt install -q=2 --yes --no-install-recommends ser2net ;\
     apt clean ;\

--- a/dockerfiles/staging/dut/Dockerfile
+++ b/dockerfiles/staging/dut/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 MAINTAINER "Kasper Revsbech" <mail@krevsbech.dk>
 


### PR DESCRIPTION
**Description**
Update the docker base image from Debian bullseye to bookworm.

**Checklist**
- [x] PR has been tested

See also #1009.