### PR TITLE
github/workflows: do not build scheduled unit tests for stable-23.0

### DIFF
--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11']
-        branch: ['master', 'stable-23.0']
+        branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       python-version: ${{ matrix.python-version }}


### PR DESCRIPTION
**Description**
This partly reverts commit 4e8c906c.

It only makes sense to add stable branches to the scheduled builds once they use the same setup as master. Otherwise CI breaks [1]. The setup changed in #1079 which introduced separating labgrid/crossbar venvs and moved the crossbar dependency to crossbar-requirements.txt. That means we cannot add the stable branch to the scheduled CI tests until the stable branch includes this setup, i.e. starting with stable-23.1.

The setup has no impact on the docker tests, so leave them enabled for stable-23.0.

[1] https://github.com/labgrid-project/labgrid/actions/runs/5462091372

**Checklist**
- [x] PR has been tested

Fixes #1226.