### PR TITLE
util/managedfile: resolve symlinks before comparing NFS paths

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Bug fixes in 23.1
   labgrid-client.
 - Fix sftp option issue in SSH driver that caused sftp to only work once per
   test run.
+- ManagedFile NFS detection heuristic now does symlink resolution on the
+  local host.
 
 Breaking changes in 23.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -31,7 +31,7 @@ class ManagedFile:
     """
     local_path = attr.ib(
         validator=attr.validators.instance_of(str),
-        converter=lambda x: os.path.abspath(str(x))
+        converter=lambda x: os.path.realpath(str(x))
     )
     resource = attr.ib(
         validator=attr.validators.instance_of(Resource),

--- a/tests/test_flashscript.py
+++ b/tests/test_flashscript.py
@@ -2,6 +2,7 @@ import pytest
 import subprocess
 import tempfile
 import attr
+import os
 from pathlib import Path
 from labgrid.driver.flashscriptdriver import FlashScriptDriver
 from labgrid.resource.common import ManagedResource
@@ -69,4 +70,4 @@ def test_argument_device_expansion(target, resource, driver):
 
 def test_argument_file_expansion(target, driver):
     value = capture_argument_expansion(driver, "file.local_path")
-    assert value == "/bin/sh"
+    assert os.path.samefile(value, "/bin/sh")


### PR DESCRIPTION
`ManagedFile` has an optimization to detect if the "local" file is available over NFS at the remote side. In that case, rsync is skipped and get_remote_path will just return the NFS path.

This is done by comparing stat(1) output of the absolute path on local and remote host. If the absolute paths contains symlinks, this comparison may not happen if the remote host doesn't contain the exact same symlinks. Let's avoid this issue by canonicalizing the path.

- what do you use the feature for?

My build directory is symlinked, so I am usually not passing the canonical path to `labgrid-client fastboot flash`

- how does labgrid benefit as a testing library from the feature?

It's faster to read piecewise from NFS than to rsync up-front.

- how did you verify the feature works?

labgrid-client without this patch shows rsync output. With patch, it starts doing fastboot stuff directly.

- if hardware is needed for the feature, which hardware is supported and which hardware did you test with?

No special HW requirement. But exporter is lxatac that has same NFS mounts, but no symlinks.

**Checklist**


- [x] PR has been tested

Fixes #1232
