### PR TITLE
pyproject: use PyYAML 6.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pytest==7.2.2",
     "pyudev==0.22.0",
     "pyusb==1.2.1",
-    "PyYAML==5.4.1",
+    "PyYAML==6.0.1",
     "requests==2.26.0",
     "xmodem==0.4.6",
 ]


### PR DESCRIPTION
With the release of Cython3 the build of PyYAML 5.4.1 is broken [1]. There seems to be no plan to fix 5.4.x branch [2]. Tox tests and a real world example runs fine with 6.0.1

[1] https://github.com/yaml/pyyaml/issues/724
[2] https://github.com/yaml/pyyaml/issues/728

master #1237
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
