### PR TITLE
tests/test_modbusrtudriver: mock serial instead of relying on port=None

### DIFF
--- a/tests/test_modbusrtudriver.py
+++ b/tests/test_modbusrtudriver.py
@@ -24,11 +24,10 @@ def test_resource_with_non_default_argument(target):
 
 def test_driver(target, mocker):
     pytest.importorskip("minimalmodbus")
+    mocker.patch('serial.Serial')
+
     ModbusRTU(target, name=None, port="/dev/tty0", address=10)
     driver = ModbusRTUDriver(target, name=None)
-
-    # Ensure pyserial will not try to open the port
-    driver.resource.port = None
 
     target.activate(driver)
 


### PR DESCRIPTION
**Description**
Since minimalmodbus 2.1.0, minimalmodbus.Instrument() [1] no longer accepts `port=None`. Accepting this was never documented. The idea was that `port=None` would be passed to `serial.Serial(port=None)`, which explicitly allows this [2].

Now that this is no longer allowed, stick to the original `port="/dev/tty0"` in the test and mock `serial.Serial`, so it is not actually opened.

[1] https://minimalmodbus.readthedocs.io/en/stable/apiminimalmodbus.html#minimalmodbus.Instrument
[2] https://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial

**Checklist**
- [x] PR has been tested

Closes #1238
