### PR TITLE
driver/bareboxdriver: run commands with saved log level

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -57,7 +57,8 @@ Breaking changes in 23.1
   unchanged), ``-vvv`` is an alias for ``--log-cli-level=CONSOLE``, and
   ``-vvvv`` is an alias for ``--log-cli-level=DEBUG``.
 - The `BareboxDriver` now remembers the log level, sets it to ``0`` on initial
-  activation/reset and recovers it on ``boot()``.
+  activation/reset and recovers it on ``boot()``. During
+  ``run()``/``run_check()`` the initially detected log level is used.
 
 Known issues in 23.1
 ~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Description**
[1] introduced lowering barebox' log level to 0 (emerg) right after the barebox prompt has been detected and recovering the log level right before booting.

Tests may rely on log output, though. To enable capturing log messages a command may emit, set the log level to the initially remembered level before the command is executed and reset it to 0 (emerg) after the exit code was emitted.

barebox' poller should not run between the echos, so this should be safe. No asynchronous prints are expected to happen during this time.

[1] #1221, 6f7bf661 ("driver/bareboxdriver: silence barebox in _await_prompt() and unsilence on boot()")

**Checklist**
- [x] PR has been tested
- [x] CHANGES.rst has been updated