### PR TITLE
doc/configuration: small fixes

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1654,6 +1654,7 @@ Implements:
 Arguments:
   - boot_expression (str, default="U-Boot 20\\d+"): regex to match the U-Boot start string
   - boot_secret (str, default="a"): secret used to unlock prompt
+  - boot_secret_nolf (bool, default=False): send boot_secret without new line
   - login_timeout (int, default=60): timeout for password/login prompt detection
   - for other arguments, see `UBootDriver`_
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1041,7 +1041,7 @@ Below an example where the local spidev is used.
 Used by:
   - `FlashromDriver`_
 
-NetworkFlashRom
+NetworkFlashrom
 ~~~~~~~~~~~~~~~
 A NetworkFlashrom describes a `Flashrom`_ available on a remote computer.
 


### PR DESCRIPTION
**Description**
Fix NetworkFlashrom class name spelling and document SmallUBootDriver's `boot_secret_nolf` attribute.