### PR TITLE
dockerfiles/dut: fix --chown option

### DIFF
--- a/dockerfiles/staging/dut/Dockerfile
+++ b/dockerfiles/staging/dut/Dockerfile
@@ -15,7 +15,7 @@ RUN set -e ;\
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
     # SSH login fix. Otherwise user is kicked off after login
 
-COPY [--chown=root:root] ./authorized_keys /root/.ssh/authorized_keys
+COPY --chown=root:root ./authorized_keys /root/.ssh/authorized_keys
 
 # As sshd scrubs ENV variables if they are set by the ENV varibale ensure to put the into /etc/profile as shown below
 ENV NOTVISIBLE "in users profile"


### PR DESCRIPTION
**Description**
The docker docs contain [1] these COPY forms:

```
COPY [--chown=<user>:<group>] [--chmod=<perms>] <src>... <dest>
COPY [--chown=<user>:<group>] [--chmod=<perms>] ["<src>",... "<dest>"]
```

Arguments within [ ] are optional. The square brackets are not meant to be part of the actual instruction.

The docker docs [1] mention that "[e]ach <src> may contain wildcards and matching will be done using Go’s filepath.Match rules". Go’s filepath.Match [2] interprets terms in square brackets as a character class. `[--chown=root:root]` must have been interpreted as a valid character class until recently. A couple of days ago, building the "dut" service started failing:

```
  Building dut
  #0 building with "default" instance using docker driver

  #1 [internal] load build definition from Dockerfile
  #1 transferring dockerfile: 924B done
  #1 DONE 0.0s

  #2 [internal] load .dockerignore
  #2 transferring context: 2B done
  #2 DONE 0.0s

  #3 [internal] load metadata for docker.io/library/debian:bookworm-slim
  #3 DONE 0.1s

  #4 [1/4] FROM docker.io/library/debian:bookworm-slim@sha256:89468107e4c2b9fdea2f15fc582bf92c25aa4296a661ca0202f7ea2f4fc3f48c
  #4 CACHED

  #5 [internal] load build context
  #5 transferring context: 56B done
  #5 ERROR: error from sender: invalid includepatterns: []: syntax error in pattern
```

Fix this by dropping the accidental square brackets around the `--chown` option.

[1] https://docs.docker.com/engine/reference/builder/#copy
[2] https://pkg.go.dev/path/filepath#Match

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested

Fixes #540
