### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/.github/workflows/build-and-release.yml
+++ b/.github/workflows/build-and-release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: "3.11"
+        python-version: "3.12"
     - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip build

--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:

--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -1,2 +1,5 @@
-crossbar==21.3.1
-autobahn<=22.4.1
+crossbar==21.3.1; python_version<"3.9"
+# includes https://github.com/crossbario/crossbar/pull/2091
+crossbar @ git+https://github.com/Bastian-Krause/crossbar@bst/python3.12; python_version>="3.9"
+autobahn==22.4.1; python_version<"3.9"
+eth-utils<2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
 ]
 dependencies = [
@@ -216,7 +217,7 @@ signature-mutators = ["labgrid.step.step"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38, py39, py310, py311
+envlist = py38, py39, py310, py311, py312
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
**Description**
[Python 3.12 is expected to be released on 2023-10-02](https://peps.python.org/pep-0693/#release-schedule). Now that [3.12.0-rc1](https://www.python.org/downloads/release/python-3120rc1/) is released and the ABI settled, it's a good time to see what needs fixing. It turns out, labgrid itself works fine, but some dependencies are not ready, yet:

- [ ] crossbar release with:
  - [ ] https://github.com/crossbario/crossbar/pull/2091
  - [x] https://github.com/crossbario/crossbar/pull/2093
- [x] crossbar dependency: wsaccel https://github.com/methane/wsaccel/issues/30 (Python 3.12 compatibility)
- [x] crossbar dependency: aiohttp 3.9.0 release on pypi (Python 3.12 compatibility, see https://github.com/aio-libs/aiohttp/issues/7675)
- [x] crossbar dependency: numpy 1.26.0 release on pypi (Python 3.12 compatibility)
- [x] https://github.com/lextudio/pysnmp/issues/10 (`ModuleNotFoundError: No module named 'asyncore'`)
- [x] pylint 3.0.0 release on pypi (Python 3.12 compatibility, see [v3.0.0a7](https://github.com/pylint-dev/pylint/releases/tag/v3.0.0a7))

This draft PR works around these issues (by using pre-releases, switching from pypi to git URLs, switching to forks).

**Checklist**
- [ ] PR has been tested (currently CI only)
