### PR TITLE
remote/client: do not print deleted resource's class on monitor

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -123,7 +123,7 @@ class ClientSession(ApplicationSession):
                 for k, v_old, v_new in diff_dict(flat_dict(old), flat_dict(resource)):
                     print(f"  {k}: {v_old} -> {v_new}")
             else:
-                print(f"Resource {exporter}/{group_name}/{resource['cls']}/{resource_name} deleted")
+                print(f"Resource {exporter}/{group_name}/???/{resource_name} deleted")
 
     async def on_place_changed(self, name, config):
         if not config:


### PR DESCRIPTION
**Description**
On delete, resource is an empty dictionary:

```
ERROR   labgrid.remote.: ClientSession.onUserError(): "While firing <bound method ClientSession.on_resource_changed of <labgrid.remote.client.ClientSession object at 0x7fcf1cbdff90>> subscribed under 8031289985454517."
Traceback (most recent call last):
  File "/usr/ptx-venvs/labgrid/lib/python3.11/site-packages/txaio/aio.py", line 487, in done
    res = f.result()
          ^^^^^^^^^^
  File "/usr/ptx-venvs/labgrid/lib/python3.11/site-packages/labgrid/remote/client.py", line 126, in on_resource_changed
    print(f"Resource {exporter}/{group_name}/{resource['cls']}/{resource_name} deleted")
                                              ~~~~~~~~^^^^^^^
KeyError: 'cls'
```

This can be reproduced easily by restarting an exporter while running `labgrid-client monitor`.

We could publish the class, but that would only work for new exporters. For now, simply replace the class name with "???".

**Checklist**
- [x] PR has been tested

Fixes #1178