### PR TITLE
Bcudriver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -128,6 +128,27 @@ Arguments:
 Used by:
   - `SerialDriver`_
 
+USBResetPort
++++++++++++++
+Describes the resource required to use the `bcu <https://github.com/nxp-imx/bcu#readme>`_ tool.
+
+.. code-block:: yaml
+
+   USBResetPort:
+     board: 'imx8dxlevk'
+     match:
+        'sys_name': '2-1.3.3'
+
+Arguments:
+  - board (str): is the board type and can be retrieved with ``bcu lsboard``
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_ ;
+    we need the sys_name as the path of the board serial - it can be retrieved
+    with ``bcu lsftdi`` command or from ``dmesg`` of the workstation after
+    you unplug/plug the board serial cable
+
+Used by:
+  - `BCUResetDriver`_
+
 Power Ports
 ~~~~~~~~~~~
 
@@ -1683,6 +1704,38 @@ Arguments:
     booting
   - password (str): optional, password to use for access to the shell
   - login_timeout (int, default=60): timeout for access to the shell
+
+BCUResetDriver
+~~~~~~~~~~~~~~
+BCUResetDriver is the driver that calls  `bcu <https://github.com/nxp-imx/bcu#readme>`_ tool. It runs the following command on the exporter:
+
+.. code-block::
+
+   bcu reset <mode> -board=USBResetPort.board \
+                    -id=USBResetPort.path \
+                    -delay=BCUResetDriver.delay
+
+Binds to:
+  port:
+    - `USBResetPort`_
+
+Implements:
+  - :any:`BootCfgProtocol`
+  - :any:`ResetProtocol`
+
+.. code-block:: yaml
+
+   BCUResetDriver:
+     qspi_cfg: 'spi'
+
+Arguments:
+  - delay (int, default=1000): time in ms before bcu reset
+  - emmc_cfg (str, default="emmc"): boot mode for emmc
+  - sd_cfg (str, default="sd"): boot mode for sd
+  - usb_cfg (str, default="usb"): boot mode for usb serial download
+  - qspi_cfg (str, default=""): boot mode for spi
+
+To find out boot modes for a specific board use ``bcu lsbootmode -board=<board>``
 
 ExternalConsoleDriver
 ~~~~~~~~~~~~~~~~~~~~~

--- a/examples/bcu/bcu_example.py
+++ b/examples/bcu/bcu_example.py
@@ -1,0 +1,36 @@
+import pytest
+
+
+@pytest.fixture()
+def switchcfg(target):
+    # bcu tool needs to be installed on workstation
+    return target.get_driver('BCUResetDriver')
+
+@pytest.fixture()
+def shell(target):
+    s = target.get_driver('ShellDriver')
+    #in case board remained booted from a different test
+    target.deactivate(s)
+    return s
+
+@pytest.mark.lg_feature("SDcard")
+def test_boot_from_sdcard(target, switchcfg, shell):
+    # Note that you need a bootable image already on sd
+    switchcfg.sd()
+    try:
+        target.activate(shell)
+    except:
+        assert False, "Board failed to boot"
+    stdout, stderr, returncode = shell.run('dmesg | grep root=/dev/mmcblk1')
+    assert returncode == 0, "Board booted from wrong environment"
+
+def test_boot_from_emmc(target, switchcfg, shell):
+    # Note that you need a bootable image already on emmc
+    switchcfg.emmc()
+    try:
+        target.activate(shell)
+    except:
+        assert False, "Board failed to boot"
+    stdout, stderr, returncode = shell.run('dmesg | grep root=/dev/mmcblk0')
+    assert returncode == 0, "Board booted from wrong environment"
+

--- a/examples/bcu/local.yaml
+++ b/examples/bcu/local.yaml
@@ -1,0 +1,20 @@
+features:
+  - SDcard
+targets:
+  main:
+    resources:
+      RawSerialPort:
+        port: "/dev/ttyUSB2"
+      USBResetPort:
+        board: 'imx8dxlevk'
+        match:
+            'sys_name': '3-11.3'
+    drivers:
+      SerialDriver: {}
+      BCUResetDriver:
+        qspi_cfg: 'spi'
+      ShellDriver:
+        prompt: 'root@[\w-]+:[^ ]+ '
+        login_prompt: ' login: '
+        username: 'root'
+        login_timeout: 180

--- a/labgrid/driver/resetdriver.py
+++ b/labgrid/driver/resetdriver.py
@@ -3,9 +3,12 @@ import time
 import attr
 
 from ..factory import target_factory
-from ..protocol import DigitalOutputProtocol, ResetProtocol
+from ..protocol import DigitalOutputProtocol, ResetProtocol, BootCfgProtocol
+from ..resource.remote import NetworkUSBResetPort
+from ..resource.udev import USBResetPort
 from ..step import step
 from .common import Driver
+from ..util.helper import processwrapper
 
 @target_factory.reg_driver
 @attr.s(eq=False)
@@ -24,3 +27,61 @@ class DigitalOutputResetDriver(Driver, ResetProtocol):
         self.output.set(True)
         time.sleep(self.delay)
         self.output.set(False)
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class BCUResetDriver(Driver, ResetProtocol, BootCfgProtocol):
+    """BCUResetDriver - Driver using https://github.com/NXPmicro/bcu and board
+    serial port as USBResetPort to reset the target into different states"""
+
+    bindings = {
+       "port": {USBResetPort, NetworkUSBResetPort}, 
+    }
+
+    delay = attr.ib(default=1000, validator=attr.validators.instance_of(int))
+    emmc_cfg = attr.ib(default="emmc", validator=attr.validators.instance_of(str))
+    sd_cfg = attr.ib(default="sd", validator=attr.validators.instance_of(str))
+    usb_cfg = attr.ib(default="usb", validator=attr.validators.instance_of(str))
+    qspi_cfg = attr.ib(default="", validator=attr.validators.instance_of(str))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.tool = 'bcu'
+
+    @Driver.check_active
+    @step()
+    def reset(self, mode=""):
+        cmd = self.port.command_prefix + [
+            self.tool,
+            "reset", mode,
+            "-board={}".format(self.port.board),
+            "-id={}".format(self.port.path),
+            "-delay={}".format(str(self.delay)),
+        ]
+        try:
+            print(str(processwrapper.check_output(cmd).decode()))
+        except subprocess.CalledProcessError as e:
+            raise  
+            
+    @Driver.check_active
+    @step()
+    def sd(self):
+        self.reset(self.sd_cfg)
+
+    @Driver.check_active
+    @step()
+    def emmc(self):
+        self.reset(self.emmc_cfg)
+
+    @Driver.check_active
+    @step()
+    def usb(self):
+        self.reset(self.usb_cfg)
+
+    @Driver.check_active
+    @step()
+    def qspi(self):
+        if not self.qspi_cfg:
+            print("QSPI mode is not set, board is reseting in current mode")
+        self.reset(self.qspi_cfg)
+

--- a/labgrid/protocol/__init__.py
+++ b/labgrid/protocol/__init__.py
@@ -3,6 +3,7 @@ from .commandprotocol import CommandProtocol
 from .consoleprotocol import ConsoleProtocol
 from .linuxbootprotocol import LinuxBootProtocol
 from .powerprotocol import PowerProtocol
+from .bootcfgprotocol import BootCfgProtocol
 from .filetransferprotocol import FileTransferProtocol
 from .infoprotocol import InfoProtocol
 from .digitaloutputprotocol import DigitalOutputProtocol

--- a/labgrid/protocol/bootcfgprotocol.py
+++ b/labgrid/protocol/bootcfgprotocol.py
@@ -1,0 +1,20 @@
+import abc
+
+
+class BootCfgProtocol(abc.ABC):
+    @abc.abstractmethod
+    def usb(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def sd(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def emmc(self):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def qspi(self):
+        raise NotImplementedError
+

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -500,6 +500,25 @@ class USBGenericRemoteExport(USBGenericExport):
         super().__attrs_post_init__()
         self.data['cls'] = f"Remote{self.cls}".replace("Network", "")
 
+@attr.s(eq=False)
+class USBResetPortExport(USBGenericExport):
+    """ResourceExport for ports used by bcu"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            'host': self.host,
+            'busnum': self.local.busnum,
+            'devnum': self.local.devnum,
+            'path': self.local.path,
+            'vendor_id': self.local.vendor_id,
+            'model_id': self.local.model_id,
+            'board': self.local.board,
+        }
+
 exports["AndroidFastboot"] = USBGenericExport
 exports["AndroidUSBFastboot"] = USBGenericRemoteExport
 exports["DFUDevice"] = USBGenericExport
@@ -512,6 +531,7 @@ exports["SigrokUSBSerialDevice"] = USBSigrokExport
 exports["USBSDMuxDevice"] = USBSDMuxExport
 exports["USBSDWireDevice"] = USBSDWireExport
 exports["USBDebugger"] = USBGenericExport
+exports["USBResetPort"] = USBResetPortExport
 
 exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -411,3 +411,15 @@ class RemoteNFSProvider(RemoteBaseProvider):
 @attr.s(eq=False)
 class RemoteHTTPProvider(RemoteBaseProvider):
     pass
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkUSBResetPort(RemoteUSBResource):
+    board = attr.ib(
+        default=None,
+        validator=attr.validators.instance_of(str)
+    )
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -708,3 +708,15 @@ class USBDebugger(USBResource):
             return False
 
         return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(cmp=False)
+class USBResetPort(USBResource):
+    """The USBResetPort is the board serial cable (not the interface),
+    it is identified via usb using udev and it accepts any vendor/product id
+
+    Args:
+        board (str): mandatory arg to declare a board type recognized by bcu
+    """
+
+    board = attr.ib(default=None, validator=attr.validators.instance_of(str))


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Implementation of BCUResetDriver which uses bcu tool: https://github.com/nxp-imx/bcu . This tool can be used on boards like i.MX8DXL or i.MX8MP in order to change the boot switches configuration: put the board in download mode, in sd mode, emmc mode an so on.

How this was tested locally:
1. Connect one i.MX8DXL board to local workstation ; board already has plugged in an SDcard with a bootable image and also has a bootable image on the emmc ;
2. Find out board serial using dmesg and unplug/plug serial cable ; third interface is the one for 8dxl main console - configured port /dev/ttyUSB2 in local.yaml (check example)
3. Find out how to configure reset port using bcu lsftdi (3-11.3) and bcu lsboard (imx8dxlevk)
4. Run example test: 
pytest -s --verbose --tb=short --lg-log=examples/bcu --lg-env examples/bcu/local.yaml examples/bcu/bcu_example.py

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Examples for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
