### PR TITLE
[feature] spe_switch: Add spe_switch power feature

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -195,6 +195,10 @@ Currently available are:
 ``netio_kshell``
   Controls a NETIO 4C PDU via a Telnet interface.
 
+``phoenix_fl_switch``
+  Controls a single-pair-ethernet powerswitch via telnet.
+  Tested on a FL SWITCH 2303-8SP1 with FW-version 3.27.01 BETA
+
 ``raritan``
   Controls Raritan PDUs via SNMP.
 

--- a/labgrid/driver/power/phoenix_fl_switch.py
+++ b/labgrid/driver/power/phoenix_fl_switch.py
@@ -1,0 +1,80 @@
+'''
+This Driver was tested on a FL SWITCH 2303-8SP1 with FW-version 3.27.01 BETA
+file   phoenix_fl_switch.py
+author Raffael Krakau
+date   2023-08-24
+
+Copyright 2023 JUMO GmbH & Co. KG
+'''
+
+from telnetlib import Telnet
+
+PORT=23
+
+def power_set(host, port, index: int, value: bool):
+    """
+    Set power state by socket port number (e.g. 1 - 8) and an value {'enable', 'disable'}.
+
+    - values:
+        - disable(False): Turn OFF,
+        - enable(True): Turn ON
+    """
+    username = "admin"
+    password = "private"
+    action = "enable" if value else "disable"
+
+    telnet = Telnet(host=host, port=port)
+
+    # login user with password
+    telnet.read_until(match=b'User: ')
+    telnet.write(bytes(f'{username}\r\n', "utf-8"))
+    telnet.read_until(match=b'Password: ')
+    telnet.write(bytes(f'{password}\r\n', "utf-8"))
+
+    # enter command
+    telnet.write(bytes(f'pse port {index} power {action}\r\n', 'utf-8'))
+    # wait for return
+    status = telnet.read_until(match=b'OK', timeout=7.0)
+    # close connection
+    telnet.close()
+    status = status.decode('utf-8')
+    if "OK" in status:
+        pass
+    else:
+        print("Could not set power")
+        raise Exception
+
+
+def power_get(host, port, index: int) -> bool:
+    """
+    Get current state of a given socket number.
+    - host: spe-switch-device adress
+    - port: standard is 23
+    - index: depends on spe-switch-device 1-n (n is the number of spe-switch-ports)
+    """
+    username = "admin"
+    password = "private"
+    status = None
+
+    telnet = Telnet(host=host, port=port)
+
+    # login user with password
+    telnet.read_until(match=b'User: ')
+    telnet.write(bytes(f'{username}\r\n', "utf-8"))
+    telnet.read_until(match=b'Password: ')
+    telnet.write(bytes(f'{password}\r\n', "utf-8"))
+
+    # enter command
+    telnet.write(bytes(f'show pse port port-no {index}\r\n', "utf-8"))
+    # wait for return
+    status = telnet.read_until(match=b'Mode')
+    status = status.decode("utf-8")
+    # close connection
+    telnet.close()
+    # check status
+    if "OK" in status:
+        status = status.split("Status :  ")[1].splitlines()[0]
+    else:
+        print("Could not get power")
+        raise Exception
+    return True if 'enable' in status else False

--- a/labgrid/driver/power/phoenix_fl_switch.py
+++ b/labgrid/driver/power/phoenix_fl_switch.py
@@ -11,12 +11,11 @@ import pexpect
 PORT = 23
 
 
-def login_telnet(tn):
+def __login_telnet(tn):
     """
     Login user with set credentials
 
     @param tn : pyexpect-telnet-object
-    @returns : logged in pyexpect-telnet-object
     """
     username = "admin"
     password = "private"
@@ -40,7 +39,7 @@ def power_set(host, port, index: int, value: bool):
 
     with pexpect.spawn(f"telnet {host} {port}", timeout=1) as tn:
         # login user with password
-        login_telnet(tn)
+        __login_telnet(tn)
 
         # set value
         tn.send(bytes(f'pse port {index} power {action}\r\n', 'utf-8'))
@@ -62,7 +61,7 @@ def power_get(host, port, index: int) -> bool:
 
     with pexpect.spawn(f"telnet {host} {port}", timeout=1) as tn:
         # login user with password
-        login_telnet(tn)
+        __login_telnet(tn)
 
         # get value
         tn.send(bytes(f'show pse port port-no {index}\r\n', "utf-8"))


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
This PR adds the feature to set power for a phoenix_fl_switch over telnet.

Devices connected with single-pair-ethernet can now be set to power off/on/cycle.

To verify, this Driver was tested on a *FL SWITCH 2303-8SP1* with FW-version *3.27.01 BETA*.
Even if it's a BETA, we got the information that the power control won't experience breaking changes.

![grafik](https://github.com/JUMO-GmbH-Co-KG/labgrid/assets/73703991/16508302-0445-40c7-b691-9a023aabbe0b)
![grafik](https://github.com/JUMO-GmbH-Co-KG/labgrid/assets/73703991/1a910d49-a660-4d41-8fe6-3c1513d5473b)

![grafik](https://github.com/JUMO-GmbH-Co-KG/labgrid/assets/73703991/1eee564d-3c13-44f7-b058-42abf95d48b4)

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
