### PR TITLE
power: add eth008 power backend

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -174,6 +174,9 @@ Currently available are:
   interface, this module deliberately uses the standard password '1' and is
   not compatible with a different password.
 
+``eth008``
+  Controls a Robot-Electronics eth008 via a simple HTTP API.
+
 ``gude``
   Controls a Gude PDU via a simple HTTP API.
 

--- a/labgrid/driver/power/eth008.py
+++ b/labgrid/driver/power/eth008.py
@@ -1,0 +1,41 @@
+"""
+This driver implements a power port for the robot electronics 8 relay
+outputs board.
+
+Driver has been tested with:
+* ETH008 - 8 relay outputs
+"""
+
+import requests
+from ..exception import ExecutionError
+
+PORT = 80
+
+def power_set(host, port, index, value):
+    index = int(index)
+    assert 1 <= index <= 8
+    # access the web interface...
+    value_str = "A" if value else "I"
+    response = requests.get(
+        f"http://{host}:{port}/io.cgi?DO{value_str}{index}"
+    )
+    response.raise_for_status()
+    
+    # Check, that the port is in the desired state
+    state = get_state(response, index)
+    if state != value:
+        raise ExecutionError(f"failed to set port {index} to status {value}")
+
+def power_get(host, port, index):
+    index = int(index)
+    assert 1 <= index <= 8
+    # get the contents of the main page
+    response = requests.get(f"http://{host}:{port}/io.cgi?relay")
+    
+    response.raise_for_status()
+    state = get_state(response, index)
+    return state
+
+def get_state(request, index):
+    value = request.text.split()[1][index-1]
+    return bool(int(value))

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -244,6 +244,7 @@ class TestNetworkPowerDriver:
         import labgrid.driver.power.apc
         import labgrid.driver.power.digipower
         import labgrid.driver.power.digitalloggers_http
+        import labgrid.driver.power.eth008
         import labgrid.driver.power.gude
         import labgrid.driver.power.gude24
         import labgrid.driver.power.netio


### PR DESCRIPTION
<!---

--->
**Description**
Adding a new power driver for robot electronics eth008 using HTTP-GET API.
Locally tested with labgrid-client power on/off/cycle.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
