### PR TITLE
docker: fix wrong state of example

### DIFF
--- a/examples/docker/conftest.py
+++ b/examples/docker/conftest.py
@@ -3,7 +3,7 @@ import pytest
 @pytest.fixture(scope='session')
 def command(target):
     strategy = target.get_driver('DockerStrategy')
-    strategy.transition("shell")
+    strategy.transition("accessible")
     shell = target.get_driver('CommandProtocol')
     return shell
 


### PR DESCRIPTION
__examples/docker__:  `pytest -s --lg-env env.yaml test_shell.py` will print next error:

```
______________________ ERROR at setup of test_shell ______________________

target = Target(name='main', env=Environment(config_file='env.yaml'))

    @pytest.fixture(scope='session')
    def command(target):
        strategy = target.get_driver('DockerStrategy')
>       strategy.transition("shell")

conftest.py:6:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../labgrid/step.py:215: in wrapper
    _result = func(*_args, **_kwargs)
../../labgrid/strategy/dockerstrategy.py:39: in transition
    status = Status[status]
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

cls = <enum 'Status'>, name = 'shell'

    def __getitem__(cls, name):
>       return cls._member_map_[name]
E       KeyError: 'shell'

/usr/lib/python3.8/enum.py:387: KeyError
```

This is because there is no `shell` state in dockerstrategy, it should be `accessible`.
