### PR TITLE
pyproject.toml: depend on pylint rather than pytest-pylint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,7 @@ dev = [
     "pytest-dependency>=0.5.1",
     "pytest-isort>=2.0.0",
     "pytest-mock>=3.6.1",
-    "pytest-pylint>=0.18.0",
+    "pylint>=3.0.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
**Description**
labgrid's tests have never been linted, so there is no need to install pytest-pylint. Install pylint instead to allow linting of the labgrid module.

Require at least version 3.0.0 of pylint which will be required for Python 3.12 anyway [1].

This also allows us to work around https://github.com/carsongee/pytest-pylint/issues/180 which currently makes our CI tests fail.

[1] https://github.com/pylint-dev/pylint/releases/tag/v3.0.0

**Checklist**
- [x] PR has been tested