### PR TITLE
crossbar: fix autobahn dependency of crossbar

### DIFF
--- a/crossbar-requirements.txt
+++ b/crossbar-requirements.txt
@@ -1,2 +1,2 @@
 crossbar==21.3.1
-autobahn<=22.4.1
+autobahn<=22.3.2


### PR DESCRIPTION
For a fresh install, it reports next:

```
2023-10-06T18:12:50+0800 [Controller 860321] <crossbar.node.node.Node.boot>::NODE_BOOT_COMPLETE
2023-10-06T18:12:50+0800 [Guest      860331] Traceback (most recent call last):
2023-10-06T18:12:50+0800 [Guest      860331] File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
2023-10-06T18:12:50+0800 [Guest      860331] return _run_code(code, main_globals, None,
2023-10-06T18:12:50+0800 [Guest      860331] File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
2023-10-06T18:12:50+0800 [Guest      860331] exec(code, run_globals)
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/labgrid_upstream/labgrid/labgrid/remote/coordinator.py", line 14, in <module>
2023-10-06T18:12:50+0800 [Guest      860331] from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/.local/lib/python3.10/site-packages/autobahn/asyncio/__init__.py", line 32, in <module>
2023-10-06T18:12:50+0800 [Guest      860331] from autobahn.asyncio.websocket import \
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/.local/lib/python3.10/site-packages/autobahn/asyncio/websocket.py", line 36, in <module>
2023-10-06T18:12:50+0800 [Guest      860331] from autobahn.wamp import websocket
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/.local/lib/python3.10/site-packages/autobahn/wamp/websocket.py", line 32, in <module>
2023-10-06T18:12:50+0800 [Guest      860331] from autobahn.websocket import protocol
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/.local/lib/python3.10/site-packages/autobahn/websocket/protocol.py", line 2533, in <module>
2023-10-06T18:12:50+0800 [Guest      860331] class WebSocketServerProtocol(WebSocketProtocol):
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/.local/lib/python3.10/site-packages/autobahn/websocket/protocol.py", line 2538, in WebSocketServerProtocol
2023-10-06T18:12:50+0800 [Guest      860331] log = txaio.make_logger()
2023-10-06T18:12:50+0800 [Guest      860331] File "/home/shubuntu1/.local/lib/python3.10/site-packages/txaio/_unframework.py", line 41, in _throw_usage_error
2023-10-06T18:12:50+0800 [Guest      860331] raise RuntimeError(
2023-10-06T18:12:50+0800 [Guest      860331] RuntimeError: To use txaio, you must first select a framework with .use_twisted() or .use_asyncio()
2023-10-06T18:12:50+0800 [Controller 860321] Guest coordinator exited with error A process has ended with a probable error condition: process ended with exit code 1.
```

This is because autobahn 22.4.1 has issue, see [this](https://github.com/crossbario/autobahn-python/issues/1563), it been resolved in later version, but the later version looks not compatible with current crossbar version labgrid choose.

So, this PR made a tiny change to downgrade autobahn from 22.4.1 to 22.3.2, which in my fresh environment proved to be OK.