### PR TITLE
sshdriver: support selecting scp mode explicitly

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1571,7 +1571,7 @@ Arguments:
     stdout, and an empty list as second element.
   - connection_timeout (float, default=30.0): timeout when trying to establish connection to
     target.
-  - explicit_sftp_mode (bool, default=False): if set to True, `put()` and `get()` will
+  - explicit_sftp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
     explicitly use the SFTP protocol for file transfers instead of scp's default protocol
 
 UBootDriver

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1573,6 +1573,8 @@ Arguments:
     target.
   - explicit_sftp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
     explicitly use the SFTP protocol for file transfers instead of scp's default protocol
+  - explicit_scp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
+    explicitly use the SCP protocol for file transfers instead of scp's default protocol
 
 UBootDriver
 ~~~~~~~~~~~

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -9,6 +9,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from functools import cached_property
 
 import attr
 
@@ -432,10 +433,14 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         """The SSHDriver is always connected, return 1"""
         return 1
 
-    def _scp_supports_explicit_sftp_mode(self):
+    @cached_property
+    def _ssh_version(self):
         version = subprocess.run(["ssh", "-V"], capture_output=True, text=True)
         version = re.match(r"^OpenSSH_(\d+)\.(\d+)", version.stderr)
-        major, minor = map(int, version.groups())
+        return map(int, version.groups())
+
+    def _scp_supports_explicit_sftp_mode(self):
+        major, minor = self._ssh_version
 
         # OpenSSH >= 8.6 supports explicitly using the SFTP protocol via -s
         if major == 8 and minor >= 6:


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

OpenSSH >= 9.0 defaults to the SFTP protocol. However, some older targets may only have scp installed. OpenSSH allows to explicitly select scp by providing the `-O` flag.

As already done for the transition of SFTP, add a dedicated SSHDriver attribute named `explicit_scp_mode` which defaults to `False`.

To not call the OpenSSH version check too often, move the call to a `@cached_property`.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
- [ ] Man pages have been regenerated

Fixes what was addressed in a [comment](https://github.com/labgrid-project/labgrid/pull/1003#pullrequestreview-1364832063) for #1003
