### PR TITLE
dockerfiles: fix has_podman routine

### DIFF
--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -22,7 +22,7 @@ has_docker() {
 }
 
 has_podman() {
-    command -v podman /dev/null 2>&1
+    command -v podman >/dev/null 2>&1
 }
 
 has_buildx() {


### PR DESCRIPTION
The `has_podman` routine contains a small bug. The routine isn't used for now, but ensure it's working anyway.


- [x] PR has been tested

Fixes: #1091