### PR TITLE
Revert "sshdriver: Prevent timeout from deadlock"

### DIFF
--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -17,8 +17,6 @@ def ssh_driver_mocked_and_activated(target, mocker):
     instance_mock = mocker.MagicMock()
     popen.return_value = instance_mock
     instance_mock.wait = mocker.MagicMock(return_value=0)
-    instance_mock.communicate = mocker.MagicMock(return_value=(b"", b""))
-    instance_mock.returncode = 0
     SSHDriver(target, "ssh")
     s = target.get_driver("SSHDriver")
     return s
@@ -37,8 +35,6 @@ def test_create(target, mocker):
     instance_mock = mocker.MagicMock()
     popen.return_value = instance_mock
     instance_mock.wait = mocker.MagicMock(return_value=0)
-    instance_mock.communicate = mocker.MagicMock(return_value=(b"", b""))
-    instance_mock.returncode = 0
     s = SSHDriver(target, "ssh")
     assert isinstance(s, SSHDriver)
 


### PR DESCRIPTION
**Description**
This reverts commit b8f059fb4277e3ca01684b7a71ac89974ff1cc36.

OpenSSH < 8.5 called with -f waits for the stderr pipe to be closed before forking. [1] fixes this behavior.
The labgrid commit to be reverted calls `communicate()`, relying on a timely fork. Affected OpenSSH versions now run into a TimeoutExpired exception on `communicate()` leading to an ExecutionError being raised in labgrid.

A `wait()` with timeout was used since the initial implementation [2]. We wanted to make sure that we don't depend on the state of the pipes, so use of wait() was intentional, as it directly covers the interesting cases:

- immediate abort (due to a config error or similar)
- normal startup (parent process exits after fork)
- hang (via `wait()` timeout)

Reverting the problematic commit avoids the complexity of having to maintain two different ways to start SSH as suggested in [3].

If timeouts still occur after the revert, we should implement this suggestion [4].

Discussion that lead to this patch can be found in the PR introducing the problematic commit [5] as well as in [3].

The other commit [6] in the PR [5] has a similar approach for `labgrid.util.SSHConnection._start_own_master()`. It shouldn't be problematic though: The ssh process is not expected to fork as it is not called with -f.

[1] https://github.com/openssh/openssh-portable/commit/396d32f3a1a16e54df2a76b2a9b237868580dcbe ("upstream: There are lots of place where we want to redirect stdin,")
[2] e4862fa4 ("SSHDriver: ControlMaster & Driver")
[3] https://github.com/labgrid-project/labgrid/pull/1278
[4] https://github.com/labgrid-project/labgrid/pull/1265#issuecomment-1761670396
[5] https://github.com/labgrid-project/labgrid/pull/1265
[6] f9ca0243 ("ssh: Prevent timeout from deadlock")

**Checklist**
- [x] PR has been tested

Fixes #1265
Closes #1278