### PR TITLE
exporter: Use fqdn instead of hostname only

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -917,6 +917,12 @@ def main():
         help='hostname (or IP) published for accessing resources (defaults to the system hostname)'
     )
     parser.add_argument(
+        '--fqdn',
+        action='store_true',
+        default=False,
+        help='Use fully qualified domain name as default for hostname'
+    )
+    parser.add_argument(
         '-d',
         '--debug',
         action='store_true',
@@ -943,7 +949,7 @@ def main():
 
     extra = {
         'name': args.name or gethostname(),
-        'hostname': args.hostname or gethostname(),
+        'hostname': args.hostname or getfqdn() if args.fqdn else gethostname(),
         'resources': args.resources,
         'isolated': args.isolated
     }

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -59,6 +59,9 @@ the public name of the exporter
 .B  \-\-hostname
 hostname (or IP) published for accessing resources
 .TP
+.B  \-\-fqdn
+use fully qualified domain name as default for hostname
+.TP
 .B  \-d\fP,\fB  \-\-debug
 enable debug mode
 .UNINDENT
@@ -83,6 +86,11 @@ exporter needs to provide a host name to set the exported value of the \(dqhost\
 key.
 If the system hostname is not resolvable via DNS, this option can be used to
 override this default with another name (or an IP address).
+.SS \-\-fqdn
+.sp
+In some networks the fully qualified domain name may be needed to reach resources
+on an exporter. This option changes the default to fqdn when no \-\-hostname is
+explicitly set.
 .SH CONFIGURATION
 .sp
 The exporter uses a YAML configuration file which defines groups of related

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -46,6 +46,8 @@ OPTIONS
     the public name of the exporter
 --hostname
     hostname (or IP) published for accessing resources
+--fqdn
+    use fully qualified domain name as default for hostname
 -d, --debug
     enable debug mode
 
@@ -72,6 +74,12 @@ exporter needs to provide a host name to set the exported value of the "host"
 key.
 If the system hostname is not resolvable via DNS, this option can be used to
 override this default with another name (or an IP address).
+
+--fqdn
+~~~~~~
+In some networks the fully qualified domain name may be needed to reach resources
+on an exporter. This option changes the default to fqdn when no --hostname is
+explicitly set.
 
 CONFIGURATION
 -------------


### PR DESCRIPTION
**Description**
In distributed setups, the coordinator may point to places in different subnets. In order for clients to resolve resources behind the exporter, they need to know its FQDN instead of just the hostname.

Thus, set this to be the default when the exporter is invoked without the --hostname parameter.



<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated


