### PR TITLE
Support multiple credentials for shell and ssh

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1557,8 +1557,8 @@ Implements:
 Arguments:
   - prompt (regex): shell prompt to match after logging in
   - login_prompt (regex): match for the login prompt
-  - username (str): username to use during login
-  - password (str): optional, password to use during login
+  - username (str or list): username(s) to use during login
+  - password (str or lits): optional, password(s) to use during login
   - keyfile (str): optional, keyfile to upload after login, making the
     `SSHDriver`_ usable
   - login_timeout (int, default=60): timeout for login prompt detection in

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -544,8 +544,8 @@ These and the sudo configuration needs to be prepared by the administrator.
 
 Arguments:
   - address (str): hostname of the remote system
-  - username (str): username used by SSH
-  - password (str, default=""): password used by SSH
+  - username (str or list): username(s) used by SSH
+  - password (str or list, default=""): password(s) used by SSH
   - port (int, default=22): port used by SSH
 
 Used by:

--- a/labgrid/resource/networkservice.py
+++ b/labgrid/resource/networkservice.py
@@ -8,6 +8,6 @@ from .common import Resource
 @attr.s(eq=False)
 class NetworkService(Resource):
     address = attr.ib(validator=attr.validators.instance_of(str))
-    username = attr.ib(validator=attr.validators.instance_of(str))
-    password = attr.ib(default='', validator=attr.validators.instance_of(str))
+    username = attr.ib(validator=attr.validators.instance_of((str,list)))
+    password = attr.ib(default='', validator=attr.validators.instance_of((str,list)))
     port = attr.ib(default=22, validator=attr.validators.instance_of(int))

--- a/tests/test_shelldriver.py
+++ b/tests/test_shelldriver.py
@@ -24,6 +24,17 @@ class TestShellDriver:
         res = d.run("test")
         assert res == (['success'], [], 0)
 
+    def test_run_list(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username=['error','dummy'])
+        d.on_activate = mocker.MagicMock()
+        d = t.get_driver('ShellDriver')
+        d._run = mocker.MagicMock(return_value=(['success'], [], 0))
+        res = d.run_check("test")
+        assert res == ['success']
+        res = d.run("test")
+        assert res == (['success'], [], 0)
+
     def test_run_error(self, target_with_fakeconsole, mocker):
         t = target_with_fakeconsole
         d = ShellDriver(t, "shell", prompt='dummy', login_prompt='dummy', username='dummy')


### PR DESCRIPTION
**Description**

Add support for having a list of usernames and passwords to try to connect with.
This touches `shelldriver`, `networkservice `and `sshdriver`.

Depending on the software provisioned on a place, credentials may be different. It's my case where 3 different credentials are needed (user1/pass1 user2/pass2 user3/pass3) when soft1 or soft2 or soft3 is on the target.

In order not to have to change the LabGrid configuration (and the exporter as `networkservice `holds the IP and credentials for ssh) I can up with this PR.

The credentials are tried in turn and I don't get a timeout with 3 credentials. More credentials will probably need a timeout tweak or a way to configure it.

I have manually tested login in with `console`, `ssh`, and `-s shell ssh`, I have also tested sending a file with `scp`.

This also enable a smoother test experience. My tests can now use the same configuration for all software.

**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature 
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested