### PR TITLE
driver/resources: use consistent logger names

### DIFF
--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -1,4 +1,3 @@
-import logging
 import shlex
 
 import attr
@@ -40,7 +39,6 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:{self.target}")
         self._status = 0
         # barebox' default log level, used as fallback if no log level can be saved
         self.saved_log_level = 7

--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -1,3 +1,4 @@
+import logging
 import subprocess
 import attr
 
@@ -24,6 +25,11 @@ class Driver(BindingMixin):
         super().__attrs_post_init__()
         if self.target is None:
             raise BindingError("Drivers can only be created on a valid target")
+
+        logger_name = f"{self.__class__.__name__}({self.target.name})"
+        if self.name:
+            logger_name += f":{self.name}"
+        self.logger = logging.getLogger(logger_name)
 
     def get_priority(self, protocol):
         """Retrieve the priority for a given protocol

--- a/labgrid/driver/dediprogflashdriver.py
+++ b/labgrid/driver/dediprogflashdriver.py
@@ -1,5 +1,4 @@
 import os.path
-import logging
 import attr
 
 from ..resource import NetworkDediprogFlasher
@@ -24,7 +23,6 @@ class DediprogFlashDriver(Driver):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f'{self}')
         if self.target.env:
             self.tool = self.target.env.config.get_tool('dpcmd')
         else:

--- a/labgrid/driver/dockerdriver.py
+++ b/labgrid/driver/dockerdriver.py
@@ -1,9 +1,6 @@
 """
 Class for connecting to a docker daemon running on the host machine.
 """
-
-import logging
-
 import attr
 
 from labgrid.factory import target_factory
@@ -62,7 +59,6 @@ class DockerDriver(PowerProtocol, Driver):
             attr.validators.instance_of(list)))
 
     def __attrs_post_init__(self):
-        self.logger = logging.getLogger(f"{self}({self.target})")
         super().__attrs_post_init__()
         self._client = None
         self._container = None

--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -1,5 +1,4 @@
 import fcntl
-import logging
 import os
 import select
 import shlex
@@ -25,7 +24,6 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}({self.target})")
         self.status = 0
         self._child = None
 

--- a/labgrid/driver/fake.py
+++ b/labgrid/driver/fake.py
@@ -1,5 +1,4 @@
 # pylint: disable=arguments-differ
-import logging
 import re
 
 import attr
@@ -18,7 +17,6 @@ class FakeConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}({self.target})")
         self.rxq = []
         self.txq = []
 

--- a/labgrid/driver/flashromdriver.py
+++ b/labgrid/driver/flashromdriver.py
@@ -1,5 +1,4 @@
 import os.path
-import logging
 import attr
 
 from ..resource import NetworkFlashrom
@@ -24,7 +23,6 @@ class FlashromDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f'{self}')
         if self.target.env:
             self.tool = self.target.env.config.get_tool('flashrom')
         else:

--- a/labgrid/driver/flashscriptdriver.py
+++ b/labgrid/driver/flashscriptdriver.py
@@ -1,4 +1,3 @@
-import logging
 import attr
 
 from ..factory import target_factory
@@ -26,10 +25,6 @@ class FlashScriptDriver(Driver):
         default=attr.Factory(list),
         validator=attr.validators.optional(attr.validators.instance_of(list)),
     )
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:{self.target}")
 
     def on_activate(self):
         pass

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -1,4 +1,3 @@
-import logging
 from itertools import chain
 import attr
 
@@ -47,7 +46,6 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:{self.target}")
 
         # FIXME make sure we always have an environment or config
         if self.target.env:

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -1,6 +1,5 @@
 """The QEMUDriver implements a driver to use a QEMU target"""
 import atexit
-import logging
 import select
 import shlex
 import shutil
@@ -89,7 +88,6 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:")
         self.status = 0
         self.txdelay = None
         self._child = None

--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -1,7 +1,6 @@
 import subprocess
 import re
 import time
-import logging
 
 import attr
 
@@ -28,7 +27,6 @@ class QuartusHPSDriver(Driver):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}({self.target})")
 
         # FIXME make sure we always have an environment or config
         if self.target.env:

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -1,5 +1,3 @@
-import logging
-
 import attr
 from pexpect import TIMEOUT
 import serial
@@ -26,7 +24,6 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}({self.target})")
         if isinstance(self.port, SerialPort):
             self.serial = serial.Serial()
         else:

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -2,7 +2,6 @@
 """The ShellDriver provides the CommandProtocol, ConsoleProtocol and
  InfoProtocol on top of a SerialPort."""
 import io
-import logging
 import re
 import shlex
 import ipaddress
@@ -58,7 +57,6 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:{self.target}")
         self._status = 0
 
         self._xmodem_cached_rx_cmd = ""

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -1,6 +1,5 @@
 """The SSHDriver uses SSH as a transport to implement CommandProtocol and FileTransferProtocol"""
 import contextlib
-import logging
 import os
 import re
 import stat
@@ -39,7 +38,6 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}({self.target})")
         self._keepalive = None
 
     def on_activate(self):

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -1,6 +1,4 @@
 """The U-Boot Module contains the UBootDriver"""
-import logging
-
 import attr
 from pexpect import TIMEOUT
 
@@ -48,7 +46,6 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:{self.target}")
         self._status = 0
 
         if self.boot_expression:

--- a/labgrid/driver/usbaudiodriver.py
+++ b/labgrid/driver/usbaudiodriver.py
@@ -1,4 +1,3 @@
-import logging
 import subprocess
 import attr
 
@@ -28,7 +27,6 @@ class USBAudioInputDriver(Driver):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}")
         self._prepared = False
 
     def _get_pipeline(self):

--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -1,5 +1,4 @@
 import enum
-import logging
 import os
 import time
 import subprocess
@@ -41,10 +40,6 @@ class USBStorageDriver(Driver):
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}:{self.target}")
 
     def on_activate(self):
         pass

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -1,4 +1,3 @@
-import logging
 import subprocess
 
 import attr
@@ -18,7 +17,6 @@ class USBVideoDriver(Driver, VideoProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}")
         self._prepared = False
 
     def get_qualities(self):

--- a/labgrid/driver/xenadriver.py
+++ b/labgrid/driver/xenadriver.py
@@ -1,4 +1,3 @@
-import logging
 from importlib import import_module
 import attr
 
@@ -17,11 +16,10 @@ class XenaDriver(Driver):
         super().__attrs_post_init__()
         self._xena_app = import_module('xenavalkyrie.xena_app')
         self._tgn_utils = import_module('trafficgenerator.tgn_utils')
-        self._logger = logging.getLogger(f"{self}")
         self._xm = None
 
     def on_activate(self):
-        self._xm = self._xena_app.init_xena(self._tgn_utils.ApiType.socket, self._logger, 'labgrid')
+        self._xm = self._xena_app.init_xena(self._tgn_utils.ApiType.socket, self.logger, 'labgrid')
         self._xm.session.add_chassis(self.xena_manager.hostname)
 
     def on_deactivate(self):

--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -1,3 +1,4 @@
+import logging
 import shlex
 from typing import Dict, Type, List
 import attr
@@ -25,6 +26,13 @@ class Resource(BindingMixin):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         self._parent = None
+
+        logger_name = self.__class__.__name__
+        if self.target:
+            logger_name += f"({self.target.name})"
+        if self.name:
+            logger_name += f":{self.name}"
+        self.logger = logging.getLogger(logger_name)
 
     @property
     def command_prefix(self):
@@ -118,6 +126,7 @@ class ResourceManager:
 
     def __attrs_post_init__(self):
         self.resources: List[ManagedResource] = []
+        self.logger = logging.getLogger(str(self))
 
     def _add_resource(self, resource: 'ManagedResource'):
         self.resources.append(resource)

--- a/labgrid/resource/docker.py
+++ b/labgrid/resource/docker.py
@@ -4,7 +4,6 @@ and DockerManager will create the NetworkResource instance that is declared
 in the specification (e.g. yaml) of DockerDriver.
 """
 
-import logging
 import socket
 
 import attr
@@ -34,7 +33,6 @@ class DockerManager(ResourceManager):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.log = logging.getLogger('DockerManager')
         self._client = dict()
         self._docker_daemons_cleaned = list()
 
@@ -71,7 +69,7 @@ class DockerManager(ResourceManager):
             for container in container_list:
                 if (container['Labels'][DockerConstants.DOCKER_LG_CLEANUP_LABEL] ==
                         DockerConstants.DOCKER_LG_CLEANUP_TYPE_AUTO):
-                    self.log.info("Deleting container %s", container['Names'][0])
+                    self.logger.info("Deleting container %s", container['Names'][0])
                     docker_client.api.remove_container(container['Id'], force=True)
             self._docker_daemons_cleaned.append(docker_client.api.base_url)
 
@@ -90,7 +88,6 @@ class DockerDaemon(ManagedResource):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         self._nw_services = dict()
-        self.log = logging.getLogger('DockerContainer')
         self.timeout = 5.0
         self.avail = True
 
@@ -132,7 +129,7 @@ class DockerDaemon(ManagedResource):
                 if nw_service.address == "":
                     container = docker_client.api.containers(
                         filters={"name": "/" + container_name})
-                    self.log.debug("Containers found %s", container)
+                    self.logger.debug("Containers found %s", container)
                     if container:
                         nw_service.address = find_dict(
                             d=container[0]['NetworkSettings'],

--- a/labgrid/resource/ethernetport.py
+++ b/labgrid/resource/ethernetport.py
@@ -183,7 +183,6 @@ class EthernetPortManager(ResourceManager):
     """The EthernetPortManager periodically polls the switch for new updates."""
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}")
         self.loop = None
         self.poll_tasks = []
         self.switches = {}

--- a/labgrid/resource/lxaiobus.py
+++ b/labgrid/resource/lxaiobus.py
@@ -1,4 +1,3 @@
-import logging
 from time import monotonic
 from importlib import import_module
 
@@ -14,8 +13,6 @@ class LXAIOBusNodeManager(ResourceManager):
         super().__attrs_post_init__()
         self._requests = import_module('requests')
 
-        self.log = logging.getLogger('LXAIOBusNodeManager')
-
         self._last = 0.0
 
     def _get_nodes(self, host):
@@ -25,7 +22,7 @@ class LXAIOBusNodeManager(ResourceManager):
             j = r.json()
             return j["result"]
         except self._requests.exceptions.ConnectionError:
-            self.log.exception("failed to connect to host %s", host)
+            self.logger.exception("failed to connect to host %s", host)
             return []
 
     def poll(self):

--- a/labgrid/resource/mqtt.py
+++ b/labgrid/resource/mqtt.py
@@ -1,4 +1,3 @@
-import logging
 import threading
 from time import monotonic
 
@@ -15,10 +14,6 @@ class MQTTManager(ResourceManager):
     _topics = attr.ib(default=attr.Factory(list), validator=attr.validators.instance_of(list))
     _topic_lock = attr.ib(default=threading.Lock())
     _last = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
-
-    def __attrs_post_init__(self):
-        super().__attrs_post_init__()
-        self.log = logging.getLogger('MQTTManager')
 
     def _create_mqtt_connection(self, host):
         import paho.mqtt.client as mqtt

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -1,5 +1,4 @@
 import copy
-import logging
 import os
 import attr
 
@@ -11,7 +10,6 @@ from .common import NetworkResource, ManagedResource, ResourceManager
 class RemotePlaceManager(ResourceManager):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self.logger = logging.getLogger(f"{self}")
         self.url = None
         self.realm = None
         self.loop = None

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import queue
 import warnings
@@ -19,7 +18,6 @@ class UdevManager(ResourceManager):
         super().__attrs_post_init__()
         self.queue = queue.Queue()
 
-        self.log = logging.getLogger('UdevManager')
         self._pyudev = import_module('pyudev')
         self._context = self._pyudev.Context()
         self._monitor = self._pyudev.Monitor.from_netlink(self._context)
@@ -32,7 +30,7 @@ class UdevManager(ResourceManager):
         devices.match_subsystem(resource.match['SUBSYSTEM'])
         for device in devices:
             if resource.try_match(device):
-                self.log.debug(" matched successfully against %s", resource.device)
+                self.logger.debug(" matched successfully against %s", resource.device)
 
     def _insert_into_queue(self, device):
         self.queue.put(device)
@@ -44,10 +42,10 @@ class UdevManager(ResourceManager):
                 device = self.queue.get(False)
             except queue.Empty:
                 break
-            self.log.debug("%s: %s", device.action, device)
+            self.logger.debug("%s: %s", device.action, device)
             for resource in self.resources:
                 if resource.try_match(device):
-                    self.log.debug(" matched successfully")
+                    self.logger.debug(" matched successfully")
 
 @attr.s(eq=False)
 class USBResource(ManagedResource):
@@ -59,7 +57,6 @@ class USBResource(ManagedResource):
 
     def __attrs_post_init__(self):
         self.timeout = 5.0
-        self.log = logging.getLogger('USBResource')
         self.match.setdefault('SUBSYSTEM', 'usb')
         super().__attrs_post_init__()
 
@@ -134,7 +131,7 @@ class USBResource(ManagedResource):
             if self.device.sys_path != device.sys_path:
                 return False
 
-        self.log.debug(" found match: %s", self)
+        self.logger.debug(" found match: %s", self)
 
         if self.suggest and device.action in [None, 'add']:
             self.device = device

--- a/labgrid/util/qmp.py
+++ b/labgrid/util/qmp.py
@@ -9,7 +9,7 @@ class QMPMonitor:
     monitor_in = attr.ib()
 
     def __attrs_post_init__(self):
-        self.logger = logging.getLogger(f"{self}:")
+        self.logger = logging.getLogger(f"{self}")
         self._negotiate_capabilities()
 
     def _negotiate_capabilities(self):


### PR DESCRIPTION
**Description**
Each driver and resource sets up their own logger in a pretty similar way. So move this functionality to the base class and generate a sane logger name there.

**Checklist**
- [ ] PR has been tested (tbd)