### PR TITLE
step: allow out of order pop

### DIFF
--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -26,8 +26,8 @@ class Steps:
         step.level = len(self._stack)
 
     def pop(self, step):  # pylint: disable=redefined-outer-name
-        assert self._stack[-1] is step
-        self._stack.pop()
+        assert step in self._stack
+        self._stack.remove(step)
 
     def subscribe(self, callback):
         self._subscribers.append(callback)


### PR DESCRIPTION
If pytest access labgrid resources from various threads, the step event may pop out of push order.
Allow the pop function to extract an element if it is not in the first place.
