### PR TITLE
qemudriver: Add support for additional disk options

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ New Features in 23.1
 - A new log level called ``CONSOLE`` has been added between the default
   ``INFO`` and ``DEBUG`` levels. This level will show all reads and writes made
   to the serial console during testing.
+- The `QEMUDriver` now has an additional ``disk_opts`` property which can be
+  used to pass additional options for the disk directly to QEMU
 
 Bug fixes in 23.1
 ~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2483,6 +2483,7 @@ Arguments:
   - boot_args (str): optional, additional kernel boot argument
   - kernel (str): optional, reference to the images key for the kernel
   - disk (str): optional, reference to the images key for the disk image
+  - disk_opts (str): optional, additional QEMU disk options
   - flash (str): optional, reference to the images key for the flash image
   - rootfs (str): optional, reference to the paths key for use as the virtio-9p filesystem
   - dtb (str): optional, reference to the image key for the device tree

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -40,6 +40,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         boot_args (str): optional, additional kernel boot argument
         kernel (str): optional, reference to the images key for the kernel
         disk (str): optional, reference to the images key for the disk image
+        disk_opts (str): optional, additional QEMU disk options
         flash (str): optional, reference to the images key for the flash image
         rootfs (str): optional, reference to the paths key for use as the virtio-9p filesystem
         dtb (str): optional, reference to the image key for the device tree
@@ -62,6 +63,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)))
     disk = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str)))
+    disk_opts = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)))
     rootfs = attr.ib(
@@ -146,20 +150,23 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             disk_format = "raw"
             if disk_path.endswith(".qcow2"):
                 disk_format = "qcow2"
+            disk_opts = ""
+            if self.disk_opts:
+                disk_opts = f",{self.disk_opts}"
             if self.machine == "vexpress-a9":
                 cmd.append("-drive")
                 cmd.append(
-                    f"if=sd,format={disk_format},file={disk_path},id=mmc0")
+                    f"if=sd,format={disk_format},file={disk_path},id=mmc0{disk_opts}")
                 boot_args.append("root=/dev/mmcblk0p1 rootfstype=ext4 rootwait")
             elif self.machine == "q35":
                 cmd.append("-drive")
                 cmd.append(
-                    f"if=virtio,format={disk_format},file={disk_path}")
+                    f"if=virtio,format={disk_format},file={disk_path}{disk_opts}")
                 boot_args.append("root=/dev/vda rootwait")
             elif self.machine == "pc":
                 cmd.append("-drive")
                 cmd.append(
-                    f"if=virtio,format={disk_format},file={disk_path}")
+                    f"if=virtio,format={disk_format},file={disk_path}{disk_opts}")
                 boot_args.append("root=/dev/vda rootwait")
             else:
                 raise NotImplementedError(


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Adds support to pass additional disk options to QEMU when creating the drive. This can be helpful for example to pass different "cache" options that may affect performance.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
