### PR TITLE
tests: fix SSHDriver deactivation test

### DIFF
--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -17,6 +17,7 @@ def ssh_driver_mocked_and_activated(target, mocker):
     instance_mock = mocker.MagicMock()
     popen.return_value = instance_mock
     instance_mock.wait = mocker.MagicMock(return_value=0)
+    instance_mock.communicate = mocker.MagicMock(return_value=(b"", b""))
     SSHDriver(target, "ssh")
     s = target.get_driver("SSHDriver")
     return s
@@ -35,6 +36,7 @@ def test_create(target, mocker):
     instance_mock = mocker.MagicMock()
     popen.return_value = instance_mock
     instance_mock.wait = mocker.MagicMock(return_value=0)
+    instance_mock.communicate = mocker.MagicMock(return_value=(b"", b""))
     s = SSHDriver(target, "ssh")
     assert isinstance(s, SSHDriver)
 

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -40,21 +40,23 @@ def test_create(target, mocker):
     s = SSHDriver(target, "ssh")
     assert isinstance(s, SSHDriver)
 
-def test_run_check(ssh_driver_mocked_and_activated, mocker):
+def test_run_check(target, ssh_driver_mocked_and_activated, mocker):
     s = ssh_driver_mocked_and_activated
     s._run = mocker.MagicMock(return_value=(['success'], [], 0))
     res = s.run_check("test")
     assert res == ['success']
     res = s.run("test")
     assert res == (['success'], [], 0)
+    target.deactivate(s)
 
-def test_run_check_raise(ssh_driver_mocked_and_activated, mocker):
+def test_run_check_raise(target, ssh_driver_mocked_and_activated, mocker):
     s = ssh_driver_mocked_and_activated
     s._run = mocker.MagicMock(return_value=(['error'], [], 1))
     with pytest.raises(ExecutionError):
         res = s.run_check("test")
     res = s.run("test")
     assert res == (['error'], [], 1)
+    target.deactivate(s)
 
 @pytest.fixture(scope='function')
 def ssh_localhost(target, pytestconfig):


### PR DESCRIPTION
**Description**
Since d08a35c5, stdout of the ssh keepalive process is logged. The return value of the communicate method is used to achieve this. This leads to ValueErrors during testing:

```
  Traceback (most recent call last):
    File "/home/runner/work/labgrid/labgrid/labgrid/target.py", line 516, in _atexit_cleanup
      self.cleanup()
    File "/home/runner/work/labgrid/labgrid/labgrid/target.py", line 562, in cleanup
      self.deactivate_all_drivers()
    File "/home/runner/work/labgrid/labgrid/labgrid/target.py", line 512, in deactivate_all_drivers
      self.deactivate(drv)
    File "/home/runner/work/labgrid/labgrid/labgrid/target.py", line 505, in deactivate
      client.on_deactivate()
    File "/home/runner/work/labgrid/labgrid/labgrid/driver/sshdriver.py", line 65, in on_deactivate
      self._stop_keepalive()
    File "/home/runner/work/labgrid/labgrid/labgrid/driver/sshdriver.py", line 565, in _stop_keepalive
      stdout, _ = self._keepalive.communicate(timeout=60)
      ^^^^^^^^^
  ValueError: not enough values to unpack (expected 2, got 0)
```

This happens also during CI testing, but is not fatal, since it happens during cleanup.

To prevent this, mock the communicate method. This has also been done in b8f059fb which has been reverted since (d425be47).

While at it, add SSHDriver deactivation testing.

**Checklist**
- [x] PR has been tested


Fixes: #1266