### PR TITLE
github/workflows/docker: upgrade setuptools before installing setuptools_scm

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,7 +14,8 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt install -yq python3-pip
-        python3 -m pip install setuptools_scm
+        pip install --upgrade setuptools
+        pip install setuptools_scm
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/reusable-unit-tests-docker.yml
+++ b/.github/workflows/reusable-unit-tests-docker.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Install system dependencies
       run: |
         sudo apt install -yq python3-pip
-        python3 -m pip install setuptools_scm
+        pip install --upgrade setuptools
+        pip install setuptools_scm
     - name: Build docker images
       run: |
         ./dockerfiles/build.sh


### PR DESCRIPTION
**Description**
Fixes warnings such as:

```
/home/runner/.local/lib/python3.10/site-packages/setuptools_scm/_integration/setuptools.py:30: RuntimeWarning: 
ERROR: setuptools==59.6.0 is used in combination with setuptools_scm>=8.x

Your build configuration is incomplete and previously worked by accident!
setuptools_scm requires setuptools>=61

Suggested workaround if applicable:
 - migrating from the deprecated setup_requires mechanism to pep517/518
   and using a pyproject.toml to declare build dependencies
   which are reliably pre-installed before running the build tools
```

**Checklist**
- [x] PR has been tested (CI only)