### PR TITLE
driver/pyvisadriver: add optional backend property

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1160,6 +1160,7 @@ Arguments:
     ASRL, TCPIP...
   - url (str): device identifier on selected resource, e.g. <ip> for TCPIP
     resource
+  - backend (str): Visa library backend, e.g. '@sim' for pyvisa-sim backend
 
 Used by:
   - `PyVISADriver`_

--- a/labgrid/driver/pyvisadriver.py
+++ b/labgrid/driver/pyvisadriver.py
@@ -18,7 +18,7 @@ class PyVISADriver(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         _py_pyvisa_module = import_module('pyvisa')
-        self._pyvisa_resource_manager = _py_pyvisa_module.ResourceManager()
+        self._pyvisa_resource_manager = _py_pyvisa_module.ResourceManager(self.pyvisa_resource.backend)
         self.pyvisa_device = None
 
     def on_activate(self):

--- a/labgrid/resource/pyvisa.py
+++ b/labgrid/resource/pyvisa.py
@@ -12,6 +12,8 @@ class PyVISADevice(Resource):
     Args:
         type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
         url (str): device identifier on selected resource, e.g. <ip> for TCPIP resource
+        backend (str, default=''): Visa library backend, e.g. '@sim' for pyvisa-sim backend
     """
     type = attr.ib(validator=attr.validators.instance_of(str))
     url = attr.ib(validator=attr.validators.instance_of(str))
+    backend = attr.ib(default='', validator=attr.validators.instance_of(str))


### PR DESCRIPTION
## Description

Allow users to override PyVISA backed to use something like PyVISA-sim or another custom backend.

## Testing
tested using PyVISA-sim with:

**lg-env.yaml**
```yaml
targets:                                                                        
  main:                                                                         
    resources:                                                                  
      RemotePlace:                                                              
        name: {{REMOTEPLACE}}                                                   
    drivers:                                                                    
      - cls: PyVISADriver                                                       
        name: 'pyvisa-3333'                                                     
        bindings:                                                               
          pyvisa_resource: dummy3333                                            
      - cls: PyVISADriver                                                       
        name: 'pyvisa-4444'                                                     
        bindings:                                                               
          pyvisa_resource: dummy4444                                            
```
**expoter.yaml**
```yaml
devboards:                                                                      
  dummy3333:                                                                    
    cls: PyVISADevice                                                           
    backend: '@sim'                                                             
    type: 'TCPIP'                                                               
    url: 'localhost:3333'                                                       
                                                                                
  dummy4444:                                                                    
    cls: PyVISADevice                                                           
    backend: '@sim'                                                             
    type: 'TCPIP'                                                               
    url: 'localhost:4444'                                                       
```
**test_scpi.py**

```python
import pytest

@pytest.fixture()
def scpidev_a(target):
    device = target.get_driver(
        cls='PyVISADriver',
        name='pyvisa-3333',
    ).get_session()
    device.write_termination='\n'                                                                                                                                                                                                                                                                                              
    device.read_termination='\n'

    return device


@pytest.fixture()
def scpidev_b(target):
    device = target.get_driver(
        cls='PyVISADriver',
        name='pyvisa-4444',
    ).get_session()
    device.write_termination='\n'
    device.read_termination='\n'

    return device


def test_idn_string_example(scpidev_a):
    out = scpidev_a.query('*IDN?')
    assert out == 'SCPI,MOCK,VERSION_1.0'


def test_volt(scpidev_a, scpidev_b):
    volt = scpidev_a.query(':VOLT:IMM:AMPL?')
    print(volt)
    assert float(volt) > 0

    volt = scpidev_a.query(':VOLT:IMM:AMPL?')
    print(volt)
    assert float(volt) > 0

    scpidev_a.write(':VOLT:IMM:AMPL 3.3')
    volt_a = scpidev_a.query(':VOLT:IMM:AMPL?')

    scpidev_b.write(':VOLT:IMM:AMPL 5.0')
    volt_b = scpidev_b.query(':VOLT:IMM:AMPL?')
    assert float(volt_a) == 3.3
    assert float(volt_b) == 5.0

```

## Checklist
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] ~~Add a section on how to use the feature to doc/usage.rst~~
- [ ] ~~Add a section on how to use the feature to doc/development.rst~~
- [x] PR has been tested
- [ ] ~~Man pages have been regenerated~~

