### PR TITLE
driver/sshdriver: Add credential overriding NetworkService's

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1619,6 +1619,8 @@ Arguments:
     explicitly use the SFTP protocol for file transfers instead of scp's default protocol
   - explicit_scp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
     explicitly use the SCP protocol for file transfers instead of scp's default protocol
+  - username (str, default=username from `NetworkService`): username used by SSH
+  - password (str, default=password from `NetworkService`): password used by SSH
 
 UBootDriver
 ~~~~~~~~~~~


### PR DESCRIPTION
**Description**

This is another approche than #1291.

Here, username and password properties are added to `SSHDriver` and used instead of username and password coming from `NetworkService`.

This will answer my original issue:
> Depending on the software provisioned on a place, credentials may be different. It's my case where 3 different credentials are needed (user1/pass1 user2/pass2 user3/pass3) when soft1 or soft2 or soft3 is on the target.

`ShellDriver` and `SSHDriver` will both hold credentials in the environment configuration, where the user can adapt then to its use case.

**Checklist**
- [X] Documentation for the feature
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested locally with `ssh` and `scp`

Closes #1291