### PR TITLE
Test with Python 3.12, but don't advertise it, yet

### DIFF
--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:

--- a/tests/test_crossbar.py
+++ b/tests/test_crossbar.py
@@ -1,5 +1,6 @@
 import os
 import re
+import sys
 import time
 
 import pytest
@@ -21,6 +22,7 @@ def resume_tree(pid):
     for child in main.children(recursive=True):
         child.resume()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_startup(crossbar):
     pass
 
@@ -69,6 +71,7 @@ def test_connect_error():
         spawn.close()
         assert spawn.exitstatus == 1, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_connect_timeout(crossbar):
     suspend_tree(crossbar.pid)
     try:
@@ -81,6 +84,7 @@ def test_connect_timeout(crossbar):
         resume_tree(crossbar.pid)
         pass
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_show(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test show') as spawn:
         spawn.expect("Place 'test':")
@@ -88,6 +92,7 @@ def test_place_show(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_alias(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-alias foo') as spawn:
         spawn.expect(pexpect.EOF)
@@ -99,6 +104,7 @@ def test_place_alias(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_comment(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test set-comment my comment') as spawn:
         spawn.expect(pexpect.EOF)
@@ -112,6 +118,7 @@ def test_place_comment(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_match(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match "e1/g1/r1" "e2/g2/*"') as spawn:
         spawn.expect(pexpect.EOF)
@@ -130,6 +137,7 @@ def test_place_match(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_match_duplicates(place):
     # first given match should succeed, second should be skipped
     matches = (
@@ -150,6 +158,7 @@ def test_place_match_duplicates(place):
             spawn.close()
             assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_acquire(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
         spawn.expect(pexpect.EOF)
@@ -167,6 +176,7 @@ def test_place_acquire(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_acquire_enforce(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match does/not/exist') as spawn:
         spawn.expect(pexpect.EOF)
@@ -190,6 +200,7 @@ def test_place_acquire_enforce(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_acquire_broken(place, exporter):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match "*/Broken/*"') as spawn:
         spawn.expect(pexpect.EOF)
@@ -209,6 +220,7 @@ def test_place_acquire_broken(place, exporter):
         print(spawn.before.decode())
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_release_from(monkeypatch, place, exporter):
     user = "test-user"
     host = "test-host"
@@ -255,6 +267,7 @@ def test_place_release_from(monkeypatch, place, exporter):
         before = spawn.before.decode("utf-8").strip()
         assert user not in before and not host in before, before
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_add_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client create') as spawn:
         spawn.expect("missing place name")
@@ -262,6 +275,7 @@ def test_place_add_no_name(crossbar):
         spawn.close()
         assert spawn.exitstatus != 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_place_del_no_name(crossbar):
     with pexpect.spawn('python -m labgrid.remote.client delete') as spawn:
         spawn.expect("deletes require an exact place name")
@@ -269,6 +283,7 @@ def test_place_del_no_name(crossbar):
         spawn.close()
         assert spawn.exitstatus != 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_remoteplace_target(place_acquire, tmpdir):
     from labgrid.environment import Environment
     p = tmpdir.join("config.yaml")
@@ -289,6 +304,7 @@ def test_remoteplace_target(place_acquire, tmpdir):
     remote_place = t.get_resource("RemotePlace")
     assert remote_place.tags == {"board": "bar"}
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_remoteplace_target_without_env(request, place_acquire):
     from labgrid import Target
     from labgrid.resource import RemotePlace
@@ -297,6 +313,7 @@ def test_remoteplace_target_without_env(request, place_acquire):
     remote_place = RemotePlace(t, name="test")
     assert remote_place.tags == {"board": "bar"}
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_resource_conflict(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test2 create') as spawn:
         spawn.expect(pexpect.EOF)
@@ -318,6 +335,7 @@ def test_resource_conflict(place_acquire, tmpdir):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_reservation(place_acquire, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client reserve --shell board=bar name=test') as spawn:
         spawn.expect(pexpect.EOF)
@@ -395,6 +413,7 @@ def test_reservation(place_acquire, tmpdir):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_exporter_timeout(place, exporter):
     with pexpect.spawn('python -m labgrid.remote.client resources') as spawn:
         spawn.expect(pexpect.EOF)
@@ -432,6 +451,7 @@ def test_exporter_timeout(place, exporter):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_reservation_custom_config(place, exporter, tmpdir):
     p = tmpdir.join("config.yaml")
     p.write(
@@ -469,6 +489,7 @@ def test_reservation_custom_config(place, exporter, tmpdir):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+@pytest.mark.xfail(sys.version_info >= (3, 12), reason="latest crossbar release incompatible with python3.12+")
 def test_same_name_resources(place, exporter, tmpdir):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-named-match "testhost/Many/NetworkService" "samename"') as spawn:
         spawn.expect(pexpect.EOF)


### PR DESCRIPTION
**Description**
crossbar is not compatible with Python 3.12, yet: [1] and [2] are not part of a release. A release will probably take some more time [3][4].

We shouldn't advertise Python 3.12 support until that happens. But we can make sure that everything else keeps working fine with Python 3.12 by marking the crossbar tests as XFAIL for 3.12 and running the test suite for 3.12.

[1] https://github.com/crossbario/crossbar/pull/2091
[2] https://github.com/crossbario/crossbar/pull/2093
[3] https://github.com/crossbario/crossbar/pull/2093#issuecomment-1853007773
[4] https://github.com/crossbario/crossbar/pull/2091#issuecomment-1850126501

See also #1260 keeping track of Python 3.12 compatibility.

**Checklist**
- [x] PR has been tested