### PR TITLE
Publish arm64 Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
     tags:
       - '*'
+  release:
+    types: [ released ]
+  workflow_dispatch:
 
 env:
     QEMU_PLATFORMS: arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,11 @@ on:
     tags:
       - '*'
 
+env:
+    QEMU_PLATFORMS: arm64
+    IMAGE_PLATFORMS: linux/amd64,linux/arm64
+    IMAGE_PREFIX: ${{ secrets.DOCKERHUB_PREFIX }}
+
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -16,32 +21,27 @@ jobs:
         sudo apt install -yq python3-pip
         pip install --upgrade setuptools
         pip install setuptools_scm
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+      with:
+        platforms: ${QEMU_PLATFORMS}
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
     - name: Login to DockerHub
       uses: docker/login-action@v3
       with:
         username: ${{ secrets.DOCKERHUB_USERNAME }}
         password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build docker image
+    - name: Build amd64 docker image and validate
       run: |
-        ./dockerfiles/build.sh
+        ./dockerfiles/build.sh --load
         docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client
         docker-compose -f dockerfiles/staging/docker-compose.yml down
         docker images
-    - name: Tag latest images
-      run: |
-        docker tag labgrid-client ${{ secrets.DOCKERHUB_PREFIX }}client
-        docker tag labgrid-exporter ${{ secrets.DOCKERHUB_PREFIX }}exporter
-        docker tag labgrid-coordinator ${{ secrets.DOCKERHUB_PREFIX }}coordinator
-    - name: Tag release image
+    - name: Build, tag and push latest image for all platforms
+      run: ./dockerfiles/build.sh --platform ${IMAGE_PLATFORMS} --push
+    - name: Tag and push release image for all platforms
       if: startsWith(github.ref, 'refs/tags')
-      run: |
-        docker tag labgrid-client ${{ secrets.DOCKERHUB_PREFIX }}client:${GITHUB_REF_NAME}
-        docker tag labgrid-exporter ${{ secrets.DOCKERHUB_PREFIX }}exporter:${GITHUB_REF_NAME}
-        docker tag labgrid-coordinator ${{ secrets.DOCKERHUB_PREFIX }}coordinator:${GITHUB_REF_NAME}
-    - name: Push to dockerhub
-      run: |
-        docker push --all-tags ${{ secrets.DOCKERHUB_PREFIX }}client
-        docker push --all-tags ${{ secrets.DOCKERHUB_PREFIX }}exporter
-        docker push --all-tags ${{ secrets.DOCKERHUB_PREFIX }}coordinator
-    - name: Show images again
-      run: docker images
+      env:
+        IMAGE_TAG: ${{ github.ref_name }}
+      run: ./dockerfiles/build.sh --platform ${IMAGE_PLATFORMS} --push

--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -22,7 +22,7 @@ Example showing how to build labgrid-client image:
 
 .. code-block:: bash
 
-   $ docker build --target labgrid-client -t labgrid-client -f dockerfiles/Dockerfile .
+   $ docker build --target labgrid-client -t docker.io/labgrid/client -f dockerfiles/Dockerfile .
 
 Using `BuildKit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_
 is recommended to reduce build times.
@@ -76,7 +76,7 @@ so you can restart the service without loosing state.
 .. code-block:: bash
 
    $ docker run -t -p 20408:20408 -v $HOME/crossbar:/opt/crossbar \
-	 labgrid-coordinator
+	 docker.io/labgrid/coordinator
 
 
 labgrid-client usage
@@ -89,14 +89,14 @@ ws://192.168.1.42:20408/ws
 
 .. code-block:: bash
 
-   $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws labgrid-client \
+   $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws docker.io/labgrid/client \
 	 labgrid-client places
 
 Or running all pytest/labgrid tests at current directory:
 
 .. code-block:: bash
 
-   $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws labgrid-client \
+   $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws docker.io/labgrid/client \
 	 pytest
 
 
@@ -115,7 +115,7 @@ Start it with something like:
 
    $ docker run -e LG_CROSSBAR=ws://192.168.1.42:20408/ws \
        -v $HOME/exporter-conf:/opt/conf \
-	 labgrid-exporter
+	 docker.io/labgrid/exporter
 
 If using ser2net or if "exporting" e.g. a serial device, the devices needed must be added to Docker container
 (``docker run --device`` option).
@@ -135,14 +135,8 @@ create a setup with the following instances
 The environment serves both to allow checking if the environment still function after changes, and can act as an example
 how to configure the docker images needed to run a minimal setup.
 
-To use the staging environment to conduct a smoke test first build the images as instructed below:
-
-.. code-block:: bash
-
-   $ pip install --upgrade setuptools_scm
-   $ ./dockerfiles/build.sh
-
-Then use docker compose to start all services except the client:
+To use the staging environment to conduct a smoke test, first run docker compose to start all services except the
+client:
 
 .. code-block:: bash
 

--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -27,8 +27,9 @@ Example showing how to build labgrid-client image:
 Using `BuildKit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_
 is recommended to reduce build times.
 
-You can also choose to build all 3 images,
-with the included script.
+You can also choose to build all 3 images with the included script. The script
+will automatically use `docker buildx
+<https://docs.docker.com/engine/reference/commandline/buildx/>`` if available.
 
 .. code-block:: bash
 
@@ -43,15 +44,13 @@ The script supports ``podman`` as well.
    $ ./dockerfiles/build.sh
 
 It builds for the native platform by default. However, building
-for foreign platforms is also supported using `docker buildx
-<https://docs.docker.com/build/building/multi-platform/>` or `podman
-buildx <https://docs.podman.io/en/latest/markdown/podman-build.1.html>`
-by passing the platform of choice, e.g. `linux/arm64`.
+for foreign platforms is also supported by passing the platform(s) of choice,
+e.g. `linux/arm64` as an additional argument.
 
 .. code-block:: bash
 
    $ pip install --upgrade setuptools_scm
-   $ ./dockerfiles/build.sh linux/arm64
+   $ ./dockerfiles/build.sh --platform linux/arm64
 
 
 Usage

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -53,12 +53,14 @@ perform_regular_build() {
     docker_cmd="${1}"
     script_dir="${2}"
     version="${3}"
+    extra_args=("${@:4}")
 
     log_info "building for native platform only."
 
     for t in client exporter coordinator; do
         "${docker_cmd}" build --build-arg VERSION="${version}" \
-            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" .
+            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" \
+            "${extra_args[@]}" .
     done
 }
 
@@ -67,16 +69,17 @@ perform_docker_buildx_build() {
     docker_cmd="${1}"
     script_dir="${2}"
     version="${3}"
+    extra_args=("${@:4}")
 
     for t in client exporter coordinator; do
-        "${docker_cmd}" buildx build --platform "${platform}" --build-arg VERSION="${version}" \
-            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" .
+        "${docker_cmd}" buildx build --build-arg VERSION="${version}" \
+            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" \
+            "${extra_args[@]}" .
     done
 }
 
 main() {
-    local platform script_dir version
-    platform="${1}"
+    local script_dir version
 
     if ! has_docker && ! has_podman; then
         die "Neither docker nor podman could be found."
@@ -88,11 +91,11 @@ main() {
 
     cd "${script_dir}/.." || die "Could not cd into repo root dir"
 
-    if has_buildx "${docker_cmd}" && [ -n "${platform}" ]; then
-        perform_docker_buildx_build "${docker_cmd}" "${script_dir}" "${version}" "${platform}"
+    if has_buildx "${docker_cmd}"; then
+        perform_docker_buildx_build "${docker_cmd}" "${script_dir}" "${version}" "${@}"
     else
-        perform_regular_build "${docker_cmd}" "${script_dir}" "${version}"
+        perform_regular_build "${docker_cmd}" "${script_dir}" "${version}" "${@}"
     fi
 }
 
-main "${1}"
+main "${@}"

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
 export DOCKER_BUILDKIT=1
+: "${IMAGE_PREFIX:=docker.io/labgrid/}"
+: "${IMAGE_TAG:=latest}"
 
 die () {
     local msg
@@ -59,7 +61,7 @@ perform_regular_build() {
 
     for t in client exporter coordinator; do
         "${docker_cmd}" build --build-arg VERSION="${version}" \
-            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" \
+            --target labgrid-${t} -t "${IMAGE_PREFIX}${t}:${IMAGE_TAG}" -f "${script_dir}/Dockerfile" \
             "${extra_args[@]}" .
     done
 }
@@ -73,7 +75,7 @@ perform_docker_buildx_build() {
 
     for t in client exporter coordinator; do
         "${docker_cmd}" buildx build --build-arg VERSION="${version}" \
-            --target labgrid-${t} -t labgrid-${t}:latest -f "${script_dir}/Dockerfile" \
+            --target labgrid-${t} -t "${IMAGE_PREFIX}${t}:${IMAGE_TAG}" -f "${script_dir}/Dockerfile" \
             "${extra_args[@]}" .
     done
 }

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.3'
 services:
   coordinator:
-    image: "labgrid-coordinator"
+    image: "${IMAGE_PREFIX:-docker.io/labgrid/}coordinator"
     volumes:
       - "./crossbar:/home/root/crossbar"
     tty: true
@@ -9,7 +9,7 @@ services:
     command: bash -c "cp /home/root/crossbar/places_example.yaml /opt/crossbar/places.yaml &&
       /opt/labgrid/crossbar-venv/bin/crossbar start --config /opt/labgrid/.crossbar/config-anonymous.yaml"
   client:
-    image: "labgrid-client"
+    image: "${IMAGE_PREFIX:-docker.io/labgrid/}client"
     volumes:
       - "./client/simple-test:/simple-test"
       - "./client/.ssh:/root/.ssh"
@@ -33,7 +33,7 @@ services:
       - exporter
       - dut
   exporter:
-    image: "labgrid-exporter"
+    image: "${IMAGE_PREFIX:-docker.io/labgrid/}exporter"
     volumes:
       - "./exporter-conf:/opt/conf"
       - "/run/udev:/run/udev:ro"


### PR DESCRIPTION
Address #917 by adding support for building and publishing arm64 Docker images on CI.

The most direct way to do this seems to be docker buildx, using Github actions provider by Docker, but buildx isn't able to push multi-platform images to a local image store so some supporting changes are required to build.sh:
  1. Allow additional arguments to be passed
  2.  Use the same image names as on Docker Hub

Note that 1. changes usage for build.sh when building for a specific platform. This is addressed in README.md and hopefully addresses more use-cases, but not sure about Labgrid policy about breaking changes?

Building non-x86 platforms with Github Actions uses emulation, so enable layer caching and tweak the Dockerfile to make better use of caches.

There is an additional patch to enable image builds on release events and manual triggers.

I have run a action on top of these changes (using the manual trigger) over at my fork: https://github.com/hoyes/labgrid/actions/runs/7209149336, resulting in https://hub.docker.com/u/hoyes

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested