### PR TITLE
shelldriver: allow login with empty password

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,7 @@ Bug fixes in 23.1
   test run.
 - ManagedFile NFS detection heuristic now does symlink resolution on the
   local host.
+- The password for the ShellDriver can now be an empty string.
 
 Breaking changes in 23.1
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1558,7 +1558,8 @@ Arguments:
   - prompt (regex): shell prompt to match after logging in
   - login_prompt (regex): match for the login prompt
   - username (str): username to use during login
-  - password (str): optional, password to use during login
+  - password (str): optional, password to use during login.
+    Can be an empty string.
   - keyfile (str): optional, keyfile to upload after login, making the
     `SSHDriver`_ usable
   - login_timeout (int, default=60): timeout for login prompt detection in

--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -48,7 +48,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     prompt = attr.ib(validator=attr.validators.instance_of(str))
     login_prompt = attr.ib(validator=attr.validators.instance_of(str))
     username = attr.ib(validator=attr.validators.instance_of(str))
-    password = attr.ib(default="", validator=attr.validators.instance_of(str))
+    password = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     keyfile = attr.ib(default="", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=60, validator=attr.validators.instance_of(int))
     console_ready = attr.ib(default="", validator=attr.validators.instance_of(str))
@@ -152,7 +152,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                 did_login = True
 
             elif index == 2:
-                if self.password:
+                if self.password is not None:
                     self.console.sendline(self.password)
                 else:
                     raise Exception("Password entry needed but no password set")


### PR DESCRIPTION
**Description**

Fixes #441

Make `password` an optional field, so when is not set, it defaults to `None`. If we then get a password prompt on login, we can still raise the Exception. Otherwise it is now possible to set the password to an empty string explicitly.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature  (not sure how to test this…?)
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] CHANGES.rst has been updated
- [x] PR has been tested