### PR TITLE
Fix modbus error parsing

### DIFF
--- a/labgrid/driver/modbusdriver.py
+++ b/labgrid/driver/modbusdriver.py
@@ -28,9 +28,9 @@ class ModbusCoilDriver(Driver, DigitalOutputProtocol):
         self.client = None
 
     def _handle_error(self, action):
-        error_code = self.client.last_error()
+        error_code = self.client.last_error
         if error_code == self._consts.MB_EXCEPT_ERR:
-            exc = self.client.last_except()
+            exc = self.client.last_except
             if exc not in [self._consts.EXP_ACKNOWLEDGE, self._consts.EXP_NONE]:
                 raise ExecutionError(
                     f'Could not {action} coil (code={error_code}/exception={exc})')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ doc = [
 docker = ["docker>=5.0.2"]
 graph = ["graphviz>=0.17.0"]
 kasa = ["python-kasa>=0.4.0"]
-modbus = ["pyModbusTCP>=0.1.10"]
+modbus = ["pyModbusTCP>=0.2.0"]
 modbusrtu = ["minimalmodbus>=1.0.2"]
 mqtt = ["paho-mqtt>=1.5.1"]
 onewire = ["onewire>=0.2"]


### PR DESCRIPTION
Small pr to fix an issue with handling error with modbus.

As per the documentation: https://pymodbustcp.readthedocs.io/en/latest/package/class_ModbusClient.html#pyModbusTCP.client.ModbusClient.last_error

`last_error` is a property, not a function

