### PR TITLE
contrib: sync-places: convert tags into strings

### DIFF
--- a/contrib/sync-places.py
+++ b/contrib/sync-places.py
@@ -109,6 +109,11 @@ def main():
                     changed = True
 
             tags = config["places"][name].get("tags", {}).copy()
+            for k, v in tags.items():
+                if not isinstance(k, str) or not isinstance(v, str):
+                    del(tags[k])
+                    tags[str(k)] = str(v)
+
             if place_tags != tags:
                 print(
                     "Setting tags for place %s to %s"


### PR DESCRIPTION
**Description**

When settings tags from the command line, key, value pairs are always strings. Make sure this is the same when reading a YAML file. It can easily be done in the YAML file itself, but this makes the syntax a bit lighter.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested


This was originally a part of #1303, but was split up now that that PR is editing another file.