### PR TITLE
debian/doc/man: extend copyright period to 2024, rename next release 24.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
-Release 23.1 (unreleased)
+Release 24.0 (unreleased)
 ------------------------------------
 
-New Features in 23.1
+New Features in 24.0
 ~~~~~~~~~~~~~~~~~~~~
 - When invoking tests with pytest, the ``--log-(cli|file)-(level|format)``
   command line arguments and their corresponding pytest.ini configure options
@@ -13,7 +13,7 @@ New Features in 23.1
 - The `QEMUDriver` now has an additional ``disk_opts`` property which can be
   used to pass additional options for the disk directly to QEMU
 
-Bug fixes in 23.1
+Bug fixes in 24.0
 ~~~~~~~~~~~~~~~~~
 - The pypi release now uses the labgrid pyserial fork in the form of the
   pyserial-labgrid package. This fixes installation with newer versions
@@ -31,7 +31,7 @@ Bug fixes in 23.1
   local host.
 - The password for the ShellDriver can now be an empty string.
 
-Breaking changes in 23.1
+Breaking changes in 24.0
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 - Support for the legacy ticket authentication was dropped: If the coordinator
   logs ModuleNotFoundError on startup, switch the crossbar config to anonymous
@@ -77,7 +77,7 @@ Breaking changes in 23.1
   ``internal`` and ``external`` arguments as they do not fit the NFS mount use
   case.
 
-Known issues in 23.1
+Known issues in 24.0
 ~~~~~~~~~~~~~~~~~~~~
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,5 @@
 Release 24.0 (unreleased)
-------------------------------------
+-------------------------
 
 New Features in 24.0
 ~~~~~~~~~~~~~~~~~~~~
@@ -32,7 +32,7 @@ Bug fixes in 24.0
 - The password for the ShellDriver can now be an empty string.
 
 Breaking changes in 24.0
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 - Support for the legacy ticket authentication was dropped: If the coordinator
   logs ModuleNotFoundError on startup, switch the crossbar config to anonymous
   authentication (see ``.crossbar/config-anonymous.yaml`` for an example).
@@ -188,7 +188,7 @@ Bug fixes in 23.0
   evaluation.
 
 Breaking changes in 23.0
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 - ``Config``'s ``get_option()``/``get_target_option()`` convert non-string
   options no longer to strings.
 - `UBootDriver`'s ``boot_expression`` attribute is deprecated, it will no
@@ -268,7 +268,7 @@ Breaking changes in 0.4.0
 - ``EthernetInterface`` has been renamed to ``NetworkInterface``.
 
 Known issues in 0.4.0
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 - Some client commands return 0 even if the command failed.
 - Currently empty passwords are not well supported by the ShellDriver
 
@@ -365,7 +365,7 @@ Breaking changes in 0.3.0
   reasons.
 
 Known issues in 0.3.0
-~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 - There are several reports of ``sshpass`` used within the SSHDriver not working
   in call cases or only on the first connection.
 - Some client commands return 0 even if the command failed.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-labgrid (23.1.0) UNRELEASED; urgency=low
+labgrid (24.0.0) UNRELEASED; urgency=low
 
   * See https://github.com/labgrid-project/labgrid/blob/master/CHANGES.rst
 
- -- Bastian Krause <bst@pengutronix.de>  Wed, 26 Apr 2023 16:06:25 +0200
+ -- Bastian Krause <bst@pengutronix.de>  Wed, 01 Jan 2024 14:06:25 +0100
 
 labgrid (23.0.0) UNRELEASED; urgency=low
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,12 +3,12 @@ Upstream-Name: labgrid
 Source: https://github.com/labgrid-project/labgrid
 
 Files: *
-Copyright: Copyright (C) 2016-2023 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
-           Copyright (C) 2016-2023 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+Copyright: Copyright (C) 2016-2024 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
+           Copyright (C) 2016-2024 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
 License: LGPL-2.1+
 
 Files: man/*
-Copyright: Copyright (C) 2016-2023 Pengutronix
+Copyright: Copyright (C) 2016-2024 Pengutronix
 License: LGPL-2.1+
 
 License: LGPL-2.1+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'labgrid'
-copyright = '2016-2023 Pengutronix, Jan Luebbe and Rouven Czerwinski'
+copyright = '2016-2024 Pengutronix, Jan Luebbe and Rouven Czerwinski'
 author = 'Jan Luebbe, Rouven Czerwinski'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -266,7 +266,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2023 Pengutronix. This library is free software;
+Copyright (C) 2016-2024 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -9,7 +9,7 @@ labgrid test configuration files
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
 :Date:   2017-04-15
-:Copyright: Copyright (C) 2016-2023 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -141,7 +141,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2023 Pengutronix. This library is free software;
+Copyright (C) 2016-2024 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -9,7 +9,7 @@ labgrid-exporter interface to control boards
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
 :Date:   2017-04-15
-:Copyright: Copyright (C) 2016-2023 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-pytest.7
+++ b/man/labgrid-pytest.7
@@ -64,7 +64,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2023 Pengutronix. This library is free software;
+Copyright (C) 2016-2024 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-pytest.rst
+++ b/man/labgrid-pytest.rst
@@ -8,7 +8,7 @@ labgrid-pytest labgrid integration for pytest
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
 :Date:   2017-04-15
-:Copyright: Copyright (C) 2016-2023 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-suggest.1
+++ b/man/labgrid-suggest.1
@@ -88,7 +88,7 @@ USBSerialPort:
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2023 Pengutronix. This library is free software;
+Copyright (C) 2016-2024 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-suggest.rst
+++ b/man/labgrid-suggest.rst
@@ -8,7 +8,7 @@ labgrid-suggest generator for YAML config files
 
 :organization: Labgrid-Project
 :Date:   2021-05-20
-:Copyright: Copyright (C) 2016-2023 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)


### PR DESCRIPTION
**Description**
labgrid is under active development, so extend the copyright period to reflect that. Since we're using a calver version scheme, rename the next release to 24.0. While at it, also fix some underlines in CHANGES.rst.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Man pages have been regenerated