### PR TITLE
contrib/coordinator-statsd: Close sessions

### DIFF
--- a/contrib/coordinator-statsd.py
+++ b/contrib/coordinator-statsd.py
@@ -181,13 +181,15 @@ def main():
                 os.environ.get("LG_CROSSBAR_REALM", "realm1"),
                 extra,
             )
-
-            session.loop.run_until_complete(
-                asyncio.gather(
-                    report_places(session, args.tags, gauges),
-                    report_reservations(session, args.tags, gauges),
+            try:
+                session.loop.run_until_complete(
+                    asyncio.gather(
+                        report_places(session, args.tags, gauges),
+                        report_reservations(session, args.tags, gauges),
+                    )
                 )
-            )
+            finally:
+                session.leave()
         except labgrid.remote.client.Error as e:
             print(f"Error communicating with labgrid: {e}")
             continue


### PR DESCRIPTION
Ensures that the statsd service closes sessions after querying the coordinator.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
