### PR TITLE
CHANGES.rst: mention logging config for StepReporter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,7 +44,8 @@ Breaking changes in 24.0
   coordinator.`` on the client when running an updated coordinator, your
   coordinator configuration may set ``ticket`` instead of ``anonymous`` auth.
 - The `StepReporter` API has been changed. To start step reporting, you must
-  now call ``StepReporter.start()`` instead of ``StepReporter()``
+  now call ``StepReporter.start()`` instead of ``StepReporter()``, and set up
+  logging via ``labgrid.logging.basicConfig()``.
 - Logging output when running pytest is no longer sent to stderr by default,
   since this is both chatty and also unnecessary with the improved logging
   flexibility. It it recommended to use the ``--log-cli-level=INFO`` command


### PR DESCRIPTION
This is consistent with commit a3df4e6698880ab1f340 (2023-04-27, Rouven Czerwinski: "stepreporter: deprecate it").