### PR TITLE
Rawnetworkinterface stream

### DIFF
--- a/helpers/labgrid-raw-interface
+++ b/helpers/labgrid-raw-interface
@@ -55,13 +55,13 @@ def main(program, ifname, count):
 
     if program == "tcpreplay":
         args.append(f"--intf1={ifname}")
-        args.append('-')
+        args.append("-")
 
     if program == "tcpdump":
         args.append("-n")
         args.append(f"--interface={ifname}")
         args.append("-w")
-        args.append('-')
+        args.append("-")
 
         if count:
             args.append("-c")
@@ -75,22 +75,17 @@ def main(program, ifname, count):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-d',
-        '--debug',
-        action='store_true',
-        default=False,
-        help="enable debug mode"
-    )
-    parser.add_argument('program', type=str, help='program to run, either tcpreplay or tcpdump')
-    parser.add_argument('interface', type=str, help='interface name')
-    parser.add_argument('count', nargs="?", type=int, default=None, help='amount of frames to capture while recording')
+    parser.add_argument("-d", "--debug", action="store_true", default=False, help="enable debug mode")
+    parser.add_argument("program", type=str, help="program to run, either tcpreplay or tcpdump")
+    parser.add_argument("interface", type=str, help="interface name")
+    parser.add_argument("count", nargs="?", type=int, default=None, help="amount of frames to capture while recording")
     args = parser.parse_args()
     try:
         main(args.program, args.interface, args.count)
     except Exception as e:  # pylint: disable=broad-except
         if args.debug:
             import traceback
+
             traceback.print_exc(file=sys.stderr)
         print(f"ERROR: {e}", file=sys.stderr)
         exit(1)

--- a/helpers/labgrid-raw-interface
+++ b/helpers/labgrid-raw-interface
@@ -32,18 +32,18 @@ def get_denylist():
     return denylist
 
 
-def main(program, ifname, count):
-    if not ifname:
+def main(program, options):
+    if not options.ifname:
         raise ValueError("Empty interface name.")
-    if any((c == "/" or c.isspace()) for c in ifname):
-        raise ValueError(f"Interface name '{ifname}' contains invalid characters.")
-    if len(ifname) > 16:
-        raise ValueError(f"Interface name '{ifname}' is too long.")
+    if any((c == "/" or c.isspace()) for c in options.ifname):
+        raise ValueError(f"Interface name '{options.ifname}' contains invalid characters.")
+    if len(options.ifname) > 16:
+        raise ValueError(f"Interface name '{options.ifname}' is too long.")
 
     denylist = get_denylist()
 
-    if ifname in denylist:
-        raise ValueError(f"Interface name '{ifname}' is denied in denylist.")
+    if options.ifname in denylist:
+        raise ValueError(f"Interface name '{options.ifname}' is denied in denylist.")
 
     programs = ["tcpreplay", "tcpdump"]
     if program not in programs:
@@ -54,18 +54,18 @@ def main(program, ifname, count):
     ]
 
     if program == "tcpreplay":
-        args.append(f"--intf1={ifname}")
+        args.append(f"--intf1={options.ifname}")
         args.append("-")
 
     if program == "tcpdump":
         args.append("-n")
-        args.append(f"--interface={ifname}")
+        args.append(f"--interface={options.ifname}")
         args.append("-w")
         args.append("-")
 
-        if count:
+        if options.count:
             args.append("-c")
-            args.append(str(count))
+            args.append(str(options.count))
 
     try:
         os.execvp(args[0], args)
@@ -76,12 +76,20 @@ def main(program, ifname, count):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action="store_true", default=False, help="enable debug mode")
-    parser.add_argument("program", type=str, help="program to run, either tcpreplay or tcpdump")
-    parser.add_argument("interface", type=str, help="interface name")
-    parser.add_argument("count", nargs="?", type=int, default=None, help="amount of frames to capture while recording")
+    subparsers = parser.add_subparsers(dest="program", help="program to run")
+
+    # tcpdump
+    tcpdump_parser = subparsers.add_parser("tcpdump")
+    tcpdump_parser.add_argument("ifname", type=str, help="interface name")
+    tcpdump_parser.add_argument("count", type=int, default=None, help="amount of frames to capture while recording")
+
+    # tcpreplay
+    tcpreplay_parser = subparsers.add_parser("tcpreplay")
+    tcpreplay_parser.add_argument("ifname", type=str, help="interface name")
+
     args = parser.parse_args()
     try:
-        main(args.program, args.interface, args.count)
+        main(args.program, args)
     except Exception as e:  # pylint: disable=broad-except
         if args.debug:
             import traceback

--- a/helpers/labgrid-raw-interface
+++ b/helpers/labgrid-raw-interface
@@ -67,6 +67,14 @@ def main(program, options):
             args.append("-c")
             args.append(str(options.count))
 
+        if options.timeout:
+            # The timeout is implemented by specifying the number of seconds before rotating the
+            # dump file, but limiting the number of files to 1
+            args.append("-G")
+            args.append(str(options.timeout))
+            args.append("-W")
+            args.append("1")
+
     try:
         os.execvp(args[0], args)
     except FileNotFoundError as e:
@@ -82,6 +90,9 @@ if __name__ == "__main__":
     tcpdump_parser = subparsers.add_parser("tcpdump")
     tcpdump_parser.add_argument("ifname", type=str, help="interface name")
     tcpdump_parser.add_argument("count", type=int, default=None, help="amount of frames to capture while recording")
+    tcpdump_parser.add_argument(
+        "--timeout", type=int, default=None, help="Amount of time to capture while recording. 0 means capture forever"
+    )
 
     # tcpreplay
     tcpreplay_parser = subparsers.add_parser("tcpreplay")

--- a/helpers/labgrid-raw-interface
+++ b/helpers/labgrid-raw-interface
@@ -60,6 +60,10 @@ def main(program, options):
     if program == "tcpdump":
         args.append("-n")
         args.append(f"--interface={options.ifname}")
+        # Write out each packet as it is received
+        args.append("--packet-buffered")
+        # Capture complete packets (for compatibility with older tcpdump versions)
+        args.append("--snapshot-length=0")
         args.append("-w")
         args.append("-")
 

--- a/labgrid/driver/rawnetworkinterfacedriver.py
+++ b/labgrid/driver/rawnetworkinterfacedriver.py
@@ -170,12 +170,7 @@ class RawNetworkInterfaceDriver(Driver):
         """
         Returns basic interface statistics of bound network interface resource.
         """
-        cmd = self.iface.command_prefix + [
-            "ip",
-            "--json",
-            "-stats", "-stats",
-            "link", "show",
-            self.iface.ifname]
+        cmd = self.iface.command_prefix + ["ip", "--json", "-stats", "-stats", "link", "show", self.iface.ifname]
         output = processwrapper.check_output(cmd)
         return json.loads(output)[0]
 


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Adds support for live streaming packets from a RawNetworkInterfaceDriver. This can be useful for writing tests that parse packets in real time looking for a specific pattern, for example:

```python
import dpkt
    
drv = target.get_driver("RawNetworkInterfaceDriver")
    
with drv.record("-", timeout=60) as p:
    pcap = dpkt.pcap.Reader(p.stdout)
    for timestamp, buf in pcap:
        eth = dpkt.ethernet.Ethernet(buf)

        if _some_criteria_:
            break
    else:
        assert False, "Packet not found!"
```
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
