### PR TITLE
Small formal Documentation Update

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2418,6 +2418,8 @@ Binds to:
 
    TFTPProviderDriver: {}
 
+   HTTPProviderDriver: {}
+
 Arguments:
   - None
 


### PR DESCRIPTION
Adjust the section ```TFTPProviderDriver / HTTPProviderDriver``` in the _Configuration_ chapter to what is found in sections ```TFTPProvider / HTTPProvider``` & ```RemoteTFTPProvider / RemoteHTTPProvider``` and enumerate the ```HTTPProviderDriver``` in the code-block, too.