### PR TITLE
doc/configuration: update/fix bindings, protocols and resource usage

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -8,8 +8,8 @@ have no dependencies.
 .. image:: res/config_graph.svg
    :width: 50%
 
-Here the resource `RawSerialPort` provides the information for the
-`SerialDriver`, which in turn is needed by the `ShellDriver`.
+Here the resource `RawSerialPort`_ provides the information for the
+`SerialDriver`_, which in turn is needed by the `ShellDriver`_.
 Driver dependency resolution is done by searching for the driver which
 implements the dependent protocol, all drivers implement one or more protocols.
 
@@ -21,8 +21,8 @@ Serial Ports
 
 RawSerialPort
 +++++++++++++
-A RawSerialPort is a serial port which is identified via the device path on the
-local computer.
+A :any:`RawSerialPort` is a serial port which is identified via the device path
+on the local computer.
 Take note that re-plugging USB serial converters can result in a different
 enumeration order.
 
@@ -44,8 +44,9 @@ Used by:
 
 NetworkSerialPort
 +++++++++++++++++
-A NetworkSerialPort describes a serial port which is exported over the network,
-usually using RFC2217 or raw tcp.
+A :any:`NetworkSerialPort` describes a serial port which is exported over the
+network, usually using `RFC2217 <https://datatracker.ietf.org/doc/rfc2217/>`_
+or raw tcp.
 
 .. code-block:: yaml
 
@@ -69,7 +70,7 @@ Used by:
 
 ModbusRTU
 +++++++++
-Describes the resource required to use the ModbusRTU driver.
+A :any:`ModbusRTU` resource is required to use the `ModbusRTUDriver`_.
 `Modbus RTU <https://en.wikipedia.org/wiki/Modbus>`_ is a communication
 protocol used to control many different kinds of electronic systems, such as
 thermostats, power plants, etc.
@@ -77,11 +78,11 @@ Modbus is normally implemented on top of RS-485, though this is not strictly
 necessary, as long as the Modbus network only has one master (and up to 256
 slaves).
 
-The labgrid driver is implemented using the minimalmodbus Python library.
+The labgrid driver is implemented using the
+`minimalmodbus <https://minimalmodbus.readthedocs.io/en/stable/>`_ Python
+library.
 The implementation only supports that labgrid will be the master on the Modbus
 network.
-For more information, see `minimalmodbus
-<https://minimalmodbus.readthedocs.io/en/stable/>`_.
 
 This resource and driver only supports local usage and will not work with an
 exporter.
@@ -105,8 +106,8 @@ Used by:
 
 USBSerialPort
 +++++++++++++
-A USBSerialPort describes a serial port which is connected via USB and is
-identified by matching udev properties.
+A :any:`USBSerialPort` describes a serial port which is connected via USB and
+is identified by matching udev properties.
 This allows identification through hot-plugging or rebooting.
 
 .. code-block:: yaml
@@ -133,7 +134,7 @@ Power Ports
 
 NetworkPowerPort
 ++++++++++++++++
-A NetworkPowerPort describes a remotely switchable power port.
+A :any:`NetworkPowerPort` describes a remotely switchable power port.
 
 .. code-block:: yaml
 
@@ -241,7 +242,7 @@ Used by:
 
 PDUDaemonPort
 +++++++++++++
-A PDUDaemonPort describes a PDU port accessible via `PDUDaemon
+A :any:`PDUDaemonPort` describes a PDU port accessible via `PDUDaemon
 <https://github.com/pdudaemon/pdudaemon>`_.
 As one PDUDaemon instance can control many PDUs, the instance name from the
 PDUDaemon configuration file needs to be specified.
@@ -266,7 +267,7 @@ Used by:
 
 YKUSHPowerPort
 ++++++++++++++
-A YKUSHPowerPort describes a YEPKIT YKUSH USB (HID) switchable USB hub.
+A :any:`YKUSHPowerPort` describes a YEPKIT YKUSH USB (HID) switchable USB hub.
 
 .. code-block:: yaml
 
@@ -287,11 +288,12 @@ Used by:
 
 NetworkYKUSHPowerPort
 +++++++++++++++++++++
-A NetworkYKUSHPowerPort describes a `YKUSHPowerPort`_ available on a remote computer.
+A :any:`NetworkYKUSHPowerPort` describes a `YKUSHPowerPort`_ available on a
+remote computer.
 
 USBPowerPort
 ++++++++++++
-A USBPowerPort describes a generic switchable USB hub as supported by
+A :any:`USBPowerPort` describes a generic switchable USB hub as supported by
 `uhubctl <https://github.com/mvp/uhubctl>`_.
 
 .. code-block:: yaml
@@ -321,7 +323,7 @@ Used by:
 
 SiSPMPowerPort
 ++++++++++++++
-A SiSPMPowerPort describes a GEMBIRD SiS-PM as supported by
+A :any:`SiSPMPowerPort` describes a GEMBIRD SiS-PM as supported by
 `sispmctl <https://sourceforge.net/projects/sispmctl/>`_.
 
 .. code-block:: yaml
@@ -343,8 +345,8 @@ Used by:
 
 TasmotaPowerPort
 ++++++++++++++++
-A :any:`TasmotaPowerPort` resource describes a switchable Tasmota power outlet
-accessed over MQTT.
+A :any:`TasmotaPowerPort` resource describes a switchable `Tasmota
+<https://tasmota.github.io/docs/>`_ power outlet accessed over MQTT.
 
 .. code-block:: yaml
 
@@ -373,7 +375,7 @@ Digital Outputs
 
 ModbusTCPCoil
 +++++++++++++
-A ModbusTCPCoil describes a coil accessible via ModbusTCP.
+A :any:`ModbusTCPCoil` describes a coil accessible via ModbusTCP.
 
 .. code-block:: yaml
 
@@ -397,7 +399,7 @@ Used by:
 
 DeditecRelais8
 ++++++++++++++
-A DeditecRelais8 describes a Deditec USB GPO module with 8 relays.
+A :any:`DeditecRelais8` describes a Deditec USB GPO module with 8 relays.
 
 .. code-block:: yaml
 
@@ -418,7 +420,7 @@ Used by:
 
 OneWirePIO
 ++++++++++
-A OneWirePIO describes a onewire programmable I/O pin.
+A :any:`OneWirePIO` describes a onewire programmable I/O pin.
 
 .. code-block:: yaml
 
@@ -465,7 +467,7 @@ Used by:
 
 NetworkLXAIOBusPIO
 ++++++++++++++++++
-A NetworkLXAIOBusPIO describes an `LXAIOBusPIO`_ exported over the network.
+A :any:`NetworkLXAIOBusPIO` describes an `LXAIOBusPIO`_ exported over the network.
 
 HIDRelay
 ++++++++
@@ -491,7 +493,7 @@ Used by:
 
 HttpDigitalOutput
 +++++++++++++++++
-A ``HttpDigitalOutput`` resource describes a generic digital output that can be
+A :any:`HttpDigitalOutput` resource describes a generic digital output that can be
 controlled via HTTP.
 
 .. code-block:: yaml
@@ -524,11 +526,11 @@ Used by:
 
 NetworkHIDRelay
 +++++++++++++++
-A NetworkHIDRelay describes an `HIDRelay`_ exported over the network.
+A :any:`NetworkHIDRelay` describes an `HIDRelay`_ exported over the network.
 
 NetworkService
 ~~~~~~~~~~~~~~
-A NetworkService describes a remote SSH connection.
+A :any:`NetworkService` describes a remote SSH connection.
 
 .. code-block:: yaml
 
@@ -559,7 +561,8 @@ Used by:
 
 USBMassStorage
 ~~~~~~~~~~~~~~
-A USBMassStorage resource describes a USB memory stick or similar device.
+A :any:`USBMassStorage` resource describes a USB memory stick or similar
+device.
 
 .. code-block:: yaml
 
@@ -575,7 +578,7 @@ Used by:
 
 NetworkUSBMassStorage
 ~~~~~~~~~~~~~~~~~~~~~
-A NetworkUSBMassStorage resource describes a USB memory stick or similar
+A :any:`NetworkUSBMassStorage` resource describes a USB memory stick or similar
 device available on a remote computer.
 
 The NetworkUSBMassStorage can be used in test cases by calling the
@@ -583,8 +586,8 @@ The NetworkUSBMassStorage can be used in test cases by calling the
 
 SigrokDevice
 ~~~~~~~~~~~~
-A SigrokDevice resource describes a sigrok device. To select a specific device
-from all connected supported devices use the `SigrokUSBDevice`_.
+A :any:`SigrokDevice` resource describes a sigrok device. To select a specific
+device from all connected supported devices use the `SigrokUSBDevice`_.
 
 .. code-block:: yaml
 
@@ -602,7 +605,7 @@ Used by:
 
 IMXUSBLoader
 ~~~~~~~~~~~~
-An IMXUSBLoader resource describes a USB device in the imx loader state.
+An :any:`IMXUSBLoader` resource describes a USB device in the imx loader state.
 
 .. code-block:: yaml
 
@@ -620,7 +623,7 @@ Used by:
 
 MXSUSBLoader
 ~~~~~~~~~~~~
-An MXSUSBLoader resource describes a USB device in the mxs loader state.
+An :any:`MXSUSBLoader` resource describes a USB device in the mxs loader state.
 
 .. code-block:: yaml
 
@@ -638,7 +641,8 @@ Used by:
 
 RKUSBLoader
 ~~~~~~~~~~~
-An RKUSBLoader resource describes a USB device in the rockchip loader state.
+An :any:`RKUSBLoader` resource describes a USB device in the rockchip loader
+state.
 
 .. code-block:: yaml
 
@@ -654,19 +658,23 @@ Used by:
 
 NetworkMXSUSBLoader
 ~~~~~~~~~~~~~~~~~~~
-A NetworkMXSUSBLoader describes an `MXSUSBLoader`_ available on a remote computer.
+A :any:`NetworkMXSUSBLoader` describes an `MXSUSBLoader`_ available on a remote
+computer.
 
 NetworkIMXUSBLoader
 ~~~~~~~~~~~~~~~~~~~
-A NetworkIMXUSBLoader describes an `IMXUSBLoader`_ available on a remote computer.
+A :any:`NetworkIMXUSBLoader` describes an `IMXUSBLoader`_ available on a remote
+computer.
 
 NetworkRKUSBLoader
 ~~~~~~~~~~~~~~~~~~
-A NetworkRKUSBLoader describes an `RKUSBLoader`_ available on a remote computer.
+A :any:`NetworkRKUSBLoader` describes an `RKUSBLoader`_ available on a remote
+computer.
 
 AndroidUSBFastboot
 ~~~~~~~~~~~~~~~~~~
-An AndroidUSBFastboot resource describes a USB device in the fastboot state.
+An :any:`AndroidUSBFastboot` resource describes a USB device in the fastboot
+state.
 Previously, this resource was named AndroidFastboot and this name still
 supported for backwards compatibility.
 
@@ -688,7 +696,8 @@ Used by:
 
 AndroidNetFastboot
 ~~~~~~~~~~~~~~~~~~
-An AndroidNetFastboot resource describes a network device in fastboot state.
+An :any:`AndroidNetFastboot` resource describes a network device in fastboot
+state.
 
 .. code-block:: yaml
 
@@ -707,8 +716,8 @@ Used by:
 
 DFUDevice
 ~~~~~~~~~
-A DFUDevice resource describes a USB device in DFU (Device Firmware Upgrade)
-mode.
+A :any:`DFUDevice` resource describes a USB device in DFU (Device Firmware
+Upgrade) mode.
 
 .. code-block:: yaml
 
@@ -724,8 +733,8 @@ Used by:
 
 NetworkInterface
 ~~~~~~~~~~~~~~~~
-A NetworkInterface resource describes a network adapter (such as Ethernet or
-WiFi)
+A :any:`NetworkInterface` resource describes a network adapter (such as
+Ethernet or WiFi)
 
 .. code-block:: yaml
 
@@ -741,7 +750,7 @@ Used by:
 
 USBNetworkInterface
 ~~~~~~~~~~~~~~~~~~~
-A USBNetworkInterface resource describes a USB network adapter (such as
+A :any:`USBNetworkInterface` resource describes a USB network adapter (such as
 Ethernet or WiFi)
 
 .. code-block:: yaml
@@ -759,12 +768,12 @@ Used by:
 
 RemoteNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~~~
-A :any:`RemoteNetworkInterface` resource describes a :any:`NetworkInterface` or
-:any:`USBNetworkInterface` resource available on a remote computer.
+A :any:`RemoteNetworkInterface` resource describes a `NetworkInterface`_ or
+`USBNetworkInterface`_ resource available on a remote computer.
 
 AlteraUSBBlaster
 ~~~~~~~~~~~~~~~~
-An AlteraUSBBlaster resource describes an Altera USB blaster.
+An :any:`AlteraUSBBlaster` resource describes an Altera USB blaster.
 
 .. code-block:: yaml
 
@@ -781,8 +790,8 @@ Used by:
 
 USBDebugger
 ~~~~~~~~~~~
-An USBDebugger resource describes a JTAG USB adapter (for example an FTDI
-FT2232H).
+An :any:`USBDebugger` resource describes a JTAG USB adapter (for example an
+FTDI FT2232H).
 
 .. code-block:: yaml
 
@@ -798,8 +807,8 @@ Used by:
 
 SNMPEthernetPort
 ~~~~~~~~~~~~~~~~
-A SNMPEthernetPort resource describes a port on an Ethernet switch, which is
-accessible via SNMP.
+A :any:`SNMPEthernetPort` resource describes a port on an Ethernet switch,
+which is accessible via SNMP.
 
 .. code-block:: yaml
 
@@ -816,7 +825,7 @@ Used by:
 
 SigrokUSBDevice
 ~~~~~~~~~~~~~~~
-A SigrokUSBDevice resource describes a sigrok USB device.
+A :any:`SigrokUSBDevice` resource describes a sigrok USB device.
 
 .. code-block:: yaml
 
@@ -837,14 +846,15 @@ Used by:
 
 NetworkSigrokUSBDevice
 ~~~~~~~~~~~~~~~~~~~~~~
-A NetworkSigrokUSBDevice resource describes a sigrok USB device connected to a
-host which is exported over the network. The SigrokDriver will access it via SSH.
+A :any:`NetworkSigrokUSBDevice` resource describes a sigrok USB device
+connected to a host which is exported over the network.
+The `SigrokDriver`_ will access it via SSH.
 
 SigrokUSBSerialDevice
 ~~~~~~~~~~~~~~~~~~~~~
-A SigrokUSBSerialDevice resource describes a sigrok device which communicates
-of a USB serial port instead of being a USB device itself (see
-`SigrokUSBDevice` for that case).
+A :any:`SigrokUSBSerialDevice` resource describes a sigrok device which
+communicates over a USB serial port instead of being a USB device itself (see
+`SigrokUSBDevice`_ for that case).
 
 .. code-block:: yaml
 
@@ -966,7 +976,7 @@ Used by:
 
 NetworkUSBVideo
 ~~~~~~~~~~~~~~~
-A :any:`NetworkUSBVideo` resource describes a :any:`USBVideo` resource available
+A :any:`NetworkUSBVideo` resource describes a `USBVideo`_ resource available
 on a remote computer.
 
 USBAudioInput
@@ -990,7 +1000,7 @@ Used by:
 
 NetworkUSBAudioInput
 ~~~~~~~~~~~~~~~~~~~~
-A :any:`NetworkUSBAudioInput` resource describes a :any:`USBAudioInput` resource
+A :any:`NetworkUSBAudioInput` resource describes a `USBAudioInput`_ resource
 available on a remote computer.
 
 USBTMC
@@ -1020,13 +1030,15 @@ Used by:
 
 NetworkUSBTMC
 ~~~~~~~~~~~~~
-A :any:`NetworkUSBTMC` resource describes a :any:`USBTMC` resource available
+A :any:`NetworkUSBTMC` resource describes a `USBTMC`_ resource available
 on a remote computer.
 
 Flashrom
 ~~~~~~~~
-A Flashrom resource is used to configure the parameters to a local installed flashrom instance.
-It is assumed that flashrom is installed on the host and the executable is configured in:
+A :any:`Flashrom` resource is used to configure the parameters to a local
+installed flashrom instance.
+It is assumed that flashrom is installed on the host and the executable is
+configured in:
 
 .. code-block:: yaml
 
@@ -1052,13 +1064,14 @@ Used by:
 
 NetworkFlashrom
 ~~~~~~~~~~~~~~~
-A NetworkFlashrom describes a `Flashrom`_ available on a remote computer.
+A :any:`NetworkFlashrom` describes a `Flashrom`_ available on a remote computer.
 
 USBFlashableDevice
 ~~~~~~~~~~~~~~~~~~
-Represents an "opaque" USB device used by custom flashing programs. There is
-usually not anything useful that can be done with the interface other than
-running a flashing program with `FlashScriptDriver`_.
+A :any:`USBFlashableDevice` represents an "opaque" USB device used by custom
+flashing programs.
+There is usually not anything useful that can be done with the interface other
+than running a flashing program with `FlashScriptDriver`_.
 
 .. note::
    This resource is only intended to be used as a last resort when it is
@@ -1079,15 +1092,16 @@ Used by:
 
 NetworkUSBFlashableDevice
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-A :any:`NetworkUSBFlashableDevice` resource describes a :any:`USBFlashableDevice`
+A :any:`NetworkUSBFlashableDevice` resource describes a `USBFlashableDevice`_
 resource available on a remote computer
 
 
 DediprogFlasher
 ~~~~~~~~~~~~~~~
-A DediprogFlasher resource is used to configure the parameters to a locally installed
-dpmcd instance. It is assumed that dpcmd is installed on the host and the
-executable can be configured via:
+A :any:`DediprogFlasher` resource is used to configure the parameters to a
+locally installed dpmcd instance.
+It is assumed that dpcmd is installed on the host and the executable can be
+configured via:
 
 .. code-block:: yaml
 
@@ -1109,12 +1123,13 @@ Used by:
 
 NetworkDediprogFlasher
 ~~~~~~~~~~~~~~~~~~~~~~
-A NetworkDediprogFlasher describes a `DediprogFlasher`_ available on a remote computer.
+A :any:`NetworkDediprogFlasher` describes a `DediprogFlasher`_ available on a
+remote computer.
 
 XenaManager
 ~~~~~~~~~~~
-A XenaManager resource describes a Xena Manager instance which is the instance the
-`XenaDriver`_ must connect to in order to configure a Xena chassis.
+A :any:`XenaManager` resource describes a Xena Manager instance which is the
+instance the `XenaDriver`_ must connect to in order to configure a Xena chassis.
 
 .. code-block:: yaml
 
@@ -1129,7 +1144,8 @@ Used by:
 
 PyVISADevice
 ~~~~~~~~~~~~
-A PyVISADevice resource describes a test stimuli device controlled by PyVISA.
+A :any:`PyVISADevice` resource describes a test stimuli device controlled by
+PyVISA.
 Such device could be a signal generator.
 
 .. code-block:: yaml
@@ -1169,8 +1185,8 @@ specific protocol.
 This is useful for software installation in the bootloader (via TFTP) or
 downloading update artifacts under Linux (via HTTP).
 
-They are used with the ManagedFile helper, which ensures that the file is
-available on the server. For HTTP and TFTP, a symlink from the internal
+They are used with the :any:`ManagedFile` helper, which ensures that the file
+is available on the server. For HTTP and TFTP, a symlink from the internal
 directory to the uploaded file is created.
 The path for the target is generated by replacing the internal prefix with the
 external prefix.
@@ -1186,6 +1202,9 @@ labgrid.
 
 TFTPProvider / HTTPProvider
 +++++++++++++++++++++++++++
+A :any:`TFTPProvider` resource describes TFTP server.
+A :any:`HTTPProvider` resource describes an HTTP server.
+
 .. code-block:: yaml
 
    TFTPProvider:
@@ -1206,6 +1225,8 @@ Used by:
 
 NFSProvider
 +++++++++++
+An :any:`NFSProvider` resource describes an NFS server.
+
 .. code-block:: yaml
 
    NFSProvider: {}
@@ -1221,8 +1242,10 @@ Used by:
 
 RemoteTFTPProvider / RemoteHTTPProvider
 +++++++++++++++++++++++++++++++++++++++
-These describe a `TFTPProvider`_ or `HTTPProvider`_ resource available on a
-remote computer.
+A :any:`RemoteTFTPProvider` describes a `TFTPProvider`_ resource available on
+a remote computer.
+A :any:`RemoteHTTPProvider` describes a `HTTPProvider`_ resource available on
+a remote computer.
 
 .. code-block:: yaml
 
@@ -1247,7 +1270,8 @@ Used by:
 
 RemoteNFSProvider
 +++++++++++++++++
-An `NFSProvider`_ resource available on a remote computer.
+A :any:`RemoteNFSProvider` describes an `NFSProvider`_ resource available on a
+remote computer.
 
 .. code-block:: yaml
 
@@ -1262,7 +1286,8 @@ Used by:
 
 RemotePlace
 ~~~~~~~~~~~
-A RemotePlace describes a set of resources attached to a labgrid remote place.
+A :any:`RemotePlace` describes a set of resources attached to a labgrid remote
+place.
 
 .. code-block:: yaml
 
@@ -1281,8 +1306,8 @@ Used by:
 
 DockerDaemon
 ~~~~~~~~~~~~
-A DockerDaemon describes where to contact a docker daemon process.
-DockerDaemon also participates in managing `NetworkService` instances
+A :any:`DockerDaemon` describes where to contact a docker daemon process.
+DockerDaemon also participates in managing `NetworkService`_ instances
 created through interaction with that daemon.
 
 .. code-block:: yaml
@@ -1291,16 +1316,16 @@ created through interaction with that daemon.
      docker_daemon_url: unix://var/run/docker.sock
 
 The example describes a docker daemon accessible via the
-'/var/run/docker.sock' unix socket. When used by a `DockerDriver`, the
-`DockerDriver` will first create a docker container which the
+``/var/run/docker.sock`` unix socket. When used by a `DockerDriver`_, the
+`DockerDriver`_ will first create a docker container which the
 DockerDaemon resource will subsequently use to create one/more
-`NetworkService` instances - as specified by `DockerDriver` configuration.
-Each `NetworkService` instance corresponds to a network service running inside
+`NetworkService`_ instances - as specified by `DockerDriver`_ configuration.
+Each `NetworkService`_ instance corresponds to a network service running inside
 the container.
 
 Moreover, DockerDaemon will remove any hanging containers if
 DockerDaemon is used several times in a row - as is the case when
-executing test suites. Normally `DockerDriver` - when deactivated -
+executing test suites. Normally `DockerDriver`_ - when deactivated -
 cleans up the created docker container; programming errors, keyboard
 interrupts or unix kill signals may lead to hanging containers, however;
 therefore auto-cleanup is important.
@@ -1383,7 +1408,7 @@ with ``udevadm info /dev/ttyUSB0``.
 
 Note the ``@`` in the ``@ID_PATH`` match, which applies this match to the
 device's parents instead of directly to itself.
-This is necessary for the `USBSerialPort` because we actually want to find the
+This is necessary for the `USBSerialPort`_ because we actually want to find the
 ``ttyUSB?`` device below the USB serial converter device.
 
 Matching an Android USB Fastboot Device
@@ -1498,8 +1523,8 @@ Drivers
 
 SerialDriver
 ~~~~~~~~~~~~
-A SerialDriver connects to a serial port. It requires one of the serial port
-resources.
+A :any:`SerialDriver` connects to a serial port. It requires one of the serial
+port resources.
 
 Binds to:
   port:
@@ -1523,8 +1548,8 @@ Arguments:
 
 ModbusRTUDriver
 ~~~~~~~~~~~~~~~
-A ModbusRTUDriver connects to a ModbusRTU resource. This driver only supports
-local usage and will not work with an exporter.
+A :any:`ModbusRTUDriver` connects to a ModbusRTU resource. This driver only
+supports local usage and will not work with an exporter.
 
 .. code-block:: yaml
 
@@ -1542,8 +1567,8 @@ Arguments:
 
 ShellDriver
 ~~~~~~~~~~~
-A ShellDriver binds on top of a `ConsoleProtocol` and is designed to interact
-with a login prompt and a Linux shell.
+A :any:`ShellDriver` binds on top of a :any:`ConsoleProtocol` and is designed
+to interact with a login prompt and a Linux shell.
 
 Binds to:
   console:
@@ -1593,8 +1618,8 @@ Arguments:
 
 SSHDriver
 ~~~~~~~~~
-A SSHDriver requires a `NetworkService` resource and allows the execution of
-commands and file upload via network.
+A :any:`SSHDriver` requires a `NetworkService`_ resource and allows the
+execution of commands and file upload via network.
 It uses SSH's `ServerAliveInterval` option to detect failed connections.
 
 If a shared SSH connection to the target is already open, it will reuse it when
@@ -1617,7 +1642,7 @@ Implements:
 
 Arguments:
   - keyfile (str): optional, filename of private key to login into the remote system
-    (has precedence over `NetworkService`'s password)
+    (has precedence over `NetworkService`_'s password)
   - stderr_merge (bool, default=False): set to True to make `run()` return stderr merged with
     stdout, and an empty list as second element.
   - connection_timeout (float, default=30.0): timeout when trying to establish connection to
@@ -1626,12 +1651,13 @@ Arguments:
     explicitly use the SFTP protocol for file transfers instead of scp's default protocol
   - explicit_scp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
     explicitly use the SCP protocol for file transfers instead of scp's default protocol
-  - username (str, default=username from `NetworkService`): username used by SSH
-  - password (str, default=password from `NetworkService`): password used by SSH
+  - username (str, default=username from `NetworkService`_): username used by SSH
+  - password (str, default=password from `NetworkService`_): password used by SSH
 
 UBootDriver
 ~~~~~~~~~~~
-A UBootDriver interfaces with a U-Boot bootloader via a `ConsoleProtocol`.
+A :any:`UBootDriver` interfaces with a U-Boot bootloader via a
+:any:`ConsoleProtocol`.
 
 Binds to:
   console:
@@ -1665,8 +1691,8 @@ Arguments:
 
 SmallUBootDriver
 ~~~~~~~~~~~~~~~~
-A SmallUBootDriver interfaces with stripped-down U-Boot variants that are
-sometimes used in cheap consumer electronics.
+A :any:`SmallUBootDriver` interfaces with stripped-down U-Boot variants that
+are sometimes used in cheap consumer electronics.
 
 SmallUBootDriver is meant as a driver for U-Boot with only little functionality
 compared to a standard U-Boot.
@@ -1718,7 +1744,8 @@ Arguments:
 
 BareboxDriver
 ~~~~~~~~~~~~~
-A BareboxDriver interfaces with a barebox bootloader via a `ConsoleProtocol`.
+A :any:`BareboxDriver` interfaces with a *barebox* bootloader via a
+:any:`ConsoleProtocol`.
 
 Binds to:
   console:
@@ -1744,8 +1771,8 @@ Arguments:
 
 ExternalConsoleDriver
 ~~~~~~~~~~~~~~~~~~~~~
-An ExternalConsoleDriver implements the `ConsoleProtocol` on top of a command
-executed on the local computer.
+An :any:`ExternalConsoleDriver` implements the :any:`ConsoleProtocol` on top of
+a command executed on the local computer.
 
 Binds to:
   - None
@@ -1765,8 +1792,8 @@ Arguments:
 
 AndroidFastbootDriver
 ~~~~~~~~~~~~~~~~~~~~~
-An AndroidFastbootDriver allows the upload of images to a device in the USB or
-network fastboot state.
+An :any:`AndroidFastbootDriver` allows the upload of images to a device in the
+USB or network fastboot state.
 
 Binds to:
   fastboot:
@@ -1795,8 +1822,8 @@ Arguments:
 
 DFUDriver
 ~~~~~~~~~
-A DFUDriver allows the download of images to a device in DFU (Device Firmware
-Upgrade) mode.
+A :any:`DFUDriver` allows the download of images to a device in DFU (Device
+Firmware Upgrade) mode.
 
 Binds to:
   dfu:
@@ -1815,7 +1842,8 @@ Arguments:
 
 OpenOCDDriver
 ~~~~~~~~~~~~~
-An OpenOCDDriver controls OpenOCD to bootstrap a target with a bootloader.
+An :any:`OpenOCDDriver` controls OpenOCD to bootstrap a target with a
+bootloader.
 
 Note that OpenOCD supports specifying USB paths since
 `a1b308ab <https://sourceforge.net/p/openocd/code/ci/a1b308ab/>`_ which was released with v0.11.
@@ -1857,8 +1885,8 @@ Arguments:
 
 QuartusHPSDriver
 ~~~~~~~~~~~~~~~~
-A QuartusHPSDriver controls the "Quartus Prime Programmer and Tools" to flash
-a target's QSPI.
+A :any:`QuartusHPSDriver` controls the "Quartus Prime Programmer and Tools" to
+flash a target's QSPI.
 
 Binds to:
   interface:
@@ -1876,8 +1904,9 @@ example strategy is included in labgrid.
 
 ManualPowerDriver
 ~~~~~~~~~~~~~~~~~
-A ManualPowerDriver requires the user to control the target power states. This
-is required if a strategy is used with the target, but no automatic power
+A :any:`ManualPowerDriver` requires the user to control the target power
+states.
+This is required if a strategy is used with the target, but no automatic power
 control is available.
 
 The driver's name will be displayed during interaction.
@@ -1899,7 +1928,8 @@ Arguments:
 
 ExternalPowerDriver
 ~~~~~~~~~~~~~~~~~~~
-An ExternalPowerDriver is used to control a target power state via an external command.
+An :any:`ExternalPowerDriver` is used to control a target power state via an
+external command.
 
 Binds to:
   - None
@@ -1923,8 +1953,8 @@ Arguments:
 
 NetworkPowerDriver
 ~~~~~~~~~~~~~~~~~~
-A NetworkPowerDriver controls a `NetworkPowerPort`, allowing control of the
-target power state without user interaction.
+A :any:`NetworkPowerDriver` controls a `NetworkPowerPort`_, allowing control of
+the target power state without user interaction.
 
 Binds to:
   port:
@@ -1944,8 +1974,8 @@ Arguments:
 
 PDUDaemonDriver
 ~~~~~~~~~~~~~~~
-A PDUDaemonDriver controls a `PDUDaemonPort`, allowing control of the target
-power state without user interaction.
+A :any:`PDUDaemonDriver` controls a `PDUDaemonPort`_, allowing control of the
+target power state without user interaction.
 
 .. note::
   PDUDaemon processes commands in the background, so the actual state change
@@ -1969,7 +1999,7 @@ Arguments:
 
 YKUSHPowerDriver
 ~~~~~~~~~~~~~~~~
-A YKUSHPowerDriver controls a `YKUSHPowerPort`, allowing control of the
+A :any:`YKUSHPowerDriver` controls a `YKUSHPowerPort`_, allowing control of the
 target power state without user interaction.
 
 Binds to:
@@ -1991,8 +2021,8 @@ Arguments:
 
 DigitalOutputPowerDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~
-A DigitalOutputPowerDriver can be used to control the power of a
-device using a DigitalOutputDriver.
+A :any:`DigitalOutputPowerDriver` can be used to control the power of a device
+using a DigitalOutputDriver.
 
 Using this driver you probably want an external relay to switch the
 power of your DUT.
@@ -2015,8 +2045,8 @@ Arguments:
 
 USBPowerDriver
 ~~~~~~~~~~~~~~
-A USBPowerDriver controls a `USBPowerPort`, allowing control of the target
-power state without user interaction.
+A :any:`USBPowerDriver` controls a `USBPowerPort`_, allowing control of the
+target power state without user interaction.
 
 Binds to:
   hub:
@@ -2037,8 +2067,8 @@ Arguments:
 
 SiSPMPowerDriver
 ~~~~~~~~~~~~~~~~
-A SiSPMPowerDriver controls a `SiSPMPowerPort`, allowing control of the target
-power state without user interaction.
+A :any:`SiSPMPowerDriver` controls a `SiSPMPowerPort`_, allowing control of the
+target power state without user interaction.
 
 Binds to:
   port:
@@ -2059,8 +2089,8 @@ Arguments:
 
 TasmotaPowerDriver
 ~~~~~~~~~~~~~~~~~~
-A TasmotaPowerDriver controls a `TasmotaPowerPort`, allowing the outlet to be
-switched on and off.
+A :any:`TasmotaPowerDriver` controls a `TasmotaPowerPort`_, allowing the outlet
+to be switched on and off.
 
 Binds to:
   power:
@@ -2079,7 +2109,7 @@ Arguments:
 
 GpioDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~
-The GpioDigitalOutputDriver writes a digital signal to a GPIO line.
+The :any:`GpioDigitalOutputDriver` writes a digital signal to a GPIO line.
 
 This driver configures GPIO lines via `the sysfs kernel interface <https://www.kernel.org/doc/html/latest/gpio/sysfs.html>`.
 While the driver automatically exports the GPIO, it does not configure it in any other way than as an output.
@@ -2101,7 +2131,7 @@ Arguments:
 
 SerialPortDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The SerialPortDigitalOutputDriver makes it possible to use a UART
+The :any:`SerialPortDigitalOutputDriver` makes it possible to use a UART
 as a 1-Bit general-purpose digital output.
 
 This driver acts on top of a SerialDriver and uses the its pyserial port to
@@ -2130,7 +2160,7 @@ Arguments:
 
 FileDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~
-The FileDigitalOutputDriver uses a file
+The :any:`FileDigitalOutputDriver` uses a file
 to write arbitrary string representations of booleans
 to a file and read from it.
 
@@ -2159,7 +2189,7 @@ Arguments:
 
 DigitalOutputResetDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~
-A DigitalOutputResetDriver uses a DigitalOutput to reset the target.
+A :any:`DigitalOutputResetDriver` uses a DigitalOutput to reset the target.
 
 Binds to:
   output:
@@ -2178,7 +2208,7 @@ Arguments:
 
 ModbusCoilDriver
 ~~~~~~~~~~~~~~~~
-A ModbusCoilDriver controls a `ModbusTCPCoil` resource.
+A :any:`ModbusCoilDriver` controls a `ModbusTCPCoil`_ resource.
 It can set and get the current state of the resource.
 
 Binds to:
@@ -2197,7 +2227,7 @@ Arguments:
 
 HIDRelayDriver
 ~~~~~~~~~~~~~~
-A HIDRelayDriver controls a `HIDRelay` or `NetworkHIDRelay` resource.
+A :any:`HIDRelayDriver` controls a `HIDRelay`_ or `NetworkHIDRelay`_ resource.
 It can set and get the current state of the resource.
 
 Binds to:
@@ -2217,9 +2247,10 @@ Arguments:
 
 ManualSwitchDriver
 ~~~~~~~~~~~~~~~~~~
-A ManualSwitchDriver requires the user to control a switch or jumper on the
-target. This can be used if a driver binds to a :any:`DigitalOutputProtocol`,
-but no automatic control is available.
+A :any:`ManualSwitchDriver` requires the user to control a switch or jumper on
+the target.
+This can be used if a driver binds to a :any:`DigitalOutputProtocol`, but no
+automatic control is available.
 
 Binds to:
   - None
@@ -2237,7 +2268,7 @@ Arguments:
 
 DeditecRelaisDriver
 ~~~~~~~~~~~~~~~~~~~
-A DeditecRelaisDriver controls a Deditec relay resource.
+A :any:`DeditecRelaisDriver` controls a Deditec relay resource.
 It can set and get the current state of the resource.
 
 Binds to:
@@ -2257,8 +2288,9 @@ Arguments:
 
 MXSUSBDriver
 ~~~~~~~~~~~~
-A MXUSBDriver is used to upload an image into a device in the mxs USB loader
-state. This is useful to bootstrap a bootloader onto a device.
+An :any:`MXSUSBDriver` is used to upload an image into a device in the mxs USB
+loader state.
+This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
   loader:
@@ -2285,8 +2317,9 @@ Arguments:
 
 IMXUSBDriver
 ~~~~~~~~~~~~
-A IMXUSBDriver is used to upload an image into a device in the imx USB loader
-state. This is useful to bootstrap a bootloader onto a device.
+A :any:`IMXUSBDriver` is used to upload an image into a device in the imx USB
+loader state.
+This is useful to bootstrap a bootloader onto a device.
 This driver uses the imx-usb-loader tool from barebox.
 
 Binds to:
@@ -2316,8 +2349,8 @@ Arguments:
 
 BDIMXUSBDriver
 ~~~~~~~~~~~~~~
-The BDIMXUSBDriver is used to upload bootloader images into an i.MX device in
-the USB SDP mode.
+The :any:`BDIMXUSBDriver` is used to upload bootloader images into an i.MX
+device in the USB SDP mode.
 This driver uses the imx_usb tool by Boundary Devices.
 Compared to the IMXUSBLoader, it supports two-stage upload of U-Boot images.
 The images paths need to be specified from code instead of in the YAML
@@ -2343,8 +2376,9 @@ Arguments:
 
 RKUSBDriver
 ~~~~~~~~~~~
-A RKUSBDriver is used to upload an image into a device in the rockchip USB loader
-state. This is useful to bootstrap a bootloader onto a device.
+A :any:`RKUSBDriver` is used to upload an image into a device in the rockchip
+USB loader state.
+This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
   loader:
@@ -2375,8 +2409,9 @@ Arguments:
 
 UUUDriver
 ~~~~~~~~~
-A UUUDriver is used to upload an image into a device in the NXP USB loader
-state. This is useful to bootstrap a bootloader onto a device.
+A :any:`UUUDriver` is used to upload an image into a device in the NXP USB
+loader state.
+This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
   loader:
@@ -2407,7 +2442,7 @@ Arguments:
 
 USBStorageDriver
 ~~~~~~~~~~~~~~~~
-A USBStorageDriver allows access to a USB stick or similar local or
+A :any:`USBStorageDriver` allows access to a USB stick or similar local or
 remote device.
 
 Binds to:
@@ -2439,7 +2474,7 @@ Arguments:
 
 OneWirePIODriver
 ~~~~~~~~~~~~~~~~
-A OneWirePIODriver controls a `OneWirePIO` resource.
+A :any:`OneWirePIODriver` controls a `OneWirePIO`_ resource.
 It can set and get the current state of the resource.
 
 Binds to:
@@ -2461,8 +2496,8 @@ Arguments:
 
 TFTPProviderDriver / HTTPProviderDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-These drivers control their corresponding Provider resources, either locally or
-remotely.
+The :any:`TFTPProviderDriver` and :any:`HTTPProviderDriver` control their
+corresponding Provider resources, either locally or remotely.
 
 Binds to:
   provider:
@@ -2488,7 +2523,7 @@ returns the path to be used by the target.
 
 NFSProviderDriver
 ~~~~~~~~~~~~~~~~~
-An NFSProviderDriver controls an `NFSProvider` resource.
+An :any:`NFSProviderDriver` controls an `NFSProvider`_ resource.
 
 Binds to:
   provider:
@@ -2511,8 +2546,8 @@ attributes.
 
 QEMUDriver
 ~~~~~~~~~~
-The QEMUDriver allows the usage of a QEMU instance as a target. It requires
-several arguments, listed below.
+The :any:`QEMUDriver` allows the usage of a QEMU instance as a target.
+It requires several arguments, listed below.
 The kernel, flash, rootfs and dtb arguments refer to images and paths declared
 in the environment configuration.
 
@@ -2579,7 +2614,7 @@ The QEMUDriver also requires the specification of:
 
 SigrokDriver
 ~~~~~~~~~~~~
-The SigrokDriver uses a SigrokDevice resource to record samples and provides
+The :any:`SigrokDriver` uses a `SigrokDevice`_ resource to record samples and provides
 them during test runs.
 
 Binds to:
@@ -2599,8 +2634,8 @@ The driver can be used in test cases by calling the `capture`, `stop` and
 
 SigrokPowerDriver
 ~~~~~~~~~~~~~~~~~
-The SigrokPowerDriver uses a `SigrokUSBSerialDevice`_ resource to control a
-programmable power supply.
+The :any:`SigrokPowerDriver` uses a `SigrokUSBSerialDevice`_ resource to
+control a programmable power supply.
 
 Binds to:
   sigrok:
@@ -2625,8 +2660,8 @@ Arguments:
 
 SigrokDmmDriver
 ~~~~~~~~~~~~~~~
-The `SigrokDmmDriver` uses a  `SigrokDevice` resource to record samples from a digital multimeter (DMM) and provides
-them during test runs.
+The :any:`SigrokDmmDriver` uses a `SigrokDevice`_ resource to record samples
+from a digital multimeter (DMM) and provides them during test runs.
 
 It is known to work with Unit-T `UT61B` and `UT61C` devices but should also work with other DMMs supported by *sigrok*.
 
@@ -2659,7 +2694,7 @@ Reading a few samples will very likely work - but obtaining a lot of samples may
 
 USBSDMuxDriver
 ~~~~~~~~~~~~~~
-The :any:`USBSDMuxDriver` uses a USBSDMuxDevice resource to control a
+The :any:`USBSDMuxDriver` uses a `USBSDMuxDevice`_ resource to control a
 USB-SD-Mux device via `usbsdmux <https://github.com/pengutronix/usbsdmux>`_
 tool.
 
@@ -2674,14 +2709,13 @@ Implements:
 Arguments:
   - None
 
-The driver can be used in test cases by calling the `set_mode()` function with
-argument being `dut`, `host`, `off`, or `client`.
+The driver can be used in test cases by calling its ``set_mode()`` method with
+argument being "dut", "host", "off", or "client".
 
 LXAUSBMuxDriver
 ~~~~~~~~~~~~~~~
-The :any:`LXAUSBMuxDriver` uses a LXAUSBMux resource to control a USB-Mux
-device via the `usbmuxctl <https://github.com/linux-automation/usbmuxctl>`_
-tool.
+The :any:`LXAUSBMuxDriver` uses a `LXAUSBMux`_ resource to control a USB-Mux
+device via the `usbmuxctl <https://github.com/linux-automation/usbmuxctl>`_ tool.
 
 Binds to:
   mux:
@@ -2700,7 +2734,7 @@ Not all combinations can be configured at the same time.
 
 USBSDWireDriver
 ~~~~~~~~~~~~~~~
-The :any:`USBSDWireDriver` uses a USBSDWireDevice resource to control a
+The :any:`USBSDWireDriver` uses a `USBSDWireDevice`_ resource to control a
 USB-SD-Wire device via `sd-mux-ctrl <https://wiki.tizen.org/SD_MUX#Software>`_
 tool.
 
@@ -2926,7 +2960,7 @@ DediprogFlasher SF100 for instance, to the device being flashed.
 
 XenaDriver
 ~~~~~~~~~~
-The XenaDriver allows to use Xena networking test equipment.
+The :any:`XenaDriver` allows to use Xena networking test equipment.
 Using the `xenavalkyrie` library a full API to control the tester is available.
 
 Binds to:
@@ -2938,8 +2972,8 @@ Currently tested on a `XenaCompact` chassis equipped with a `1 GE test module`.
 
 DockerDriver
 ~~~~~~~~~~~~
-A DockerDriver binds to a `DockerDaemon` and is used to create and control one
-docker container.
+A :any:`DockerDriver` binds to a `DockerDaemon`_ and is used to create and
+control one docker container.
 
 | The driver uses the docker python module to interact with the docker daemon.
 | For more information on the parameters see:
@@ -2974,8 +3008,8 @@ Arguments:
 
 LXAIOBusPIODriver
 ~~~~~~~~~~~~~~~~~
-An LXAIOBusPIODriver binds to a single `LXAIOBusPIO` to toggle and read the PIO
-states.
+An :any:`LXAIOBusPIODriver` binds to a single `LXAIOBusPIO`_ to toggle and read
+the PIO states.
 
 Binds to:
   pio:
@@ -2994,8 +3028,8 @@ Arguments:
 
 HttpDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~
-A HttpDigitalOutputDriver binds to a `HttpDigitalOutput` to set and get a
-digital output state via HTTP.
+A :any:`HttpDigitalOutputDriver` binds to a `HttpDigitalOutput`_ to set and get
+a digital output state via HTTP.
 
 Binds to:
   http:
@@ -3013,7 +3047,8 @@ Arguments:
 
 PyVISADriver
 ~~~~~~~~~~~~
-The PyVISADriver uses a PyVISADevice resource to control test equipment manageable by PyVISA.
+The :any:`PyVISADriver` uses a `PyVISADevice`_ resource to control test
+equipment manageable by PyVISA.
 
 Binds to:
   pyvisa_resource:
@@ -3027,8 +3062,8 @@ Arguments:
 
 NetworkInterfaceDriver
 ~~~~~~~~~~~~~~~~~~~~~~
-This driver allows controlling a network interface (such as Ethernet or WiFi) on
-the exporter using NetworkManager.
+The :any:`NetworkInterfaceDriver` allows controlling a network interface (such
+as Ethernet or WiFi) on the exporter using NetworkManager.
 
 The configuration is based on dictionaries with contents similar to NM's
 connection files in INI-format.
@@ -3059,8 +3094,8 @@ Arguments:
 
 RawNetworkInterfaceDriver
 ~~~~~~~~~~~~~~~~~~~~~~~~~
-This driver allows "raw" control of a network interface (such as Ethernet or
-WiFi).
+The :any:`RawNetworkInterfaceDriver` allows "raw" control of a network
+interface (such as Ethernet or WiFi).
 
 The labgrid-raw-interface helper (``helpers/labgrid-raw-interface``) needs to
 be installed in the PATH and usable via sudo without password.
@@ -3110,7 +3145,7 @@ Such a state could be the bootloader or a booted Linux kernel with shell.
 
 BareboxStrategy
 ~~~~~~~~~~~~~~~
-A BareboxStrategy has four states:
+A :any:`BareboxStrategy` has four states:
 
 - unknown
 - off
@@ -3155,11 +3190,11 @@ the ``shell`` state:
    >>> s.transition("shell")
 
 This command would transition from the bootloader into a Linux shell and
-activate the ShellDriver.
+activate the `ShellDriver`_.
 
 ShellStrategy
 ~~~~~~~~~~~~~
-A ShellStrategy has three states:
+A :any:`ShellStrategy` has three states:
 
 - unknown
 - off
@@ -3201,11 +3236,11 @@ the ``shell`` state:
    >>> s = t.get_driver("ShellStrategy")
 
 This command would transition directly into a Linux shell and
-activate the ShellDriver.
+activate the `ShellDriver`_.
 
 UBootStrategy
 ~~~~~~~~~~~~~
-A UBootStrategy has four states:
+A :any:`UBootStrategy` has four states:
 
 - unknown
 - off
@@ -3250,11 +3285,11 @@ the ``shell`` state:
    >>> s.transition("shell")
 
 This command would transition from the bootloader into a Linux shell and
-activate the ShellDriver.
+activate the `ShellDriver`_.
 
 DockerStrategy
 ~~~~~~~~~~~~~~
-A DockerStrategy has three states:
+A :any:`DockerStrategy` has three states:
 
 - unknown
 - gone
@@ -3305,7 +3340,7 @@ Reporters
 
 StepReporter
 ~~~~~~~~~~~~
-The StepReporter outputs individual labgrid steps to `STDOUT`.
+The :any:`StepReporter` outputs individual labgrid steps to `STDOUT`.
 
 .. doctest::
 
@@ -3324,7 +3359,7 @@ AssertionError, as will starting an already started StepReporter.
 
 ConsoleLoggingReporter
 ~~~~~~~~~~~~~~~~~~~~~~
-The ConsoleLoggingReporter outputs read calls from the console transports into
+The :any:`ConsoleLoggingReporter` outputs read calls from the console transports into
 files. It takes the path as a parameter.
 
 .. doctest::
@@ -3429,8 +3464,8 @@ becomes:
   - SerialDriver: {}
   - SerialDriver: {}
 
-This configuration doesn't specify which :any:`RawSerialPort` to use for each
-:any:`SerialDriver`, so it will cause an exception when instantiating the
+This configuration doesn't specify which `RawSerialPort`_ to use for each
+`SerialDriver`_, so it will cause an exception when instantiating the
 :any:`Target`.
 To bind the correct driver to the correct resource, explicit ``name`` and
 ``bindings`` properties are used:
@@ -3476,7 +3511,7 @@ As an example:
     qemu_bin: !template "$BASE/bin/qemu-bin"
 
 would resolve the qemu_bin path relative to the BASE dir of the YAML file and
-try to use the RemotePlace with the name set in the LG_PLACE environment
+try to use the `RemotePlace`_ with the name set in the LG_PLACE environment
 variable.
 
 See the :ref:`labgrid-device-config` man page for documentation on the
@@ -3517,7 +3552,7 @@ and `<params>` will be passed to its constructor.
 For USB resources, you will most likely want to use :ref:`udev-matching` here.
 
 As a simple example, here is one group called *usb-hub-in-rack12* containing
-a single :any:`USBSerialPort` resource (using udev matching), which will be
+a single `USBSerialPort`_ resource (using udev matching), which will be
 exported as `exportername/usb-hub-in-rack12/NetworkSerialPort/USBSerialPort`:
 
 .. code-block:: yaml
@@ -3531,9 +3566,9 @@ To export multiple resources of the same class in the same group,
 you can choose a unique resource name, and then use the ``cls`` parameter to
 specify the class name instead (which will not be passed as a parameter to the
 class constructor).
-In this next example we will export one :any:`USBSerialPort` as
+In this next example we will export one `USBSerialPort`_ as
 `exportername/usb-hub-in-rack12/NetworkSerialPort/console-main`,
-and another :any:`USBSerialPort` as
+and another `USBSerialPort`_ as
 `exportername/usb-hub-in-rack12/NetworkSerialPort/console-secondary`:
 
 .. code-block:: yaml

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1503,6 +1503,7 @@ Binds to:
 
 Implements:
   - :any:`ConsoleProtocol`
+  - :any:`ResetProtocol`
 
 Arguments:
   - txdelay (float, default=0.0): time in seconds to wait before sending each byte
@@ -1522,6 +1523,9 @@ Binds to:
   port:
     - `ModbusRTU`_
 
+Implements:
+  - None (yet)
+
 ShellDriver
 ~~~~~~~~~~~
 A ShellDriver binds on top of a `ConsoleProtocol` and is designed to interact
@@ -1533,6 +1537,7 @@ Binds to:
 
 Implements:
   - :any:`CommandProtocol`
+  - :any:`FileTransferProtocol`
 
 .. code-block:: yaml
 
@@ -1620,6 +1625,7 @@ Binds to:
 
 Implements:
   - :any:`CommandProtocol`
+  - :any:`LinuxBootProtocol`
 
 .. code-block:: yaml
 
@@ -1679,6 +1685,7 @@ Binds to:
 
 Implements:
   - :any:`CommandProtocol`
+  - :any:`LinuxBootProtocol`
 
 .. code-block:: yaml
 
@@ -1704,6 +1711,7 @@ Binds to:
 
 Implements:
   - :any:`CommandProtocol`
+  - :any:`LinuxBootProtocol`
 
 .. code-block:: yaml
 
@@ -1851,6 +1859,7 @@ The driver's name will be displayed during interaction.
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -1866,6 +1875,7 @@ An ExternalPowerDriver is used to control a target power state via an external c
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -1891,6 +1901,7 @@ Binds to:
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -1915,6 +1926,7 @@ Binds to:
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -1935,6 +1947,7 @@ Binds to:
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -1956,6 +1969,10 @@ Binds to:
   output:
     - :any:`DigitalOutputProtocol`
 
+Implements:
+  - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
+
 .. code-block:: yaml
 
    DigitalOutputPowerDriver:
@@ -1974,6 +1991,7 @@ Binds to:
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -1993,6 +2011,7 @@ Binds to:
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -2394,6 +2413,9 @@ Binds to:
     - `HTTPProvider`_
     - `RemoteHTTPProvider`_
 
+Implements:
+  - None (yet)
+
 .. code-block:: yaml
 
    TFTPProviderDriver: {}
@@ -2414,6 +2436,9 @@ Binds to:
   provider:
     - `NFSProvider`_
     - `RemoteNFSProvider`_
+
+Implements:
+  - None (yet)
 
 .. code-block:: yaml
 
@@ -2526,6 +2551,7 @@ Binds to:
 
 Implements:
   - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
 
 .. code-block:: yaml
 
@@ -2810,6 +2836,9 @@ Binds to:
   DediprogFlasher_resource:
     - `DediprogFlasher`_
     - `NetworkDediprogFlasher`_
+
+Implements:
+  - None (yet)
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1537,6 +1537,9 @@ Binds to:
 Implements:
   - None (yet)
 
+Arguments:
+  - None
+
 ShellDriver
 ~~~~~~~~~~~
 A ShellDriver binds on top of a `ConsoleProtocol` and is designed to interact
@@ -2875,6 +2878,9 @@ Binds to:
 
 Implements:
   - :any:`VideoProtocol`
+
+Arguments:
+  - None
 
 Although the driver can be used from Python code by calling the `stream()`
 method, it is currently mainly useful for the ``video`` subcommand of

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2957,6 +2957,7 @@ To use it, `PyGObject <https://pygobject.readthedocs.io/>`_ must be installed
 For Debian, the necessary packages are `python3-gi` and `gir1.2-nm-1.0`.
 
 It supports:
+
 - static and DHCP address configuration
 - WiFi client or AP
 - connection sharing (DHCP server with NAT)
@@ -2991,15 +2992,17 @@ exporting network interfaces for the RawNetworkInterfaceDriver, e.g.:
        - eth1
 
 It supports:
+
 - recording traffic
 - replaying traffic
 - basic statistic collection
 
 For now, the RawNetworkInterfaceDriver leaves pre-configuration of the exported
 network interface to the user, including:
+
 - disabling DHCP
 - disabling IPv6 Duplicate Address Detection (DAD) by SLAAC (Stateless
-Address Autoconfiguration) and Neighbor Discovery
+  Address Autoconfiguration) and Neighbor Discovery
 - disabling Generic Receive Offload (GRO)
 
 This might change in the future.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2842,6 +2842,9 @@ The :any:`FlashromDriver` is used to flash a ROM, using the flashrom utility.
 
    FlashromDriver:
      image: 'foo'
+
+.. code-block:: yaml
+
    images:
      foo: '../images/image_to_load.raw'
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -872,7 +872,6 @@ Used by:
 
 NetworkUSBSDMuxDevice
 ~~~~~~~~~~~~~~~~~~~~~
-
 A :any:`NetworkUSBSDMuxDevice` resource describes a `USBSDMuxDevice`_ available
 on a remote computer.
 
@@ -894,7 +893,6 @@ Used by:
 
 NetworkLXAUSBMux
 ~~~~~~~~~~~~~~~~
-
 A :any:`NetworkLXAUSBMux` resource describes a `LXAUSBMux`_ available on a
 remote computer.
 
@@ -918,13 +916,11 @@ Used by:
 
 NetworkUSBSDWireDevice
 ~~~~~~~~~~~~~~~~~~~~~~
-
 A :any:`NetworkUSBSDWireDevice` resource describes a `USBSDWireDevice`_ available
 on a remote computer.
 
 USBVideo
 ~~~~~~~~
-
 A :any:`USBVideo` resource describes a USB video camera which is supported by a
 Video4Linux2 kernel driver.
 
@@ -942,7 +938,6 @@ Used by:
 
 SysfsGPIO
 ~~~~~~~~~
-
 A :any:`SysfsGPIO` resource describes a GPIO line.
 
 .. code-block:: yaml
@@ -958,13 +953,11 @@ Used by:
 
 NetworkUSBVideo
 ~~~~~~~~~~~~~~~
-
 A :any:`NetworkUSBVideo` resource describes a :any:`USBVideo` resource available
 on a remote computer.
 
 USBAudioInput
 ~~~~~~~~~~~~~
-
 A :any:`USBAudioInput` resource describes a USB audio input which is supported
 by an ALSA kernel driver.
 
@@ -984,13 +977,11 @@ Used by:
 
 NetworkUSBAudioInput
 ~~~~~~~~~~~~~~~~~~~~
-
 A :any:`NetworkUSBAudioInput` resource describes a :any:`USBAudioInput` resource
 available on a remote computer.
 
 USBTMC
 ~~~~~~
-
 A :any:`USBTMC` resource describes an oscilloscope connected via the USB TMC
 protocol.
 The low-level communication is handled by the ``usbtmc`` kernel driver.
@@ -1016,7 +1007,6 @@ Used by:
 
 NetworkUSBTMC
 ~~~~~~~~~~~~~
-
 A :any:`NetworkUSBTMC` resource describes a :any:`USBTMC` resource available
 on a remote computer.
 
@@ -1103,7 +1093,6 @@ For instance, to flash using 3.5V vcc:
   DediprogFlasher:
     vcc: '3.5V'
 
-
 Used by:
   - `DediprogFlashDriver`_
 
@@ -1149,7 +1138,6 @@ Used by:
 
 HTTPVideoStream
 ~~~~~~~~~~~~~~~
-
 A :any:`HTTPVideoStream` resource describes a IP video stream over HTTP or HTTPS.
 
 .. code-block:: yaml
@@ -1187,7 +1175,6 @@ labgrid.
 
 TFTPProvider / HTTPProvider
 +++++++++++++++++++++++++++
-
 .. code-block:: yaml
 
    TFTPProvider:
@@ -1208,7 +1195,6 @@ Used by:
 
 NFSProvider
 +++++++++++
-
 .. code-block:: yaml
 
    NFSProvider: {}
@@ -1318,7 +1304,6 @@ Used by:
 
 udev Matching
 ~~~~~~~~~~~~~
-
 labgrid allows the exporter (or the client-side environment) to match resources
 via udev rules.
 Any udev property key and value can be used, path matching USB devices is
@@ -1374,7 +1359,6 @@ use-cases.
 
 Matching a USB Serial Converter on a Hub Port
 +++++++++++++++++++++++++++++++++++++++++++++
-
 This will match any USB serial converter connected below the hub port 1.2.5.5
 on bus 1.
 The `ID_PATH` value corresponds to the hierarchy of buses and ports as shown
@@ -1393,7 +1377,6 @@ This is necessary for the `USBSerialPort` because we actually want to find the
 
 Matching an Android USB Fastboot Device
 +++++++++++++++++++++++++++++++++++++++
-
 In this case, we want to match the USB device on that port directly, so we
 don't use a parent match.
 
@@ -1405,7 +1388,6 @@ don't use a parent match.
 
 Matching a Specific UART in a Dual-Port Adapter
 +++++++++++++++++++++++++++++++++++++++++++++++
-
 On this board, the serial console is connected to the second port of an
 on-board dual-port USB-UART.
 The board itself is connected to the bus 3 and port path 10.2.2.2.
@@ -1457,7 +1439,6 @@ We use the ``ID_USB_INTERFACE_NUM`` to distinguish between the two ports:
 
 Matching a USB UART by Serial Number
 ++++++++++++++++++++++++++++++++++++
-
 Most of the USB serial converters in our lab have been programmed with unique
 serial numbers.
 This makes it easy to always match the same one even if the USB topology
@@ -1715,7 +1696,6 @@ Arguments:
 
 BareboxDriver
 ~~~~~~~~~~~~~
-
 A BareboxDriver interfaces with a barebox bootloader via a `ConsoleProtocol`.
 
 Binds to:
@@ -2804,7 +2784,6 @@ Although the driver can be used from Python code by calling the `stream()`
 method, it is currently mainly useful for the ``video`` subcommand of
 ``labgrid-client``.
 
-
 ========== =========================================================
 Key        Description
 ========== =========================================================
@@ -2908,7 +2887,6 @@ Implements:
 Arguments:
   - None
 
-
 HttpDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~
 A HttpDigitalOutputDriver binds to a `HttpDigitalOutput` to set and get a
@@ -2927,7 +2905,6 @@ Implements:
 
 Arguments:
   - None
-
 
 PyVISADriver
 ~~~~~~~~~~~~
@@ -3023,7 +3000,6 @@ Arguments:
 
 Strategies
 ----------
-
 Strategies are used to ensure that the device is in a certain state during a test.
 Such a state could be the bootloader or a booted Linux kernel with shell.
 
@@ -3241,7 +3217,6 @@ The Reporter can be stopped with a call to the stop function:
 Stopping the StepReporter if it has not been started will raise an
 AssertionError, as will starting an already started StepReporter.
 
-
 ConsoleLoggingReporter
 ~~~~~~~~~~~~~~~~~~~~~~
 The ConsoleLoggingReporter outputs read calls from the console transports into
@@ -3259,11 +3234,8 @@ The Reporter can be stopped with a call to the stop function:
     >>> from labgrid import ConsoleLoggingReporter
     >>> ConsoleLoggingReporter.stop()
 
-
 Stopping the ConsoleLoggingReporter if it has not been started will raise an
 AssertionError, as will starting an already started StepReporter.
-
-
 
 Environment Configuration
 -------------------------

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1531,7 +1531,7 @@ local usage and will not work with an exporter.
     ModbusRTUDriver: {}
 
 Binds to:
-  port:
+  resource:
     - `ModbusRTU`_
 
 Implements:
@@ -1692,7 +1692,8 @@ This driver needs the following features activated in U-Boot to work:
 - The U-Boot must support the "bootm" command to boot from a memory location.
 
 Binds to:
-  - :any:`ConsoleProtocol` (see `SerialDriver`_)
+  console:
+    - :any:`ConsoleProtocol` (see `SerialDriver`_)
 
 Implements:
   - :any:`CommandProtocol`
@@ -1743,6 +1744,9 @@ ExternalConsoleDriver
 An ExternalConsoleDriver implements the `ConsoleProtocol` on top of a command
 executed on the local computer.
 
+Binds to:
+  - None
+
 Implements:
   - :any:`ConsoleProtocol`
 
@@ -1764,7 +1768,9 @@ network fastboot state.
 Binds to:
   fastboot:
     - `AndroidUSBFastboot`_
+    - RemoteAndroidUSBFastboot
     - `AndroidNetFastboot`_
+    - RemoteAndroidNetFastboot
 
 Implements:
   - None (yet)
@@ -1792,6 +1798,7 @@ Upgrade) mode.
 Binds to:
   dfu:
     - `DFUDevice`_
+    - NetworkDFUDevice
 
 Implements:
   - None (yet)
@@ -1818,7 +1825,9 @@ Consider updating your OpenOCD version when using multiple USB Blasters.
 Binds to:
   interface:
     - `AlteraUSBBlaster`_
+    - NetworkAlteraUSBBlaster
     - `USBDebugger`_
+    - NetworkUSBDebugger
 
 Implements:
   - :any:`BootstrapProtocol`
@@ -1849,7 +1858,9 @@ A QuartusHPSDriver controls the "Quartus Prime Programmer and Tools" to flash
 a target's QSPI.
 
 Binds to:
-  - `AlteraUSBBlaster`_
+  interface:
+    - `AlteraUSBBlaster`_
+    - NetworkAlteraUSBBlaster
 
 Implements:
   - None
@@ -1868,6 +1879,9 @@ control is available.
 
 The driver's name will be displayed during interaction.
 
+Binds to:
+  - None
+
 Implements:
   - :any:`PowerProtocol`
   - :any:`ResetProtocol`
@@ -1883,6 +1897,9 @@ Arguments:
 ExternalPowerDriver
 ~~~~~~~~~~~~~~~~~~~
 An ExternalPowerDriver is used to control a target power state via an external command.
+
+Binds to:
+  - None
 
 Implements:
   - :any:`PowerProtocol`
@@ -1955,6 +1972,7 @@ target power state without user interaction.
 Binds to:
   port:
     - `YKUSHPowerPort`_
+    - `NetworkYKUSHPowerPort`_
 
 Implements:
   - :any:`PowerProtocol`
@@ -1998,7 +2016,9 @@ A USBPowerDriver controls a `USBPowerPort`, allowing control of the target
 power state without user interaction.
 
 Binds to:
-  - `USBPowerPort`_
+  hub:
+    - `USBPowerPort`_
+    - NetworkUSBPowerPort
 
 Implements:
   - :any:`PowerProtocol`
@@ -2018,7 +2038,9 @@ A SiSPMPowerDriver controls a `SiSPMPowerPort`, allowing control of the target
 power state without user interaction.
 
 Binds to:
-  - `SiSPMPowerPort`_
+  port:
+    - `SiSPMPowerPort`_
+    - NetworkSiSPMPowerPort
 
 Implements:
   - :any:`PowerProtocol`
@@ -2038,7 +2060,8 @@ A TasmotaPowerDriver controls a `TasmotaPowerPort`, allowing the outlet to be
 switched on and off.
 
 Binds to:
-  - `TasmotaPowerPort`_
+  power:
+    - `TasmotaPowerPort`_
 
 Implements:
   - :any:`PowerProtocol`
@@ -2059,7 +2082,9 @@ This driver configures GPIO lines via `the sysfs kernel interface <https://www.k
 While the driver automatically exports the GPIO, it does not configure it in any other way than as an output.
 
 Binds to:
-  - `SysfsGPIO`_
+  gpio:
+    - `SysfsGPIO`_
+    - NetworkSysfsGPIO
 
 Implements:
   - :any:`DigitalOutputProtocol`
@@ -2078,6 +2103,10 @@ as a 1-Bit general-purpose digital output.
 
 This driver acts on top of a SerialDriver and uses the its pyserial port to
 control the flow control lines.
+
+Binds to:
+  serial:
+    - `SerialDriver`_
 
 Implements:
   - :any:`DigitalOutputProtocol`
@@ -2108,6 +2137,9 @@ If the file's content does not match any of the representations
 reading defaults to False.
 
 A prime example for using this driver is Linux's sysfs.
+
+Binds to:
+  - None
 
 Implements:
   - :any:`DigitalOutputProtocol`
@@ -2186,6 +2218,9 @@ A ManualSwitchDriver requires the user to control a switch or jumper on the
 target. This can be used if a driver binds to a :any:`DigitalOutputProtocol`,
 but no automatic control is available.
 
+Binds to:
+  - None
+
 Implements:
   - :any:`DigitalOutputProtocol`
 
@@ -2205,6 +2240,7 @@ It can set and get the current state of the resource.
 Binds to:
   relais:
     - `DeditecRelais8`_
+    - NetworkDeditecRelais8
 
 Implements:
   - :any:`DigitalOutputProtocol`
@@ -2254,6 +2290,8 @@ Binds to:
   loader:
     - `IMXUSBLoader`_
     - `NetworkIMXUSBLoader`_
+    - `MXSUSBLoader`_
+    - `NetworkMXSUSBLoader`_
 
 Implements:
   - :any:`BootstrapProtocol`
@@ -2370,8 +2408,14 @@ A USBStorageDriver allows access to a USB stick or similar local or
 remote device.
 
 Binds to:
-  - `USBMassStorage`_
-  - `NetworkUSBMassStorage`_
+  storage:
+    - `USBMassStorage`_
+    - `NetworkUSBMassStorage`_
+    - `USBSDMuxDevice`_
+    - `NetworkUSBSDMuxDevice`_
+    - `USBSDWireDevice`_
+    - `NetworkUSBSDWireDevice`_
+
 
 Implements:
   - None (yet)
@@ -2538,8 +2582,8 @@ them during test runs.
 Binds to:
   sigrok:
     - `SigrokUSBDevice`_
-    - `SigrokDevice`_
     - `NetworkSigrokUSBDevice`_
+    - `SigrokDevice`_
 
 Implements:
   - None yet
@@ -2586,8 +2630,8 @@ It is known to work with Unit-T `UT61B` and `UT61C` devices but should also work
 Binds to:
   sigrok:
     - `SigrokUSBDevice`_
-    - `SigrokUSBSerialDevice`_
     - `NetworkSigrokUSBDevice`_
+    - `SigrokUSBSerialDevice`_
     - NetworkSigrokUSBSerialDevice
 
 Implements:
@@ -2616,6 +2660,11 @@ The :any:`USBSDMuxDriver` uses a USBSDMuxDevice resource to control a
 USB-SD-Mux device via `usbsdmux <https://github.com/pengutronix/usbsdmux>`_
 tool.
 
+Binds to:
+  mux:
+    - `USBSDMuxDevice`_
+    - `NetworkUSBSDMuxDevice`_
+
 Implements:
   - None yet
 
@@ -2630,6 +2679,11 @@ LXAUSBMuxDriver
 The :any:`LXAUSBMuxDriver` uses a LXAUSBMux resource to control a USB-Mux
 device via the `usbmuxctl <https://github.com/linux-automation/usbmuxctl>`_
 tool.
+
+Binds to:
+  mux:
+    - `LXAUSBMux`_
+    - `NetworkLXAUSBMux`
 
 Implements:
   - None yet
@@ -2646,6 +2700,11 @@ USBSDWireDriver
 The :any:`USBSDWireDriver` uses a USBSDWireDevice resource to control a
 USB-SD-Wire device via `sd-mux-ctrl <https://wiki.tizen.org/SD_MUX#Software>`_
 tool.
+
+Binds to:
+  mux:
+    - `USBSDWireDevice`_
+    - `NetworkUSBSDWireDevice`
 
 Implements:
   - None yet
@@ -2696,7 +2755,7 @@ On the receiver, it either uses ``gst-launch`` for simple playback or
 complex cases (such as measuring the current volume level).
 
 Binds to:
-  video:
+  res:
     - `USBAudioInput`_
     - `NetworkUSBAudioInput`_
 
@@ -2781,7 +2840,7 @@ a device.
      foo: ../images/flash_device.sh
 
 Binds to:
-  flashabledevice_resource:
+  device:
     - `USBFlashableDevice`_
     - `NetworkUSBFlashableDevice`_
 
@@ -2844,7 +2903,7 @@ The :any:`DediprogFlashDriver` is used to flash an SPI device using DediprogFlas
      foo: ../images/image_to_load.raw
 
 Binds to:
-  DediprogFlasher_resource:
+  flasher:
     - `DediprogFlasher`_
     - `NetworkDediprogFlasher`_
 
@@ -2983,8 +3042,8 @@ It supports:
 Binds to:
   iface:
     - `NetworkInterface`_
-    - `USBNetworkInterface`_
     - `RemoteNetworkInterface`_
+    - `USBNetworkInterface`_
 
 Implements:
   - None yet
@@ -3027,8 +3086,8 @@ This might change in the future.
 Binds to:
   iface:
     - `NetworkInterface`_
-    - `USBNetworkInterface`_
     - `RemoteNetworkInterface`_
+    - `USBNetworkInterface`_
 
 Implements:
   - None yet

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1195,19 +1195,28 @@ see below.
 For now, the TFTP/NFS/HTTP server needs to be configured before using it from
 labgrid.
 
-.. _TFTPProvider:
-.. _HTTPProvider:
-
-TFTPProvider / HTTPProvider
-+++++++++++++++++++++++++++
-A :any:`TFTPProvider` resource describes TFTP server.
-A :any:`HTTPProvider` resource describes an HTTP server.
+TFTPProvider
+++++++++++++
+A :any:`TFTPProvider` resource describes a TFTP server.
 
 .. code-block:: yaml
 
    TFTPProvider:
      internal: '/srv/tftp/board-23/'
      external: 'board-23/'
+
+Arguments:
+  - internal (str): path prefix to the local directory accessible by the target
+  - external (str): corresponding path prefix for use by the target
+
+Used by:
+  - `TFTPProviderDriver`_
+
+HTTPProvider
+++++++++++++
+An :any:`HTTPProvider` resource describes an HTTP server.
+
+.. code-block:: yaml
 
    HTTPProvider:
      internal: '/srv/www/board-23/'
@@ -1218,7 +1227,6 @@ Arguments:
   - external (str): corresponding path prefix for use by the target
 
 Used by:
-  - `TFTPProviderDriver`_
   - `HTTPProviderDriver`_
 
 NFSProvider
@@ -1235,14 +1243,9 @@ Arguments:
 Used by:
   - `NFSProviderDriver`_
 
-.. _RemoteTFTPProvider:
-.. _RemoteHTTPProvider:
-
-RemoteTFTPProvider / RemoteHTTPProvider
-+++++++++++++++++++++++++++++++++++++++
+RemoteTFTPProvider
+++++++++++++++++++
 A :any:`RemoteTFTPProvider` describes a `TFTPProvider`_ resource available on
-a remote computer.
-A :any:`RemoteHTTPProvider` describes a `HTTPProvider`_ resource available on
 a remote computer.
 
 .. code-block:: yaml
@@ -1252,6 +1255,21 @@ a remote computer.
      internal: '/srv/tftp/board-23/'
      external: 'board-23/'
 
+Arguments:
+  - host (str): hostname of the remote host
+  - internal (str): path prefix to the TFTP root directory on ``host``
+  - external (str): corresponding path prefix for use by the target
+
+Used by:
+  - `TFTPProviderDriver`_
+
+RemoteHTTPProvider
+++++++++++++++++++
+A :any:`RemoteHTTPProvider` describes an `HTTPProvider`_ resource available on
+a remote computer.
+
+.. code-block:: yaml
+
    RemoteHTTPProvider:
      host: 'httphost'
      internal: '/srv/www/board-23/'
@@ -1259,11 +1277,10 @@ a remote computer.
 
 Arguments:
   - host (str): hostname of the remote host
-  - internal (str): path prefix to the HTTP/TFTP root directory on ``host``
+  - internal (str): path prefix to the HTTP root directory on ``host``
   - external (str): corresponding path prefix for use by the target
 
 Used by:
-  - `TFTPProviderDriver`_
   - `HTTPProviderDriver`_
 
 RemoteNFSProvider
@@ -2496,20 +2513,15 @@ Implements:
 Arguments:
   - None
 
-.. _TFTPProviderDriver:
-.. _HTTPProviderDriver:
-
-TFTPProviderDriver / HTTPProviderDriver
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The :any:`TFTPProviderDriver` and :any:`HTTPProviderDriver` control their
-corresponding Provider resources, either locally or remotely.
+TFTPProviderDriver
+~~~~~~~~~~~~~~~~~~
+The :any:`TFTPProviderDriver` controls its corresponding TFTP resource, either
+locally or remotely.
 
 Binds to:
   provider:
     - `TFTPProvider`_
     - `RemoteTFTPProvider`_
-    - `HTTPProvider`_
-    - `RemoteHTTPProvider`_
 
 Implements:
   - None (yet)
@@ -2517,6 +2529,27 @@ Implements:
 .. code-block:: yaml
 
    TFTPProviderDriver: {}
+
+Arguments:
+  - None
+
+The driver can be used in test cases by calling its ``stage()`` method, which
+returns the path to be used by the target.
+
+HTTPProviderDriver
+~~~~~~~~~~~~~~~~~~
+The :any:`HTTPProviderDriver` controls its corresponding HTTP resource, either
+locally or remotely.
+
+Binds to:
+  provider:
+    - `HTTPProvider`_
+    - `RemoteHTTPProvider`_
+
+Implements:
+  - None (yet)
+
+.. code-block:: yaml
 
    HTTPProviderDriver: {}
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -46,7 +46,7 @@ NetworkSerialPort
 +++++++++++++++++
 A :any:`NetworkSerialPort` describes a serial port which is exported over the
 network, usually using `RFC2217 <https://datatracker.ietf.org/doc/rfc2217/>`_
-or raw tcp.
+or raw TCP.
 
 .. code-block:: yaml
 
@@ -157,13 +157,13 @@ The ``model`` property selects one of several `backend implementations
 Currently available are:
 
 ``apc``
-  Controls an *APU PDU* via SNMP.
+  Controls *APU PDUs* via SNMP.
 
 ``digipower``
-  Controls a *DigiPower PDU* via a simple HTTP API.
+  Controls *DigiPower PDUs* via a simple HTTP API.
 
 ``digitalloggers_http``
-  Control a *Digital Loggers PDUs* that use the legacy HTTP API. Note that
+  Controls *Digital Loggers PDUs* that use the legacy HTTP API. Note that
   host argument must include the protocol, such as
   ``http://192.168.0.3`` or ``http://admin:pass@192.168.0.4``.
 
@@ -171,34 +171,34 @@ Currently available are:
   Controls *Eaton ePDUs* via SNMP.
 
 ``eg_pms2_network``
-  Controls the *EG_PMS2_LAN* & *EG_PMS2_WLAN* devices, through simple HTTP POST
+  Controls *EG_PMS2_LAN* and *EG_PMS2_WLAN* devices, through simple HTTP POST
   and GET requests. The device requires a password for logging into the
   control interface, this module deliberately uses the standard password ``1``
   and is not compatible with a different password.
 
 ``eth008``
-  Controls a *Robot-Electronics eth008* via a simple HTTP API.
+  Controls *Robot-Electronics eth008* via a simple HTTP API.
 
 ``gude``
-  Controls a *Gude PDU* via a simple HTTP API.
+  Controls *Gude PDUs* via a simple HTTP API.
 
 ``gude24``
-  Controls a *Gude Expert Power Control 8008 PDU* via a simple HTTP API.
+  Controls *Gude Expert Power Control 8008 PDUs* via a simple HTTP API.
 
 ``gude8031``
-  Controls a *Gude Expert Power Control 8031 PDU* via a simple HTTP API.
+  Controls *Gude Expert Power Control 8031 PDUs* via a simple HTTP API.
 
 ``gude8225``
-  Controls a *Gude Expert Power Control 8225 PDUs via a simple HTTP API.
+  Controls *Gude Expert Power Control 8225 PDUs* via a simple HTTP API.
 
 ``gude8316``
-  Controls a *Gude Expert Power Control 8316 PDU* via a simple HTTP API.
+  Controls *Gude Expert Power Control 8316 PDUs* via a simple HTTP API.
 
 ``netio``
-  Controls a *NETIO 4-Port PDU* via a simple HTTP API.
+  Controls *NETIO 4-Port PDUs* via a simple HTTP API.
 
 ``netio_kshell``
-  Controls a *NETIO 4C PDU* via a Telnet interface.
+  Controls *NETIO 4C PDUs* via a Telnet interface.
 
 ``raritan``
   Controls *Raritan PDUs* via SNMP.
@@ -211,7 +211,7 @@ Currently available are:
   for details.
 
 ``sentry``
-  Controls a *Sentry PDU* via SNMP using Sentry3-MIB.
+  Controls *Sentry PDUs* via SNMP using Sentry3-MIB.
   It was tested on *CW-24VDD* and *4805-XLS-16*.
 
 ``shelly_gen1``
@@ -317,7 +317,7 @@ Used by:
   - `USBPowerDriver`_
 
 .. note::
-   Labgrid requires that the interface is contained in the ID_PATH.
+   labgrid requires that the interface is contained in the ID_PATH.
    This usually means that the ID_PATH should end with ``:1.0``.
    Only this first interface is registered with the ``hub`` driver labgrid is
    looking for, paths without the interface will fail to match since they use
@@ -473,7 +473,7 @@ A :any:`NetworkLXAIOBusPIO` describes an `LXAIOBusPIO`_ exported over the networ
 
 HIDRelay
 ++++++++
-An :any:`HIDRelay` resource describes a single output of a HID protocol based
+An :any:`HIDRelay` resource describes a single output of an HID protocol based
 USB relays.
 It currently supports the widely used *dcttech USBRelay*.
 
@@ -495,8 +495,8 @@ Used by:
 
 HttpDigitalOutput
 +++++++++++++++++
-A :any:`HttpDigitalOutput` resource describes a generic digital output that can be
-controlled via HTTP.
+An :any:`HttpDigitalOutput` resource describes a generic digital output that
+can be controlled via HTTP.
 
 .. code-block:: yaml
 
@@ -794,7 +794,7 @@ Used by:
 
 USBDebugger
 ~~~~~~~~~~~
-An :any:`USBDebugger` resource describes a JTAG USB adapter (for example an
+A :any:`USBDebugger` resource describes a JTAG USB adapter (for example an
 *FTDI FT2232H*).
 
 .. code-block:: yaml
@@ -903,7 +903,7 @@ on a remote computer.
 
 LXAUSBMux
 ~~~~~~~~~
-A :any:`LXAUSBMux` resource describes a *Linux Automation GmbH USB-Mux* device.
+An :any:`LXAUSBMux` resource describes a *Linux Automation GmbH USB-Mux* device.
 
 .. code-block:: yaml
 
@@ -919,14 +919,13 @@ Used by:
 
 NetworkLXAUSBMux
 ~~~~~~~~~~~~~~~~
-A :any:`NetworkLXAUSBMux` resource describes a `LXAUSBMux`_ available on a
+A :any:`NetworkLXAUSBMux` resource describes an `LXAUSBMux`_ available on a
 remote computer.
 
 USBSDWireDevice
 ~~~~~~~~~~~~~~~
 A :any:`USBSDWireDevice` resource describes a Tizen
-`SD Wire device <https://wiki.tizen.org/SDWire>`_
-device.
+`SD Wire device <https://wiki.tizen.org/SDWire>`_.
 
 .. code-block:: yaml
 
@@ -949,7 +948,7 @@ on a remote computer.
 USBVideo
 ~~~~~~~~
 A :any:`USBVideo` resource describes a USB video camera which is supported by a
-Video4Linux2 kernel driver.
+Video4Linux2 (v4l2) kernel driver.
 
 .. code-block:: yaml
 
@@ -1161,7 +1160,7 @@ Such device could be a signal generator.
      url: '192.168.110.11'
 
 Arguments:
-  - type (str): device resource type following the pyVISA resource syntax, e.g.
+  - type (str): device resource type following the PyVISA resource syntax, e.g.
     ASRL, TCPIP...
   - url (str): device identifier on selected resource, e.g. <ip> for TCPIP
     resource
@@ -1171,7 +1170,7 @@ Used by:
 
 HTTPVideoStream
 ~~~~~~~~~~~~~~~
-A :any:`HTTPVideoStream` resource describes a IP video stream over HTTP or HTTPS.
+An :any:`HTTPVideoStream` resource describes an IP video stream over HTTP or HTTPS.
 
 .. code-block:: yaml
 
@@ -1624,7 +1623,7 @@ Arguments:
 
 SSHDriver
 ~~~~~~~~~
-A :any:`SSHDriver` requires a `NetworkService`_ resource and allows the
+An :any:`SSHDriver` requires a `NetworkService`_ resource and allows the
 execution of commands and file upload via network.
 It uses SSH's ``ServerAliveInterval`` option to detect failed connections.
 
@@ -2234,7 +2233,7 @@ Arguments:
 
 HIDRelayDriver
 ~~~~~~~~~~~~~~
-A :any:`HIDRelayDriver` controls a `HIDRelay`_ or `NetworkHIDRelay`_ resource.
+An :any:`HIDRelayDriver` controls an `HIDRelay`_ or `NetworkHIDRelay`_ resource.
 It can set and get the current state of the resource.
 
 Binds to:
@@ -2384,8 +2383,9 @@ Arguments:
 
 RKUSBDriver
 ~~~~~~~~~~~
-A :any:`RKUSBDriver` is used to upload an image into a device in the *Rockchip
-USB loader state*. This is useful to bootstrap a bootloader onto a device.
+An :any:`RKUSBDriver` is used to upload an image into a device in the *Rockchip
+USB loader state*.
+This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
   loader:
@@ -2721,8 +2721,9 @@ argument being "dut", "host", "off", or "client".
 
 LXAUSBMuxDriver
 ~~~~~~~~~~~~~~~
-The :any:`LXAUSBMuxDriver` uses a `LXAUSBMux`_ resource to control a USB-Mux
-device via the `usbmuxctl <https://github.com/linux-automation/usbmuxctl>`_ tool.
+The :any:`LXAUSBMuxDriver` uses an `LXAUSBMux`_ resource to control a USB-Mux
+device via the `usbmuxctl <https://github.com/linux-automation/usbmuxctl>`_
+tool.
 
 Binds to:
   mux:
@@ -2789,7 +2790,7 @@ Appropriate configuration parameters can be determined by using the GStreamer
 
 USBAudioInputDriver
 ~~~~~~~~~~~~~~~~~~~
-The :any:`USBAudioInputDriver` is used to receive a audio stream from a local
+The :any:`USBAudioInputDriver` is used to receive an audio stream from a local
 or remote USB audio input.
 It uses the GStreamer command line utility ``gst-launch`` on the sender side to
 stream the audio to the client.
@@ -2811,7 +2812,7 @@ Arguments:
 
 USBTMCDriver
 ~~~~~~~~~~~~
-The :any:`USBTMCDriver` is used to control a oscilloscope via the *USB TMC
+The :any:`USBTMCDriver` is used to control an oscilloscope via the *USB TMC
 protocol*.
 
 Binds to:
@@ -2835,7 +2836,7 @@ but more devices can be added by extending ``on_activate()`` in
 
 FlashromDriver
 ~~~~~~~~~~~~~~
-The :any:`FlashromDriver` is used to flash a rom, using the flashrom utility.
+The :any:`FlashromDriver` is used to flash a ROM, using the flashrom utility.
 
 .. code-block:: yaml
 
@@ -3036,8 +3037,8 @@ Arguments:
 
 HttpDigitalOutputDriver
 ~~~~~~~~~~~~~~~~~~~~~~~
-A :any:`HttpDigitalOutputDriver` binds to a `HttpDigitalOutput`_ to set and get
-a digital output state via HTTP.
+A :any:`HttpDigitalOutputDriver` binds to an `HttpDigitalOutput`_ to set and
+get a digital output state via HTTP.
 
 Binds to:
   http:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -79,14 +79,7 @@ Modbus is normally implemented on top of RS-485, though this is not strictly
 necessary, as long as the Modbus network only has one master (and up to 256
 slaves).
 
-The labgrid driver is implemented using the
-`minimalmodbus <https://minimalmodbus.readthedocs.io/en/stable/>`_ Python
-library.
-The implementation only supports that labgrid will be the master on the Modbus
-network.
-
-This resource and driver only supports local usage and will not work with an
-exporter.
+This resource only supports local usage and will not work with an exporter.
 
 .. code-block:: yaml
 
@@ -1555,6 +1548,12 @@ ModbusRTUDriver
 ~~~~~~~~~~~~~~~
 A :any:`ModbusRTUDriver` connects to a ModbusRTU resource. This driver only
 supports local usage and will not work with an exporter.
+
+The driver is implemented using the
+`minimalmodbus <https://minimalmodbus.readthedocs.io/en/stable/>`_ Python
+library.
+The implementation only supports that labgrid will be the master on the Modbus
+network.
 
 .. code-block:: yaml
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -578,9 +578,6 @@ NetworkUSBMassStorage
 A NetworkUSBMassStorage resource describes a USB memory stick or similar
 device available on a remote computer.
 
-Used by:
-  - `USBStorageDriver`_
-
 The NetworkUSBMassStorage can be used in test cases by calling the
 `write_image()`, and `get_size()` functions.
 
@@ -1085,8 +1082,6 @@ NetworkUSBFlashableDevice
 A :any:`NetworkUSBFlashableDevice` resource describes a :any:`USBFlashableDevice`
 resource available on a remote computer
 
-Used by:
-  - `FlashScriptDriver`_
 
 DediprogFlasher
 ~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -638,7 +638,7 @@ Used by:
   - `UUUDriver`_
 
 RKUSBLoader
-~~~~~~~~~~~~
+~~~~~~~~~~~
 An RKUSBLoader resource describes a USB device in the rockchip loader state.
 
 .. code-block:: yaml
@@ -662,7 +662,7 @@ NetworkIMXUSBLoader
 A NetworkIMXUSBLoader describes an `IMXUSBLoader`_ available on a remote computer.
 
 NetworkRKUSBLoader
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 A NetworkRKUSBLoader describes an `RKUSBLoader`_ available on a remote computer.
 
 AndroidUSBFastboot
@@ -737,7 +737,7 @@ Arguments:
   - ifname (str): name of the interface
 
 USBNetworkInterface
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 A USBNetworkInterface resource describes a USB network adapter (such as
 Ethernet or WiFi)
 
@@ -2291,7 +2291,7 @@ Arguments:
   - None
 
 RKUSBDriver
-~~~~~~~~~~~~
+~~~~~~~~~~~
 A RKUSBDriver is used to upload an image into a device in the rockchip USB loader
 state. This is useful to bootstrap a bootloader onto a device.
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -32,8 +32,8 @@ enumeration order.
      port: '/dev/ttyUSB0'
      speed: 115200
 
-The example would access the serial port /dev/ttyUSB0 on the local computer with
-a baud rate of 115200.
+The example would access the serial port ``/dev/ttyUSB0`` on the local computer
+with a baud rate of ``115200``.
 
 Arguments:
   - port (str): path to the serial device
@@ -55,8 +55,9 @@ or raw tcp.
      port: 53867
      speed: 115200
 
-The example would access the serial port on computer remote.example.computer via
-port 53867 and use a baud rate of 115200 with the RFC2217 protocol.
+The example would access the serial port on computer
+``remote.example.computer`` via port ``53867`` and use a baud rate of
+``115200`` with the RFC2217 protocol.
 
 Arguments:
   - host (str): hostname of the remote host
@@ -96,7 +97,7 @@ exporter.
       timeout: 0.25
 
 Arguments:
-  - port (str): tty the instrument is connected to, e.g. '/dev/ttyUSB0'
+  - port (str): tty the instrument is connected to, e.g. ``/dev/ttyUSB0``
   - address (int): slave address on the modbus, e.g. 16
   - speed (int, default=115200): baud rate of the serial port
   - timeout (float, default=0.25): timeout in seconds
@@ -118,9 +119,9 @@ This allows identification through hot-plugging or rebooting.
      speed: 115200
 
 The example would search for a USB serial converter with the key
-`ID_SERIAL_SHORT` and the value `P-00-00682` and use it with a baud rate
-of 115200.
-The `ID_SERIAL_SHORT` property is set by the usb_id builtin helper program.
+``ID_SERIAL_SHORT`` and the value ``P-00-00682`` and use it with a baud rate
+of ``115200``.
+The ``ID_SERIAL_SHORT`` property is set by the ``usb_id`` builtin helper program.
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -144,63 +145,63 @@ A :any:`NetworkPowerPort` describes a remotely switchable power port.
      index: 0
 
 The example describes port 0 on the remote power switch
-`powerswitch.example.computer`, which is a `gude` model.
+``powerswitch.example.computer``, which is a ``gude`` model.
 
 Arguments:
   - model (str): model of the power switch
   - host (str): hostname of the power switch
   - index (int): number of the port to switch
 
-The `model` property selects one of several `backend implementations
+The ``model`` property selects one of several `backend implementations
 <https://github.com/labgrid-project/labgrid/tree/master/labgrid/driver/power>`_.
 Currently available are:
 
 ``apc``
-  Controls an APU PDU via SNMP.
+  Controls an *APU PDU* via SNMP.
 
 ``digipower``
-  Controls a DigiPower PDU via a simple HTTP API.
+  Controls a *DigiPower PDU* via a simple HTTP API.
 
 ``digitalloggers_http``
-  Control a Digital Loggers PDU that use the legacy HTTP API. Note that
+  Control a *Digital Loggers PDUs* that use the legacy HTTP API. Note that
   host argument must include the protocol, such as
   ``http://192.168.0.3`` or ``http://admin:pass@192.168.0.4``.
 
 ``eaton``
-  Controls Eaton ePDUs via SNMP.
+  Controls *Eaton ePDUs* via SNMP.
 
 ``eg_pms2_network``
-  Controls the EG_PMS2_LAN & EG_PMS2_WLAN devices, through simple HTTP POST and
-  GET requests.  The device requires a password for logging into the control
-  interface, this module deliberately uses the standard password '1' and is
-  not compatible with a different password.
+  Controls the *EG_PMS2_LAN* & *EG_PMS2_WLAN* devices, through simple HTTP POST
+  and GET requests. The device requires a password for logging into the
+  control interface, this module deliberately uses the standard password ``1``
+  and is not compatible with a different password.
 
 ``eth008``
-  Controls a Robot-Electronics eth008 via a simple HTTP API.
+  Controls a *Robot-Electronics eth008* via a simple HTTP API.
 
 ``gude``
-  Controls a Gude PDU via a simple HTTP API.
+  Controls a *Gude PDU* via a simple HTTP API.
 
 ``gude24``
-  Controls a Gude Expert Power Control 8008 PDU via a simple HTTP API.
+  Controls a *Gude Expert Power Control 8008 PDU* via a simple HTTP API.
 
 ``gude8031``
-  Controls a Gude Expert Power Control 8031 PDU via a simple HTTP API.
+  Controls a *Gude Expert Power Control 8031 PDU* via a simple HTTP API.
 
 ``gude8225``
-  Controls a Gude Expert Power Control 8225 PDU via a simple HTTP API.
+  Controls a *Gude Expert Power Control 8225 PDUs via a simple HTTP API.
 
 ``gude8316``
-  Controls a Gude Expert Power Control 8316 PDU via a simple HTTP API.
+  Controls a *Gude Expert Power Control 8316 PDU* via a simple HTTP API.
 
 ``netio``
-  Controls a NETIO 4-Port PDU via a simple HTTP API.
+  Controls a *NETIO 4-Port PDU* via a simple HTTP API.
 
 ``netio_kshell``
-  Controls a NETIO 4C PDU via a Telnet interface.
+  Controls a *NETIO 4C PDU* via a Telnet interface.
 
 ``raritan``
-  Controls Raritan PDUs via SNMP.
+  Controls *Raritan PDUs* via SNMP.
 
 ``rest``
   This is a generic backend for PDU implementations which can be controlled via
@@ -210,17 +211,17 @@ Currently available are:
   for details.
 
 ``sentry``
-  Controls a Sentry PDU via SNMP using Sentry3-MIB.
-  It was tested on CW-24VDD and 4805-XLS-16.
+  Controls a *Sentry PDU* via SNMP using Sentry3-MIB.
+  It was tested on *CW-24VDD* and *4805-XLS-16*.
 
 ``shelly_gen1``
-  Controls relays of Shelly devices using the Gen 1 Device API.
+  Controls relays of *Shelly* devices using the Gen 1 Device API.
   See the `docstring in the module
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/shelly_gen1.py>`__
   for details.
 
 ``siglent``
-  Controls Siglent SPD3000X series modules via the `vxi11 Python module
+  Controls *Siglent SPD3000X* series modules via the `vxi11 Python module
   <https://pypi.org/project/python-vxi11/>`_.
 
 ``simplerest``
@@ -231,7 +232,7 @@ Currently available are:
   for details.
 
 ``tplink``
-  Controls TP-Link power strips via `python-kasa
+  Controls *TP-Link power strips* via `python-kasa
   <https://github.com/python-kasa/python-kasa>`_.
 
 ``poe_mib``
@@ -254,8 +255,8 @@ PDUDaemon configuration file needs to be specified.
      pdu: 'apc-snmpv3-noauth'
      index: 1
 
-The example describes port 1 on the PDU configured as `apc-snmpv3-noauth`, with
-PDUDaemon running on the host `pduserver`.
+The example describes port ``1`` on the PDU configured as
+``apc-snmpv3-noauth``, with PDUDaemon running on the host ``pduserver``.
 
 Arguments:
   - host (str): name of the host running the PDUDaemon
@@ -267,7 +268,8 @@ Used by:
 
 YKUSHPowerPort
 ++++++++++++++
-A :any:`YKUSHPowerPort` describes a YEPKIT YKUSH USB (HID) switchable USB hub.
+A :any:`YKUSHPowerPort` describes a *YEPKIT YKUSH* USB (HID) switchable USB
+hub.
 
 .. code-block:: yaml
 
@@ -276,8 +278,8 @@ A :any:`YKUSHPowerPort` describes a YEPKIT YKUSH USB (HID) switchable USB hub.
      index: 1
 
 The example describes port 1 on the YKUSH USB hub with the
-serial "YK12345".
-(use "ykushcmd -l" to get your serial...)
+serial ``YK12345``.
+Use ``ykushcmd -l`` to get your serial number.
 
 Arguments:
   - serial (str): serial number of the YKUSH hub
@@ -304,7 +306,7 @@ A :any:`USBPowerPort` describes a generic switchable USB hub as supported by
      index: 1
 
 The example describes port 1 on the hub with the ID_PATH
-"pci-0000:00:14.0-usb-0:2:1.0".
+``pci-0000:00:14.0-usb-0:2:1.0``.
 (use ``udevadm info /sys/bus/usb/devices/...`` to find the ID_PATH value)
 
 Arguments:
@@ -323,7 +325,7 @@ Used by:
 
 SiSPMPowerPort
 ++++++++++++++
-A :any:`SiSPMPowerPort` describes a GEMBIRD SiS-PM as supported by
+A :any:`SiSPMPowerPort` describes a *GEMBIRD SiS-PM* as supported by
 `sispmctl <https://sourceforge.net/projects/sispmctl/>`_.
 
 .. code-block:: yaml
@@ -334,7 +336,7 @@ A :any:`SiSPMPowerPort` describes a GEMBIRD SiS-PM as supported by
      index: 1
 
 The example describes port 1 on the hub with the ID_PATH
-"platform-1c1a400.usb-usb-0:2".
+``platform-1c1a400.usb-usb-0:2``.
 
 Arguments:
   - index (int): number of the port to switch
@@ -346,7 +348,7 @@ Used by:
 TasmotaPowerPort
 ++++++++++++++++
 A :any:`TasmotaPowerPort` resource describes a switchable `Tasmota
-<https://tasmota.github.io/docs/>`_ power outlet accessed over MQTT.
+<https://tasmota.github.io/docs/>`_ power outlet accessed over *MQTT*.
 
 .. code-block:: yaml
 
@@ -356,8 +358,8 @@ A :any:`TasmotaPowerPort` resource describes a switchable `Tasmota
      power_topic: 'cmnd/tasmota_575A2B/POWER'
      avail_topic: 'tele/tasmota_575A2B/LWT'
 
-The example uses a mosquitto server at "this.is.an.example.host.com" and has the
-topics setup for a tasmota power port that has the ID 575A2B.
+The example uses a *Mosquitto* server at ``this.is.an.example.host.com`` and
+has the topics setup for a Tasmota power port that has the ID ``575A2B``.
 
 Arguments:
   - host (str): hostname of the MQTT server
@@ -375,7 +377,7 @@ Digital Outputs
 
 ModbusTCPCoil
 +++++++++++++
-A :any:`ModbusTCPCoil` describes a coil accessible via ModbusTCP.
+A :any:`ModbusTCPCoil` describes a coil accessible via *Modbus TCP*.
 
 .. code-block:: yaml
 
@@ -383,12 +385,12 @@ A :any:`ModbusTCPCoil` describes a coil accessible via ModbusTCP.
      host: '192.168.23.42'
      coil: 1
 
-The example describes the coil with the address 1 on the ModbusTCP device
-`192.168.23.42`.
+The example describes the coil with the address ``1`` on the Modbus TCP device
+``192.168.23.42``.
 
 Arguments:
-  - host (str): hostname of the Modbus TCP server e.g. "192.168.23.42:502"
-  - coil (int): index of the coil e.g. 3
+  - host (str): hostname of the Modbus TCP server e.g. ``192.168.23.42:502``
+  - coil (int): index of the coil, e.g. ``3``
   - invert (bool, default=False): whether the logic level is inverted
     (active-low)
   - write_multiple_coils (bool, default=False): whether to perform write
@@ -399,7 +401,7 @@ Used by:
 
 DeditecRelais8
 ++++++++++++++
-A :any:`DeditecRelais8` describes a Deditec USB GPO module with 8 relays.
+A :any:`DeditecRelais8` describes a *Deditec USB GPO module* with 8 relays.
 
 .. code-block:: yaml
 
@@ -420,7 +422,7 @@ Used by:
 
 OneWirePIO
 ++++++++++
-A :any:`OneWirePIO` describes a onewire programmable I/O pin.
+A :any:`OneWirePIO` describes a *1-Wire* programmable I/O pin.
 
 .. code-block:: yaml
 
@@ -429,11 +431,11 @@ A :any:`OneWirePIO` describes a onewire programmable I/O pin.
      path: '/29.7D6913000000/PIO.0'
      invert: false
 
-The example describes a `PIO.0` at device address `29.7D6913000000` via the onewire
-server on `example.computer`.
+The example describes a ``PIO.0`` at device address ``29.7D6913000000`` via the
+1-Wire server on ``example.computer``.
 
 Arguments:
-  - host (str): hostname of the remote system running the onewire server
+  - host (str): hostname of the remote system running the 1-Wire server
   - path (str): path on the server to the programmable I/O pin
   - invert (bool, default=False): whether the logic level is inverted
     (active-low)
@@ -453,8 +455,8 @@ An :any:`LXAIOBusPIO` resource describes a single PIO pin on an LXAIOBusNode.
      pin: 'OUT0'
      invert: false
 
-The example uses an lxa-iobus-server running on localhost:8080, with node
-IOMux-00000003 and pin OUT0.
+The example uses an lxa-iobus-server running on ``localhost:8080``, with node
+``IOMux-00000003`` and pin ``OUT0``.
 
 Arguments:
   - host (str): hostname with port of the lxa-io-bus server
@@ -473,7 +475,7 @@ HIDRelay
 ++++++++
 An :any:`HIDRelay` resource describes a single output of a HID protocol based
 USB relays.
-It currently supports the widely used "dcttech USBRelay".
+It currently supports the widely used *dcttech USBRelay*.
 
 .. code-block:: yaml
 
@@ -538,8 +540,8 @@ A :any:`NetworkService` describes a remote SSH connection.
      address: 'example.computer'
      username: 'root'
 
-The example describes a remote SSH connection to the computer `example.computer`
-with the username `root`.
+The example describes a remote SSH connection to the computer
+``example.computer`` with the username ``root``.
 Set the optional password password property to make SSH login with a password
 instead of the key file.
 
@@ -582,12 +584,13 @@ A :any:`NetworkUSBMassStorage` resource describes a USB memory stick or similar
 device available on a remote computer.
 
 The NetworkUSBMassStorage can be used in test cases by calling the
-`write_image()`, and `get_size()` functions.
+``write_image()``, and ``get_size()`` functions.
 
 SigrokDevice
 ~~~~~~~~~~~~
-A :any:`SigrokDevice` resource describes a sigrok device. To select a specific
-device from all connected supported devices use the `SigrokUSBDevice`_.
+A :any:`SigrokDevice` resource describes a *Sigrok* device. To select a
+specific device from all connected supported devices use the
+`SigrokUSBDevice`_.
 
 .. code-block:: yaml
 
@@ -623,7 +626,8 @@ Used by:
 
 MXSUSBLoader
 ~~~~~~~~~~~~
-An :any:`MXSUSBLoader` resource describes a USB device in the mxs loader state.
+An :any:`MXSUSBLoader` resource describes a USB device in the *MXS loader
+state*.
 
 .. code-block:: yaml
 
@@ -641,8 +645,8 @@ Used by:
 
 RKUSBLoader
 ~~~~~~~~~~~
-An :any:`RKUSBLoader` resource describes a USB device in the rockchip loader
-state.
+An :any:`RKUSBLoader` resource describes a USB device in the *Rockchip loader
+state*.
 
 .. code-block:: yaml
 
@@ -673,8 +677,8 @@ computer.
 
 AndroidUSBFastboot
 ~~~~~~~~~~~~~~~~~~
-An :any:`AndroidUSBFastboot` resource describes a USB device in the fastboot
-state.
+An :any:`AndroidUSBFastboot` resource describes a USB device in the *Fastboot
+state*.
 Previously, this resource was named AndroidFastboot and this name still
 supported for backwards compatibility.
 
@@ -696,8 +700,8 @@ Used by:
 
 AndroidNetFastboot
 ~~~~~~~~~~~~~~~~~~
-An :any:`AndroidNetFastboot` resource describes a network device in fastboot
-state.
+An :any:`AndroidNetFastboot` resource describes a network device in *Fastboot
+state*.
 
 .. code-block:: yaml
 
@@ -791,7 +795,7 @@ Used by:
 USBDebugger
 ~~~~~~~~~~~
 An :any:`USBDebugger` resource describes a JTAG USB adapter (for example an
-FTDI FT2232H).
+*FTDI FT2232H*).
 
 .. code-block:: yaml
 
@@ -825,7 +829,7 @@ Used by:
 
 SigrokUSBDevice
 ~~~~~~~~~~~~~~~
-A :any:`SigrokUSBDevice` resource describes a sigrok USB device.
+A :any:`SigrokUSBDevice` resource describes a *Sigrok* USB device.
 
 .. code-block:: yaml
 
@@ -846,13 +850,13 @@ Used by:
 
 NetworkSigrokUSBDevice
 ~~~~~~~~~~~~~~~~~~~~~~
-A :any:`NetworkSigrokUSBDevice` resource describes a sigrok USB device
+A :any:`NetworkSigrokUSBDevice` resource describes a *Sigrok* USB device
 connected to a host which is exported over the network.
 The `SigrokDriver`_ will access it via SSH.
 
 SigrokUSBSerialDevice
 ~~~~~~~~~~~~~~~~~~~~~
-A :any:`SigrokUSBSerialDevice` resource describes a sigrok device which
+A :any:`SigrokUSBSerialDevice` resource describes a *Sigrok* device which
 communicates over a USB serial port instead of being a USB device itself (see
 `SigrokUSBDevice`_ for that case).
 
@@ -865,8 +869,8 @@ communicates over a USB serial port instead of being a USB device itself (see
 
 Arguments:
   - driver (str): name of the sigrok driver to use
-  - channels (str): optional, channel mapping as described in the sigrok-cli
-    man page
+  - channels (str): optional, channel mapping as described in the
+    ``sigrok-cli`` man page
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 
 Used by:
@@ -899,7 +903,7 @@ on a remote computer.
 
 LXAUSBMux
 ~~~~~~~~~
-A :any:`LXAUSBMux` resource describes a Linux Automation GmbH USB-Mux device.
+A :any:`LXAUSBMux` resource describes a *Linux Automation GmbH USB-Mux* device.
 
 .. code-block:: yaml
 
@@ -992,7 +996,7 @@ by an ALSA kernel driver.
 
 Arguments:
   - index (int, default=0): ALSA PCM device number (as in
-    `hw:CARD=<card>,DEV=<index>`)
+    ``hw:CARD=<card>,DEV=<index>``)
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 
 Used by:
@@ -1005,9 +1009,9 @@ available on a remote computer.
 
 USBTMC
 ~~~~~~
-A :any:`USBTMC` resource describes an oscilloscope connected via the USB TMC
-protocol.
-The low-level communication is handled by the ``usbtmc`` kernel driver.
+A :any:`USBTMC` resource describes an oscilloscope connected via the *USB TMC
+protocol*.
+The low-level communication is handled by the "usbtmc" kernel driver.
 
 
 .. code-block:: yaml
@@ -1046,12 +1050,13 @@ configured in:
     flashrom: '/usr/sbin/flashrom'
 
 Arguments:
-  - programmer (str): programmer device as described in `-p, --programmer` in
-    `man 8 flashrom`
+  - programmer (str): programmer device as described in ``-p, --programmer`` in
+    ``man 8 flashrom``
 
-The resource must configure which programmer to use and the parameters to the programmer.
-The programmer parameter is passed directly to the flashrom bin hence man(8) flashrom
-can be used for reference.
+The resource must configure which programmer to use and the parameters to the
+programmer.
+The programmer parameter is passed directly to the flashrom bin hence
+``man 8 flashrom`` can be used for reference.
 Below an example where the local spidev is used.
 
 .. code-block:: yaml
@@ -1109,9 +1114,9 @@ configured via:
     dpcmd: '/usr/sbin/dpcmd'
 
 Arguments:
-  - vcc (str): '3.5V', '2.5V' or '1.8V'.
+  - vcc (str): ``3.5V``, ``2.5V`` or ``1.8V``.
 
-For instance, to flash using 3.5V vcc:
+For instance, to flash using 3.5 V VCC:
 
 .. code-block:: yaml
 
@@ -1128,8 +1133,9 @@ remote computer.
 
 XenaManager
 ~~~~~~~~~~~
-A :any:`XenaManager` resource describes a Xena Manager instance which is the
-instance the `XenaDriver`_ must connect to in order to configure a Xena chassis.
+A :any:`XenaManager` resource describes a *Xena Manager* instance which is the
+instance the `XenaDriver`_ must connect to in order to configure a Xena
+chassis.
 
 .. code-block:: yaml
 
@@ -1294,7 +1300,7 @@ place.
    RemotePlace:
      name: 'example-place'
 
-The example describes the remote place `example-place`. It will connect to the
+The example describes the remote place ``example-place``. It will connect to the
 labgrid remote coordinator, wait until the resources become available and expose
 them to the internal environment.
 
@@ -1306,7 +1312,7 @@ Used by:
 
 DockerDaemon
 ~~~~~~~~~~~~
-A :any:`DockerDaemon` describes where to contact a docker daemon process.
+A :any:`DockerDaemon` describes where to contact a *docker daemon* process.
 DockerDaemon also participates in managing `NetworkService`_ instances
 created through interaction with that daemon.
 
@@ -1397,7 +1403,7 @@ Matching a USB Serial Converter on a Hub Port
 +++++++++++++++++++++++++++++++++++++++++++++
 This will match any USB serial converter connected below the hub port 1.2.5.5
 on bus 1.
-The `ID_PATH` value corresponds to the hierarchy of buses and ports as shown
+The ``ID_PATH`` value corresponds to the hierarchy of buses and ports as shown
 with ``udevadm info /dev/ttyUSB0``.
 
 .. code-block:: yaml
@@ -1420,13 +1426,13 @@ don't use a parent match.
 
   AndroidUSBFastboot:
     match:
-      ID_PATH: pci-0000:05:00.0-usb-0:1.2.3
+      ID_PATH: 'pci-0000:05:00.0-usb-0:1.2.3'
 
 Matching a Specific UART in a Dual-Port Adapter
 +++++++++++++++++++++++++++++++++++++++++++++++
 On this board, the serial console is connected to the second port of an
 on-board dual-port USB-UART.
-The board itself is connected to the bus 3 and port path 10.2.2.2.
+The board itself is connected to the bus 3 and port path ``10.2.2.2``.
 The correct value can be shown by running ``udevadm info /dev/ttyUSB9`` in our
 case:
 
@@ -1620,11 +1626,11 @@ SSHDriver
 ~~~~~~~~~
 A :any:`SSHDriver` requires a `NetworkService`_ resource and allows the
 execution of commands and file upload via network.
-It uses SSH's `ServerAliveInterval` option to detect failed connections.
+It uses SSH's ``ServerAliveInterval`` option to detect failed connections.
 
 If a shared SSH connection to the target is already open, it will reuse it when
 running commands.
-In that case, `ServerAliveInterval` should be set outside of labgrid, as it
+In that case, ``ServerAliveInterval`` should be set outside of labgrid, as it
 cannot be enabled for an existing connection.
 
 Binds to:
@@ -1643,14 +1649,14 @@ Implements:
 Arguments:
   - keyfile (str): optional, filename of private key to login into the remote system
     (has precedence over `NetworkService`_'s password)
-  - stderr_merge (bool, default=False): set to True to make `run()` return stderr merged with
+  - stderr_merge (bool, default=False): set to True to make ``run()`` return stderr merged with
     stdout, and an empty list as second element.
   - connection_timeout (float, default=30.0): timeout when trying to establish connection to
     target.
-  - explicit_sftp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
-    explicitly use the SFTP protocol for file transfers instead of scp's default protocol
-  - explicit_scp_mode (bool, default=False): if set to True, `put()`, `get()`, and `scp()` will
-    explicitly use the SCP protocol for file transfers instead of scp's default protocol
+  - explicit_sftp_mode (bool, default=False): if set to True, ``put()``, ``get()``, and ``scp()``
+    will explicitly use the SFTP protocol for file transfers instead of scp's default protocol
+  - explicit_scp_mode (bool, default=False): if set to True, ``put()``, ``get()``, and ``scp()``
+    will explicitly use the SCP protocol for file transfers instead of scp's default protocol
   - username (str, default=username from `NetworkService`_): username used by SSH
   - password (str, default=password from `NetworkService`_): password used by SSH
 
@@ -1679,7 +1685,7 @@ Arguments:
   - prompt (regex, default=""): U-Boot prompt to match
   - autoboot (regex, default="stop autoboot"): autoboot message to match
   - password (str): optional, U-Boot unlock password
-  - interrupt (str, default="\\n"): string to interrupt autoboot (use "\\x03" for CTRL-C)
+  - interrupt (str, default="\\n"): string to interrupt autoboot (use ``\\x03`` for CTRL-C)
   - init_commands (tuple): optional, tuple of commands to execute after matching the
     prompt
   - password_prompt (str, default="enter Password: "): regex to match the U-Boot password prompt
@@ -1691,7 +1697,7 @@ Arguments:
 
 SmallUBootDriver
 ~~~~~~~~~~~~~~~~
-A :any:`SmallUBootDriver` interfaces with stripped-down U-Boot variants that
+A :any:`SmallUBootDriver` interfaces with stripped-down *U-Boot* variants that
 are sometimes used in cheap consumer electronics.
 
 SmallUBootDriver is meant as a driver for U-Boot with only little functionality
@@ -1701,7 +1707,7 @@ Especially is copes with the following limitations:
 - The U-Boot does not have a real password-prompt but can be activated by
   entering a "secret" after a message was displayed.
 - The command line does not have a built-in echo command.
-  Thus this driver uses 'Unknown Command' messages as marker before and after
+  Thus this driver uses "Unknown Command" messages as marker before and after
   the output of a command.
 - Since there is no echo we cannot return the exit code of the command.
   Commands will always return 0 unless the command was not found.
@@ -1793,7 +1799,7 @@ Arguments:
 AndroidFastbootDriver
 ~~~~~~~~~~~~~~~~~~~~~
 An :any:`AndroidFastbootDriver` allows the upload of images to a device in the
-USB or network fastboot state.
+USB or network *Fastboot state*.
 
 Binds to:
   fastboot:
@@ -1842,7 +1848,7 @@ Arguments:
 
 OpenOCDDriver
 ~~~~~~~~~~~~~
-An :any:`OpenOCDDriver` controls OpenOCD to bootstrap a target with a
+An :any:`OpenOCDDriver` controls *OpenOCD* to bootstrap a target with a
 bootloader.
 
 Note that OpenOCD supports specifying USB paths since
@@ -1899,7 +1905,7 @@ Implements:
 Arguments:
   - image (str): optional, filename of image to write into QSPI flash
 
-The driver can be used in test cases by calling the `flash` function. An
+The driver can be used in test cases by calling its ``flash()`` method. An
 example strategy is included in labgrid.
 
 ManualPowerDriver
@@ -2269,7 +2275,7 @@ Arguments:
 
 DeditecRelaisDriver
 ~~~~~~~~~~~~~~~~~~~
-A :any:`DeditecRelaisDriver` controls a Deditec relay resource.
+A :any:`DeditecRelaisDriver` controls a *Deditec* relay resource.
 It can set and get the current state of the resource.
 
 Binds to:
@@ -2289,8 +2295,8 @@ Arguments:
 
 MXSUSBDriver
 ~~~~~~~~~~~~
-An :any:`MXSUSBDriver` is used to upload an image into a device in the mxs USB
-loader state.
+An :any:`MXSUSBDriver` is used to upload an image into a device in the *MXS USB
+loader state*.
 This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
@@ -2318,10 +2324,10 @@ Arguments:
 
 IMXUSBDriver
 ~~~~~~~~~~~~
-A :any:`IMXUSBDriver` is used to upload an image into a device in the imx USB
-loader state.
+An :any:`IMXUSBDriver` is used to upload an image into a device in the *i.MX
+USB loader state*.
 This is useful to bootstrap a bootloader onto a device.
-This driver uses the imx-usb-loader tool from barebox.
+This driver uses the ``imx-usb-loader`` tool from barebox.
 
 Binds to:
   loader:
@@ -2350,10 +2356,11 @@ Arguments:
 
 BDIMXUSBDriver
 ~~~~~~~~~~~~~~
-The :any:`BDIMXUSBDriver` is used to upload bootloader images into an i.MX
-device in the USB SDP mode.
-This driver uses the imx_usb tool by Boundary Devices.
-Compared to the IMXUSBLoader, it supports two-stage upload of U-Boot images.
+The :any:`BDIMXUSBDriver` is used to upload bootloader images into an *i.MX
+device* in the *USB SDP mode*.
+This driver uses the ``imx_usb`` tool by Boundary Devices.
+Compared to the ``imx-usb-loader``, it supports two-stage upload of U-Boot
+images.
 The images paths need to be specified from code instead of in the YAML
 environment, as the correct image depends on the system state.
 
@@ -2377,9 +2384,8 @@ Arguments:
 
 RKUSBDriver
 ~~~~~~~~~~~
-A :any:`RKUSBDriver` is used to upload an image into a device in the rockchip
-USB loader state.
-This is useful to bootstrap a bootloader onto a device.
+A :any:`RKUSBDriver` is used to upload an image into a device in the *Rockchip
+USB loader state*. This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
   loader:
@@ -2410,8 +2416,8 @@ Arguments:
 
 UUUDriver
 ~~~~~~~~~
-A :any:`UUUDriver` is used to upload an image into a device in the NXP USB
-loader state.
+A :any:`UUUDriver` is used to upload an image into a device in the *NXP USB
+loader state*.
 This is useful to bootstrap a bootloader onto a device.
 
 Binds to:
@@ -2439,7 +2445,7 @@ Implements:
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
     of an image to bootstrap onto the target
-  - script (str): run built-in script with "uuu -b", called with image as arg0
+  - script (str): run built-in script with ``uuu -b``, called with image as arg0
 
 USBStorageDriver
 ~~~~~~~~~~~~~~~~
@@ -2518,7 +2524,7 @@ Implements:
 Arguments:
   - None
 
-The driver can be used in test cases by calling the `stage()` function, which
+The driver can be used in test cases by calling its ``stage()`` method, which
 returns the path to be used by the target.
 
 NFSProviderDriver
@@ -2540,7 +2546,7 @@ Implements:
 Arguments:
   - None
 
-The driver can be used in test cases by calling the `stage()` function, which
+The driver can be used in test cases by calling its ``stage()`` method, which
 returns an NFSFile object with ``host``, ``export`` and ``relative_file_path``
 attributes.
 
@@ -2629,8 +2635,8 @@ Implements:
 Arguments:
   - None
 
-The driver can be used in test cases by calling the `capture`, `stop` and
-`analyze` functions.
+The driver can be used in test cases by calling its ``capture()``, ``stop()``
+and ``analyze()`` methods.
 
 SigrokPowerDriver
 ~~~~~~~~~~~~~~~~~
@@ -2661,9 +2667,10 @@ Arguments:
 SigrokDmmDriver
 ~~~~~~~~~~~~~~~
 The :any:`SigrokDmmDriver` uses a `SigrokDevice`_ resource to record samples
-from a digital multimeter (DMM) and provides them during test runs.
+from a *digital multimeter* (DMM) and provides them during test runs.
 
-It is known to work with Unit-T `UT61B` and `UT61C` devices but should also work with other DMMs supported by *sigrok*.
+It is known to work with *Unit-T UT61B* and *UT61C* devices but should also
+work with other DMMs supported by *Sigrok*.
 
 Binds to:
   sigrok:
@@ -2678,15 +2685,15 @@ Implements:
 Arguments:
   - None
 
-Sampling can be started calling `capture(samples, timeout=None)`.
+Sampling can be started calling ``capture(samples, timeout=None)``.
 It sets up sampling and returns immediately.
-The default timeout has been chosen to work with Unit-T `UT61B`.
+The default timeout has been chosen to work with *Unit-T UT61B*.
 Other devices may require a different timeout setting.
 
-Samples can be obtained using `stop()`.
-`stop()` will block until either *sigrok* terminates or `timeout` is reached.
-This method returns a `(unit, samples)` tuple:
-`unit` is the physical unit reported by the DMM;
+Samples can be obtained using ``stop()``.
+``stop()`` will block until either *sigrok* terminates or *timeout* is reached.
+This method returns a ``(unit, samples)`` tuple:
+``unit`` is the physical unit reported by the DMM;
 samples is an iterable of samples.
 
 This driver relies on buffering of the subprocess call.
@@ -2728,7 +2735,7 @@ Implements:
 Arguments:
   - None
 
-The driver can be used in test cases by calling the `set_links()` function with
+The driver can be used in test cases by calling its ``set_links()`` method with
 a list containing one or more of "dut-device", "host-dut" and "host-device".
 Not all combinations can be configured at the same time.
 
@@ -2749,8 +2756,8 @@ Implements:
 Arguments:
   - None
 
-The driver can be used in test cases by calling the `set_mode()` function with
-argument being `dut`, `host`, `off`, or `client`.
+The driver can be used in test cases by calling its ``set_mode()`` method with
+argument being "dut", "host", "off", or "client".
 
 USBVideoDriver
 ~~~~~~~~~~~~~~
@@ -2770,12 +2777,12 @@ Implements:
 Arguments:
   - None
 
-Although the driver can be used from Python code by calling the `stream()`
+Although the driver can be used from Python code by calling the ``stream()``
 method, it is currently mainly useful for the ``video`` subcommand of
 ``labgrid-client``.
 It supports the `Logitech HD Pro Webcam C920` with the USB ID 046d:082d and a
 few others.
-More cameras can be added to `get_qualities()` and `get_pipeline()` in
+More cameras can be added to ``get_qualities()`` and ``get_pipeline()`` in
 ``labgrid/driver/usbvideodriver.py``.
 Appropriate configuration parameters can be determined by using the GStreamer
 ``gst-device-monitor-1.0`` command line utility.
@@ -2804,8 +2811,8 @@ Arguments:
 
 USBTMCDriver
 ~~~~~~~~~~~~
-The :any:`USBTMCDriver` is used to control a oscilloscope via the USB TMC
-protocol.
+The :any:`USBTMCDriver` is used to control a oscilloscope via the *USB TMC
+protocol*.
 
 Binds to:
   tmc:
@@ -2822,7 +2829,7 @@ Currently, it can be used by the ``labgrid-client`` ``tmc`` subcommands to show
 (and save) a screenshot, to show per channel measurements and to execute raw
 TMC commands.
 It only supports the `Keysight DSO-X 2000` series (with the USB ID 0957:1798),
-but more devices can be added by extending `on_activate()` in
+but more devices can be added by extending ``on_activate()`` in
 ``labgrid/driver/usbtmcdriver.py`` and writing a corresponding backend in
 ``labgrid/driver/usbtmc/``.
 
@@ -2916,7 +2923,7 @@ Implements:
 Arguments:
   - None
 
-Although the driver can be used from Python code by calling the `stream()`
+Although the driver can be used from Python code by calling the ``stream()``
 method, it is currently mainly useful for the ``video`` subcommand of
 ``labgrid-client``.
 
@@ -2928,8 +2935,8 @@ Key        Description
 ========== =========================================================
 
 Properties of these keys can be selected using the Python format string syntax,
-e.g. ``{device.devnode}`` to select the device node path of
-:any:`USBFlashableDevice`
+e.g. ``{device.devnode}`` to select the device node path of a
+:any:`USBFlashableDevice`.
 
 DediprogFlashDriver
 ~~~~~~~~~~~~~~~~~~~
@@ -2955,8 +2962,9 @@ Arguments:
     of an image to flash onto the target
 
 The DediprogFlashDriver allows using DediprogFlasher dpcmd to flash or erase SPI
-devices. It is assumed that the device flashing is an exporter wired, via
-DediprogFlasher SF100 for instance, to the device being flashed.
+devices. It is assumed that the device flashing is an exporter wired, via a
+*Dediprog SF100 SPI NOR Flash Programmer* for instance, to the device being
+flashed.
 
 XenaDriver
 ~~~~~~~~~~
@@ -3071,7 +3079,7 @@ Currently basic wired and wireless configuration options have been tested.
 
 To use it, `PyGObject <https://pygobject.readthedocs.io/>`_ must be installed
 (on the same system as the network interface).
-For Debian, the necessary packages are `python3-gi` and `gir1.2-nm-1.0`.
+For Debian, the necessary packages are ``python3-gi`` and ``gir1.2-nm-1.0``.
 
 It supports:
 
@@ -3173,7 +3181,7 @@ Here is an example environment config:
          BareboxStrategy: {}
 
 In order to use the BareboxStrategy via labgrid as a library and transition to
-the ``shell`` state:
+the "shell" state:
 
 .. testsetup:: barebox-strategy
 
@@ -3220,7 +3228,7 @@ Here is an example environment config:
          ShellStrategy: {}
 
 In order to use the ShellStrategy via labgrid as a library and transition to
-the ``shell`` state:
+the "shell" state:
 
 .. testsetup:: shell-strategy
 
@@ -3268,7 +3276,7 @@ Here is an example environment config:
          UBootStrategy: {}
 
 In order to use the UBootStrategy via labgrid as a library and transition to
-the ``shell`` state:
+the "shell" state:
 
 .. testsetup:: uboot-strategy
 
@@ -3314,7 +3322,7 @@ Here is an example environment config:
          DockerStrategy: {}
 
 In order to use the DockerStrategy via labgrid as a library and transition to
-the ``accessible`` state:
+the "accessible" state:
 
 .. testsetup:: docker-strategy
 
@@ -3489,14 +3497,15 @@ To bind the correct driver to the correct resource, explicit ``name`` and
       bindings:
         port: 'bar'
 
-The property name for the binding (e.g. `port` in the example above) is
+The property name for the binding (e.g. ``port`` in the example above) is
 documented for each individual driver in this chapter.
 
 The YAML configuration file also supports templating for some substitutions,
 these are:
 
-- LG_* variables, are replaced with their respective LG_* environment variable
-- BASE is substituted with the base directory of the YAML file.
+- ``LG_*`` variables, are replaced with their respective ``LG_*`` environment
+  variable
+- ``BASE`` is substituted with the base directory of the YAML file.
 
 As an example:
 
@@ -3510,9 +3519,9 @@ As an example:
   tools:
     qemu_bin: !template '$BASE/bin/qemu-bin'
 
-would resolve the qemu_bin path relative to the BASE dir of the YAML file and
-try to use the `RemotePlace`_ with the name set in the LG_PLACE environment
-variable.
+would resolve the ``qemu_bin`` path relative to the ``BASE`` dir of the YAML
+file and try to use the `RemotePlace`_ with the name set in the ``LG_PLACE``
+environment variable.
 
 See the :ref:`labgrid-device-config` man page for documentation on the
 top-level ``options``, ``images``, ``tools``, and ``examples`` keys in the
@@ -3551,9 +3560,9 @@ By default, the class name is inferred from the resource name,
 and `<params>` will be passed to its constructor.
 For USB resources, you will most likely want to use :ref:`udev-matching` here.
 
-As a simple example, here is one group called *usb-hub-in-rack12* containing
+As a simple example, here is one group called ``usb-hub-in-rack12`` containing
 a single `USBSerialPort`_ resource (using udev matching), which will be
-exported as `exportername/usb-hub-in-rack12/NetworkSerialPort/USBSerialPort`:
+exported as ``exportername/usb-hub-in-rack12/NetworkSerialPort/USBSerialPort``:
 
 .. code-block:: yaml
 
@@ -3567,9 +3576,9 @@ you can choose a unique resource name, and then use the ``cls`` parameter to
 specify the class name instead (which will not be passed as a parameter to the
 class constructor).
 In this next example we will export one `USBSerialPort`_ as
-`exportername/usb-hub-in-rack12/NetworkSerialPort/console-main`,
+``exportername/usb-hub-in-rack12/NetworkSerialPort/console-main``,
 and another `USBSerialPort`_ as
-`exportername/usb-hub-in-rack12/NetworkSerialPort/console-secondary`:
+``exportername/usb-hub-in-rack12/NetworkSerialPort/console-secondary``:
 
 .. code-block:: yaml
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -29,7 +29,7 @@ enumeration order.
 .. code-block:: yaml
 
    RawSerialPort:
-     port: /dev/ttyUSB0
+     port: '/dev/ttyUSB0'
      speed: 115200
 
 The example would access the serial port /dev/ttyUSB0 on the local computer with
@@ -51,7 +51,7 @@ or raw tcp.
 .. code-block:: yaml
 
    NetworkSerialPort:
-     host: remote.example.computer
+     host: 'remote.example.computer'
      port: 53867
      speed: 115200
 
@@ -90,7 +90,7 @@ exporter.
 .. code-block:: yaml
 
     ModbusRTU:
-      port: "/dev/ttyUSB0"
+      port: '/dev/ttyUSB0'
       address: 16
       speed: 115200
       timeout: 0.25
@@ -114,7 +114,7 @@ This allows identification through hot-plugging or rebooting.
 
    USBSerialPort:
      match:
-       ID_SERIAL_SHORT: P-00-00682
+       ID_SERIAL_SHORT: 'P-00-00682'
      speed: 115200
 
 The example would search for a USB serial converter with the key
@@ -139,8 +139,8 @@ A :any:`NetworkPowerPort` describes a remotely switchable power port.
 .. code-block:: yaml
 
    NetworkPowerPort:
-     model: gude
-     host: powerswitch.example.computer
+     model: 'gude'
+     host: 'powerswitch.example.computer'
      index: 0
 
 The example describes port 0 on the remote power switch
@@ -250,8 +250,8 @@ PDUDaemon configuration file needs to be specified.
 .. code-block:: yaml
 
    PDUDaemonPort:
-     host: pduserver
-     pdu: apc-snmpv3-noauth
+     host: 'pduserver'
+     pdu: 'apc-snmpv3-noauth'
      index: 1
 
 The example describes port 1 on the PDU configured as `apc-snmpv3-noauth`, with
@@ -272,7 +272,7 @@ A :any:`YKUSHPowerPort` describes a YEPKIT YKUSH USB (HID) switchable USB hub.
 .. code-block:: yaml
 
    YKUSHPowerPort:
-     serial: YK12345
+     serial: 'YK12345'
      index: 1
 
 The example describes port 1 on the YKUSH USB hub with the
@@ -300,7 +300,7 @@ A :any:`USBPowerPort` describes a generic switchable USB hub as supported by
 
    USBPowerPort:
      match:
-       ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
+       ID_PATH: 'pci-0000:00:14.0-usb-0:2:1.0'
      index: 1
 
 The example describes port 1 on the hub with the ID_PATH
@@ -330,7 +330,7 @@ A :any:`SiSPMPowerPort` describes a GEMBIRD SiS-PM as supported by
 
    SiSPMPowerPort:
      match:
-       ID_PATH: platform-1c1a400.usb-usb-0:2
+       ID_PATH: 'platform-1c1a400.usb-usb-0:2'
      index: 1
 
 The example describes port 1 on the hub with the ID_PATH
@@ -351,10 +351,10 @@ A :any:`TasmotaPowerPort` resource describes a switchable `Tasmota
 .. code-block:: yaml
 
    TasmotaPowerPort:
-     host: this.is.an.example.host.com
-     status_topic: stat/tasmota_575A2B/POWER
-     power_topic: cmnd/tasmota_575A2B/POWER
-     avail_topic: tele/tasmota_575A2B/LWT
+     host: 'this.is.an.example.host.com'
+     status_topic: 'stat/tasmota_575A2B/POWER'
+     power_topic: 'cmnd/tasmota_575A2B/POWER'
+     avail_topic: 'tele/tasmota_575A2B/LWT'
 
 The example uses a mosquitto server at "this.is.an.example.host.com" and has the
 topics setup for a tasmota power port that has the ID 575A2B.
@@ -380,7 +380,7 @@ A :any:`ModbusTCPCoil` describes a coil accessible via ModbusTCP.
 .. code-block:: yaml
 
    ModbusTCPCoil:
-     host: "192.168.23.42"
+     host: '192.168.23.42'
      coil: 1
 
 The example describes the coil with the address 1 on the ModbusTCP device
@@ -407,7 +407,7 @@ A :any:`DeditecRelais8` describes a Deditec USB GPO module with 8 relays.
      index: 1
      invert: false
      match:
-       ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
+       ID_PATH: 'pci-0000:00:14.0-usb-0:2:1.0'
 
 Arguments:
   - index (int): number of the relay to use
@@ -425,8 +425,8 @@ A :any:`OneWirePIO` describes a onewire programmable I/O pin.
 .. code-block:: yaml
 
    OneWirePIO:
-     host: example.computer
-     path: /29.7D6913000000/PIO.0
+     host: 'example.computer'
+     path: '/29.7D6913000000/PIO.0'
      invert: false
 
 The example describes a `PIO.0` at device address `29.7D6913000000` via the onewire
@@ -448,10 +448,10 @@ An :any:`LXAIOBusPIO` resource describes a single PIO pin on an LXAIOBusNode.
 .. code-block:: yaml
 
    LXAIOBusPIO:
-     host: localhost:8080
-     node: IOMux-00000003
-     pin: OUT0
-     invert: False
+     host: 'localhost:8080'
+     node: 'IOMux-00000003'
+     pin: 'OUT0'
+     invert: false
 
 The example uses an lxa-iobus-server running on localhost:8080, with node
 IOMux-00000003 and pin OUT0.
@@ -479,9 +479,9 @@ It currently supports the widely used "dcttech USBRelay".
 
    HIDRelay:
      index: 2
-     invert: False
+     invert: false
      match:
-       ID_PATH: pci-0000:00:14.0-usb-0:2:1.0
+       ID_PATH: 'pci-0000:00:14.0-usb-0:2:1.0'
 
 Arguments:
   - index (int, default=1): number of the relay to use
@@ -499,9 +499,9 @@ controlled via HTTP.
 .. code-block:: yaml
 
    HttpDigitalOutput:
-     url: http://host.example/some/endpoint
-     body_asserted: "On"
-     body_deasserted: "Off"
+     url: 'http://host.example/some/endpoint'
+     body_asserted: 'On'
+     body_deasserted: 'Off'
 
 The example assumes a simple scenario where the same URL is used for PUT
 requests that set the output state and GET requests to get the current state.
@@ -535,8 +535,8 @@ A :any:`NetworkService` describes a remote SSH connection.
 .. code-block:: yaml
 
    NetworkService:
-     address: example.computer
-     username: root
+     address: 'example.computer'
+     username: 'root'
 
 The example describes a remote SSH connection to the computer `example.computer`
 with the username `root`.
@@ -568,7 +568,7 @@ device.
 
    USBMassStorage:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0-scsi-0:0:0:3
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0-scsi-0:0:0:3'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -592,8 +592,8 @@ device from all connected supported devices use the `SigrokUSBDevice`_.
 .. code-block:: yaml
 
    SigrokDevice:
-     driver: fx2lafw
-     channels: "D0=CLK,D1=DATA"
+     driver: 'fx2lafw'
+     channels: 'D0=CLK,D1=DATA'
 
 Arguments:
   - driver (str): name of the sigrok driver to use
@@ -611,7 +611,7 @@ An :any:`IMXUSBLoader` resource describes a USB device in the imx loader state.
 
    IMXUSBLoader:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -629,7 +629,7 @@ An :any:`MXSUSBLoader` resource describes a USB device in the mxs loader state.
 
    MXSUSBLoader:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -648,7 +648,7 @@ state.
 
    RKUSBLoader:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -682,7 +682,7 @@ supported for backwards compatibility.
 
    AndroidUSBFastboot:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - usb_vendor_id (str, default="1d6b"): USB vendor ID to be compared with the
@@ -702,7 +702,7 @@ state.
 .. code-block:: yaml
 
    AndroidNetFastboot:
-     address: "192.168.23.42"
+     address: '192.168.23.42'
 
 Arguments:
   - address (str): ip address of the fastboot device
@@ -723,7 +723,7 @@ Upgrade) mode.
 
    DFUDevice:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -739,7 +739,7 @@ Ethernet or WiFi)
 .. code-block:: yaml
 
    NetworkInterface:
-     ifname: eth0
+     ifname: 'eth0'
 
 Arguments:
   - ifname (str): name of the interface
@@ -757,7 +757,7 @@ Ethernet or WiFi)
 
    USBNetworkInterface:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -779,7 +779,7 @@ An :any:`AlteraUSBBlaster` resource describes an Altera USB blaster.
 
    AlteraUSBBlaster:
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -797,7 +797,7 @@ FTDI FT2232H).
 
    USBDebugger:
      match:
-       ID_PATH: pci-0000:00:10.0-usb-0:1.4
+       ID_PATH: 'pci-0000:00:10.0-usb-0:1.4'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -813,8 +813,8 @@ which is accessible via SNMP.
 .. code-block:: yaml
 
    SNMPEthernetPort:
-     switch: "switch-012"
-     interface: "17"
+     switch: 'switch-012'
+     interface: '17'
 
 Arguments:
   - switch (str): host name of the Ethernet switch
@@ -830,10 +830,10 @@ A :any:`SigrokUSBDevice` resource describes a sigrok USB device.
 .. code-block:: yaml
 
    SigrokUSBDevice:
-     driver: fx2lafw
-     channels: "D0=CLK,D1=DATA"
+     driver: 'fx2lafw'
+     channels: 'D0=CLK,D1=DATA'
      match:
-       ID_PATH: pci-0000:06:00.0-usb-0:1.3.2:1.0
+       ID_PATH: 'pci-0000:06:00.0-usb-0:1.3.2:1.0'
 
 Arguments:
   - driver (str): name of the sigrok driver to use
@@ -859,9 +859,9 @@ communicates over a USB serial port instead of being a USB device itself (see
 .. code-block:: yaml
 
    SigrokUSBSerialDevice:
-     driver: manson-hcs-3xxx
+     driver: 'manson-hcs-3xxx'
      match:
-       '@ID_SERIAL_SHORT': P-00-02389
+       '@ID_SERIAL_SHORT': 'P-00-02389'
 
 Arguments:
   - driver (str): name of the sigrok driver to use
@@ -883,7 +883,7 @@ device.
 
    USBSDMuxDevice:
      match:
-       '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -905,7 +905,7 @@ A :any:`LXAUSBMux` resource describes a Linux Automation GmbH USB-Mux device.
 
    LXAUSBMux:
      match:
-       '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -928,7 +928,7 @@ device.
 
    USBSDWireDevice:
      match:
-       '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -951,7 +951,7 @@ Video4Linux2 kernel driver.
 
    USBVideo:
      match:
-       '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -988,7 +988,7 @@ by an ALSA kernel driver.
 
    USBAudioInput:
      match:
-       ID_PATH: pci-0000:00:14.0-usb-0:3:1.0
+       ID_PATH: 'pci-0000:00:14.0-usb-0:3:1.0'
 
 Arguments:
   - index (int, default=0): ALSA PCM device number (as in
@@ -1014,7 +1014,7 @@ The low-level communication is handled by the ``usbtmc`` kernel driver.
 
    USBTMC:
      match:
-       '@ID_PATH': pci-0000:00:14.0-usb-0:1.2
+       '@ID_PATH': 'pci-0000:00:14.0-usb-0:1.2'
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
@@ -1081,7 +1081,7 @@ than running a flashing program with `FlashScriptDriver`_.
 
    USBFlashableDevice:
      match:
-       SUBSYSTEM: usb
+       SUBSYSTEM: 'usb'
        ID_SERIAL: '1234'
 
 Arguments:
@@ -1134,7 +1134,7 @@ instance the `XenaDriver`_ must connect to in order to configure a Xena chassis.
 .. code-block:: yaml
 
    XenaManager:
-     hostname: "example.computer"
+     hostname: 'example.computer'
 
 Arguments:
   - hostname (str): hostname or IP of the management address of the Xena tester
@@ -1151,8 +1151,8 @@ Such device could be a signal generator.
 .. code-block:: yaml
 
    PyVISADevice:
-     type: "TCPIP"
-     url: "192.168.110.11"
+     type: 'TCPIP'
+     url: '192.168.110.11'
 
 Arguments:
   - type (str): device resource type following the pyVISA resource syntax, e.g.
@@ -1170,7 +1170,7 @@ A :any:`HTTPVideoStream` resource describes a IP video stream over HTTP or HTTPS
 .. code-block:: yaml
 
    HTTPVideoStream:
-     url: http://192.168.110.11/0.ts
+     url: 'http://192.168.110.11/0.ts'
 
 Arguments:
   - url (str): URI of the IP video stream
@@ -1208,12 +1208,12 @@ A :any:`HTTPProvider` resource describes an HTTP server.
 .. code-block:: yaml
 
    TFTPProvider:
-     internal: "/srv/tftp/board-23/"
-     external: "board-23/"
+     internal: '/srv/tftp/board-23/'
+     external: 'board-23/'
 
    HTTPProvider:
-     internal: "/srv/www/board-23/"
-     external: "http://192.168.1.1/board-23/"
+     internal: '/srv/www/board-23/'
+     external: 'http://192.168.1.1/board-23/'
 
 Arguments:
   - internal (str): path prefix to the local directory accessible by the target
@@ -1250,14 +1250,14 @@ a remote computer.
 .. code-block:: yaml
 
    RemoteTFTPProvider
-     host: "tftphost"
-     internal: "/srv/tftp/board-23/"
-     external: "board-23/"
+     host: 'tftphost'
+     internal: '/srv/tftp/board-23/'
+     external: 'board-23/'
 
    RemoteHTTPProvider:
-     host: "httphost"
-     internal: "/srv/www/board-23/"
-     external: "http://192.168.1.1/board-23/"
+     host: 'httphost'
+     internal: '/srv/www/board-23/'
+     external: 'http://192.168.1.1/board-23/'
 
 Arguments:
   - host (str): hostname of the remote host
@@ -1276,7 +1276,7 @@ remote computer.
 .. code-block:: yaml
 
    RemoteNFSProvider:
-     host: "nfshost"
+     host: 'nfshost'
 
 Arguments:
   - host (str): hostname of the remote host
@@ -1292,7 +1292,7 @@ place.
 .. code-block:: yaml
 
    RemotePlace:
-     name: example-place
+     name: 'example-place'
 
 The example describes the remote place `example-place`. It will connect to the
 labgrid remote coordinator, wait until the resources become available and expose
@@ -1313,7 +1313,7 @@ created through interaction with that daemon.
 .. code-block:: yaml
 
    DockerDaemon:
-     docker_daemon_url: unix://var/run/docker.sock
+     docker_daemon_url: 'unix://var/run/docker.sock'
 
 The example describes a docker daemon accessible via the
 ``/var/run/docker.sock`` unix socket. When used by a `DockerDriver`_, the
@@ -1404,7 +1404,7 @@ with ``udevadm info /dev/ttyUSB0``.
 
   USBSerialPort:
     match:
-      '@ID_PATH': pci-0000:05:00.0-usb-0:1.2.5.5
+      '@ID_PATH': 'pci-0000:05:00.0-usb-0:1.2.5.5'
 
 Note the ``@`` in the ``@ID_PATH`` match, which applies this match to the
 device's parents instead of directly to itself.
@@ -1470,7 +1470,7 @@ We use the ``ID_USB_INTERFACE_NUM`` to distinguish between the two ports:
 
   USBSerialPort:
     match:
-      '@ID_PATH': pci-0000:05:00.0-usb-2:10.2.2.2'
+      '@ID_PATH': 'pci-0000:05:00.0-usb-2:10.2.2.2'
       ID_USB_INTERFACE_NUM: '01'
 
 Matching a USB UART by Serial Number
@@ -1484,7 +1484,7 @@ changes or a board has been moved between host systems.
 
   USBSerialPort:
     match:
-      ID_SERIAL_SHORT: P-00-03564
+      ID_SERIAL_SHORT: 'P-00-03564'
 
 To check if your device has a serial number, you can use ``udevadm info``:
 
@@ -1583,7 +1583,7 @@ Implements:
    ShellDriver:
      prompt: 'root@\w+:[^ ]+ '
      login_prompt: ' login: '
-     username: root
+     username: 'root'
 
 Arguments:
   - prompt (regex): shell prompt to match after logging in
@@ -1638,7 +1638,7 @@ Implements:
 .. code-block:: yaml
 
    SSHDriver:
-     keyfile: example.key
+     keyfile: 'example.key'
 
 Arguments:
   - keyfile (str): optional, filename of private key to login into the remote system
@@ -1672,8 +1672,8 @@ Implements:
    UBootDriver:
      prompt: 'Uboot> '
      boot_commands:
-       net: run netboot
-       spi: run spiboot
+       net: 'run netboot'
+       spi: 'run spiboot'
 
 Arguments:
   - prompt (regex, default=""): U-Boot prompt to match
@@ -1733,7 +1733,7 @@ Implements:
    SmallUBootDriver:
      prompt: 'ap143-2\.0> '
      boot_expression: 'Autobooting in 1 seconds'
-     boot_secret: "tpl"
+     boot_secret: 'tpl'
 
 Arguments:
   - boot_expression (str, default="U-Boot 20\\d+"): regex to match the U-Boot start string
@@ -1808,8 +1808,8 @@ Implements:
 .. code-block:: yaml
 
    AndroidFastbootDriver:
-     boot_image: mylocal.image
-     sparse_size: 100M
+     boot_image: 'mylocal.image'
+     sparse_size: '100M'
 
 Arguments:
   - boot_image (str): optional, image key referring to the image to boot
@@ -1866,14 +1866,14 @@ Implements:
 .. code-block:: yaml
 
    OpenOCDDriver:
-     config: local-settings.cfg
-     image: bitstream
-     interface_config: ftdi/lambdaconcept_ecpix-5.cfg
-     board_config: lambdaconcept_ecpix-5.cfg
+     config: 'local-settings.cfg'
+     image: 'bitstream'
+     interface_config: 'ftdi/lambdaconcept_ecpix-5.cfg'
+     board_config: 'lambdaconcept_ecpix-5.cfg'
      load_commands:
-     - "init"
-     - "svf -quiet {filename}"
-     - "exit"
+     - 'init'
+     - 'svf -quiet {filename}'
+     - 'exit'
 
 Arguments:
   - config (str/list): optional, OpenOCD configuration file(s)
@@ -1941,9 +1941,9 @@ Implements:
 .. code-block:: yaml
 
    ExternalPowerDriver:
-     cmd_on: example_command on
-     cmd_off: example_command off
-     cmd_cycle: example_command cycle
+     cmd_on: 'example_command on'
+     cmd_off: 'example_command off'
+     cmd_cycle: 'example_command cycle'
 
 Arguments:
   - cmd_on (str): command to turn power to the board on
@@ -2147,8 +2147,9 @@ Implements:
 .. code-block:: yaml
 
    SerialPortDigitalOutputDriver:
-     signal: "dtr"
-     bindings: { serial : "nameOfSerial" }
+     signal: 'dtr'
+     bindings:
+       serial: 'nameOfSerial'
 
 Arguments:
   - signal (str): control signal to use: "dtr" or "rts"
@@ -2180,7 +2181,7 @@ Implements:
 .. code-block:: yaml
 
    FileDigitalOutputDriver:
-     filepath: "/sys/class/leds/myled/brightness"
+     filepath: '/sys/class/leds/myled/brightness'
 
 Arguments:
   - filepath (str): file that is used for reads and writes.
@@ -2306,10 +2307,10 @@ Implements:
      main:
        drivers:
          MXSUSBDriver:
-           image: mybootloaderkey
+           image: 'mybootloaderkey'
 
    images:
-     mybootloaderkey: path/to/mybootloader.img
+     mybootloaderkey: 'path/to/mybootloader.img'
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
@@ -2338,10 +2339,10 @@ Implements:
      main:
        drivers:
          IMXUSBDriver:
-           image: mybootloaderkey
+           image: 'mybootloaderkey'
 
    images:
-     mybootloaderkey: path/to/mybootloader.img
+     mybootloaderkey: 'path/to/mybootloader.img'
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
@@ -2394,12 +2395,12 @@ Implements:
      main:
        drivers:
          RKUSBDriver:
-           image: mybootloaderkey
-           usb_loader: myloaderkey
+           image: 'mybootloaderkey'
+           usb_loader: 'myloaderkey'
 
    images:
-     mybootloaderkey: path/to/mybootloader.img
-     myloaderkey: path/to/myloader.bin
+     mybootloaderkey: 'path/to/mybootloader.img'
+     myloaderkey: 'path/to/myloader.bin'
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
@@ -2429,11 +2430,11 @@ Implements:
      main:
        drivers:
          UUUDriver:
-           image: mybootloaderkey
-           cmd: spl
+           image: 'mybootloaderkey'
+           cmd: 'spl'
 
    images:
-     mybootloaderkey: path/to/mybootloader.img
+     mybootloaderkey: 'path/to/mybootloader.img'
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
@@ -2454,19 +2455,18 @@ Binds to:
     - `USBSDWireDevice`_
     - `NetworkUSBSDWireDevice`_
 
-
 Implements:
   - None (yet)
 
 .. code-block:: yaml
 
    USBStorageDriver:
-     image: flashimage
+     image: 'flashimage'
 
 .. code-block:: yaml
 
    images:
-     flashimage: ../images/myusb.image
+     flashimage: '../images/myusb.image'
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
@@ -2557,26 +2557,26 @@ Binds to:
 .. code-block:: yaml
 
    QEMUDriver:
-     qemu_bin: qemu_arm
-     machine: vexpress-a9
-     cpu: cortex-a9
-     memory: 512M
-     boot_args: "root=/dev/root console=ttyAMA0,115200"
-     extra_args: ""
-     kernel: kernel
-     rootfs: rootfs
-     dtb: dtb
-     nic: user
+     qemu_bin: 'qemu_arm'
+     machine: 'vexpress-a9'
+     cpu: 'cortex-a9'
+     memory: '512M'
+     boot_args: 'root=/dev/root console=ttyAMA0,115200'
+     extra_args: ''
+     kernel: 'kernel'
+     rootfs: 'rootfs'
+     dtb: 'dtb'
+     nic: 'user'
 
 .. code-block:: yaml
 
    tools:
-     qemu_arm: /bin/qemu-system-arm
+     qemu_arm: '/bin/qemu-system-arm'
    paths:
-     rootfs: ../images/root
+     rootfs: '../images/root'
    images:
-     dtb: ../images/mydtb.dtb
-     kernel: ../images/vmlinuz
+     dtb: '../images/mydtb.dtb'
+     kernel: '../images/vmlinuz'
 
 
 Implements:
@@ -2835,7 +2835,7 @@ The :any:`FlashromDriver` is used to flash a rom, using the flashrom utility.
    FlashromDriver:
      image: 'foo'
    images:
-     foo: ../images/image_to_load.raw
+     foo: '../images/image_to_load.raw'
 
 Binds to:
   flashrom_resource:
@@ -2874,7 +2874,7 @@ a device.
 .. code-block:: yaml
 
    images:
-     foo: ../images/flash_device.sh
+     foo: '../images/flash_device.sh'
 
 Binds to:
   device:
@@ -2940,7 +2940,7 @@ The :any:`DediprogFlashDriver` is used to flash an SPI device using DediprogFlas
    DediprogFlashDriver:
      image: 'foo'
    images:
-     foo: ../images/image_to_load.raw
+     foo: '../images/image_to_load.raw'
 
 Binds to:
   flasher:
@@ -2989,10 +2989,10 @@ Implements:
 .. code-block:: yaml
 
    DockerDriver:
-     image_uri: "rastasheep/ubuntu-sshd:16.04"
-     container_name: "ubuntu-lg-example"
-     host_config: {"network_mode":"bridge"}
-     network_services: [{"port":22,"username":"root","password":"root"}]
+     image_uri: 'rastasheep/ubuntu-sshd:16.04'
+     container_name: 'ubuntu-lg-example'
+     host_config: {'network_mode': 'bridge'}
+     network_services: [{'port': 22, 'username': 'root', 'password': 'root'}]
 
 Arguments:
   - image_uri (str): identifier of the docker image to use (may have a tag suffix)
@@ -3106,7 +3106,7 @@ exporting network interfaces for the RawNetworkInterfaceDriver, e.g.:
 
    raw-interface:
      denied-interfaces:
-       - eth1
+       - 'eth1'
 
 It supports:
 
@@ -3169,7 +3169,7 @@ Here is an example environment config:
          ShellDriver:
            prompt: 'root@\w+:[^ ]+ '
            login_prompt: ' login: '
-           username: root
+           username: 'root'
          BareboxStrategy: {}
 
 In order to use the BareboxStrategy via labgrid as a library and transition to
@@ -3216,7 +3216,7 @@ Here is an example environment config:
          ShellDriver:
            prompt: 'root@\w+:[^ ]+ '
            login_prompt: ' login: '
-           username: root
+           username: 'root'
          ShellStrategy: {}
 
 In order to use the ShellStrategy via labgrid as a library and transition to
@@ -3264,7 +3264,7 @@ Here is an example environment config:
          ShellDriver:
            prompt: 'root@\w+:[^ ]+ '
            login_prompt: ' login: '
-           username: root
+           username: 'root'
          UBootStrategy: {}
 
 In order to use the UBootStrategy via labgrid as a library and transition to
@@ -3304,13 +3304,13 @@ Here is an example environment config:
      main:
        resources:
          DockerDaemon:
-           docker_daemon_url: unix://var/run/docker.sock
+           docker_daemon_url: 'unix://var/run/docker.sock'
        drivers:
          DockerDriver:
-           image_uri: "rastasheep/ubuntu-sshd:16.04"
-           container_name: "ubuntu-lg-example"
-           host_config: {"network_mode":"bridge"}
-           network_services: [{"port":22,"username":"root","password":"root"}]
+           image_uri: 'rastasheep/ubuntu-sshd:16.04'
+           container_name: 'ubuntu-lg-example'
+           host_config: {'network_mode': 'bridge'}
+           network_services: [{'port': 22, 'username': 'root', 'password': 'root'}]
          DockerStrategy: {}
 
 In order to use the DockerStrategy via labgrid as a library and transition to
@@ -3506,9 +3506,9 @@ As an example:
     main:
       resources:
         RemotePlace:
-          name: !template $LG_PLACE
+          name: !template '$LG_PLACE'
   tools:
-    qemu_bin: !template "$BASE/bin/qemu-bin"
+    qemu_bin: !template '$BASE/bin/qemu-bin'
 
 would resolve the qemu_bin path relative to the BASE dir of the YAML file and
 try to use the `RemotePlace`_ with the name set in the LG_PLACE environment
@@ -3560,7 +3560,7 @@ exported as `exportername/usb-hub-in-rack12/NetworkSerialPort/USBSerialPort`:
    usb-hub-in-rack12:
      USBSerialPort:
        match:
-         '@ID_PATH': pci-0000:05:00.0-usb-3-1.3
+         '@ID_PATH': 'pci-0000:05:00.0-usb-3-1.3'
 
 To export multiple resources of the same class in the same group,
 you can choose a unique resource name, and then use the ``cls`` parameter to
@@ -3575,13 +3575,13 @@ and another `USBSerialPort`_ as
 
    usb-hub-in-rack12:
      console-main:
-       cls: USBSerialPort
+       cls: 'USBSerialPort'
        match:
-         '@ID_PATH': pci-0000:05:00.0-usb-3-1.3
+         '@ID_PATH': 'pci-0000:05:00.0-usb-3-1.3'
      console-secondary:
-       cls: USBSerialPort
+       cls: 'USBSerialPort'
        match:
-         '@ID_PATH': pci-0000:05:00.0-usb-3-1.4
+         '@ID_PATH': 'pci-0000:05:00.0-usb-3-1.4'
 
 Note that you could also split the resources up into distinct groups instead
 to achieve the same effect:
@@ -3591,11 +3591,11 @@ to achieve the same effect:
    usb-hub-in-rack12-port3:
      USBSerialPort:
        match:
-         '@ID_PATH': pci-0000:05:00.0-usb-3-1.3
+         '@ID_PATH': 'pci-0000:05:00.0-usb-3-1.3'
    usb-hub-in-rack12-port4:
      USBSerialPort:
        match:
-         '@ID_PATH': pci-0000:05:00.0-usb-3-1.4
+         '@ID_PATH': 'pci-0000:05:00.0-usb-3-1.4'
 
 Templating
 ~~~~~~~~~~
@@ -3609,14 +3609,21 @@ is used as a preprocessor for the configuration file:
    # for idx in range(1, 17)
    {{ 1000 + idx }}:
      NetworkSerialPort:
-       {host: rl1, port: {{ 4000 + idx }}}
+       host: 'rl1'
+       port: {{ 4000 + idx }}
      NetworkPowerPort:
        # if 1 <= idx <= 8
-       {model: apc, host: apc1, index: {{ idx }}}
+       model: 'apc'
+       host: 'apc1'
+       index: {{ idx }}
        # elif 9 <= idx <= 12
-       {model: netio, host: netio4, index: {{ idx - 8 }}}
+       model: 'netio'
+       host: 'netio4'
+       index: {{ idx - 8 }}
        # elif 13 <= idx <= 16
-       {model: netio, host: netio5, index: {{ idx - 12 }}}
+       model: 'netio'
+       host: 'netio5'
+       index: {{ idx - 12 }}
        # endif
    # endfor
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -619,6 +619,7 @@ Arguments:
 Used by:
   - `IMXUSBDriver`_
   - `UUUDriver`_
+  - `BDIMXUSBDriver`_
 
 MXSUSBLoader
 ~~~~~~~~~~~~
@@ -635,6 +636,7 @@ Arguments:
 
 Used by:
   - `MXSUSBDriver`_
+  - `IMXUSBDriver`_
   - `UUUDriver`_
 
 RKUSBLoader
@@ -736,6 +738,10 @@ WiFi)
 Arguments:
   - ifname (str): name of the interface
 
+Used by:
+  - `NetworkInterfaceDriver`_
+  - `RawNetworkInterfaceDriver`_
+
 USBNetworkInterface
 ~~~~~~~~~~~~~~~~~~~
 A USBNetworkInterface resource describes a USB network adapter (such as
@@ -749,6 +755,10 @@ Ethernet or WiFi)
 
 Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - `NetworkInterfaceDriver`_
+  - `RawNetworkInterfaceDriver`_
 
 RemoteNetworkInterface
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -804,6 +814,9 @@ Arguments:
   - switch (str): host name of the Ethernet switch
   - interface (str): interface name
 
+Used by:
+  - None
+
 SigrokUSBDevice
 ~~~~~~~~~~~~~~~
 A SigrokUSBDevice resource describes a sigrok USB device.
@@ -851,6 +864,7 @@ Arguments:
 
 Used by:
   - `SigrokPowerDriver`_
+  - `SigrokDmmDriver`_
 
 USBSDMuxDevice
 ~~~~~~~~~~~~~~
@@ -868,7 +882,8 @@ Arguments:
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 
 Used by:
-  - `USBSDMUXDriver`_
+  - `USBSDMuxDriver`_
+  - `USBStorageDriver`_
 
 NetworkUSBSDMuxDevice
 ~~~~~~~~~~~~~~~~~~~~~
@@ -913,6 +928,7 @@ Arguments:
 
 Used by:
   - `USBSDWireDriver`_
+  - `USBStorageDriver`_
 
 NetworkUSBSDWireDevice
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
**Description**
Initially, all driver bindings were documented with their respective binding key. This wasn't documented consistently since then.

Especially when using multiple instances of a single driver class, the bindings are needed to specify on which resource or other driver a driver should bind on. Until now, most binding keys had to be looked up in the source code. So improve this situation by fixing and adding binding keys as well as also adding all Remote/Network resource variants a driver is able to bind to.

Also update protocol implementations and resource usage. While at it, document drivers not expecting arguments, drop driver usage from network resouces, fix header underlines and remove unnecessary new lines.

**Checklist**
- [x] PR has been tested