### PR TITLE
remote/exporter: hostname option is ignored

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -949,7 +949,7 @@ def main():
 
     extra = {
         'name': args.name or gethostname(),
-        'hostname': args.hostname or getfqdn() if args.fqdn else gethostname(),
+        'hostname': args.hostname or (getfqdn() if args.fqdn else gethostname()),
         'resources': args.resources,
         'isolated': args.isolated
     }


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->

Following the addition of the fqdn option, the hostname is ignored. Hostname is set with gethostname() regardless of args.hostname value because the condition is incorrect.

Fix this and get the hostname option working again.

Fixes #1290 

