### PR TITLE
driver/pe6216: add support for Aten PE6216 PDU

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -198,6 +198,9 @@ Currently available are:
 ``netio_kshell``
   Controls a NETIO 4C PDU via a Telnet interface.
 
+``pe6216``
+  Controls an Aten PE6216 PDU via a simple HTTP API.
+
 ``raritan``
   Controls Raritan PDUs via SNMP.
 

--- a/labgrid/driver/power/pe6216.py
+++ b/labgrid/driver/power/pe6216.py
@@ -1,0 +1,49 @@
+"""Tested with Aten PE6216.
+
+HTTP API is defined by in the aten PDU PE6216 specification:
+https://assets.aten.com/product/manual/Restful-API-Guide-for-PDU_2022-11-18.pdf
+"""
+import re
+import requests
+
+PORT = 80
+
+MIN_OUTLET_INDEX = 1
+MAX_OUTLET_INDEX = 16
+headers = {'Content-Type': 'application/x-www-form-urlencoded'}
+
+def power_set(host, port, index, value):
+    index = int(index)
+    assert MIN_OUTLET_INDEX <= index <= MAX_OUTLET_INDEX
+    value = 'on' if value else 'off'
+
+    requests.post(
+        f'http://{host}:{port}/api/outlet/relay',
+        headers=headers,
+        data={
+            'usr': 'administrator',
+            'pwd': 'password',
+            'index': index,
+            'method': value,
+        }
+    )
+
+
+def power_get(host, port, index):
+    index = int(index)
+    assert MIN_OUTLET_INDEX <= index <= MAX_OUTLET_INDEX
+
+    response = requests.get(
+        f'http://{host}:{port}/api/outlet/relay',
+        headers=headers,
+        params={
+            'usr': 'administrator',
+            'pwd': 'password',
+            'index': index,
+        }
+    )
+
+    m = re.search( r'<\d+>(?P<state>(ON|OFF|PENDING))<.*', response.text)
+    if m is None:
+        raise RuntimeError('PE6216: could not match reponse')
+    return m.group('state') == 'ON'


### PR DESCRIPTION
**Description**
We are using the [Aten PE6216 PDU](https://www.aten.com/global/en/products/power-distribution-&-racks/rack-pdu/pe6216/) on our testfleet and we want to use labgrid for test management. This PDU is not present in labgrid power drivers or in the `pdudaemon` project, hence we have to add it.

I did test it on our test fleet with few very simple tests:
```python
import time

def test_power_on(target):
    pwd = target.get_driver('NetworkPowerDriver')
    pwd.on()
    time.sleep(10.0)
    assert pwd.get() == True

def test_power_cycle(target):
    pwd = target.get_driver('NetworkPowerDriver')
    pwd.cycle()
    time.sleep(10.0)
    assert pwd.get() == True

def test_power_off(target):
    pwd = target.get_driver('NetworkPowerDriver')
    pwd.off()
    time.sleep(10.0)
    assert pwd.get() == False
```
(PDU takes some time to change states as it has built-in delay between changes (althrough they can be turned of with 'no-wait' option in the [HTTP request](https://assets.aten.com/product/manual/Restful-API-Guide-for-PDU_2022-11-18.pdf)))

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested