### PR TITLE
labgrid-client.rst: replace 'status' with 'cycle'

### DIFF
--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -183,7 +183,7 @@ not at all.
 .sp
 \fBenv\fP                         Generate a labgrid environment file for a place
 .sp
-\fBpower (pw)\fP action           Change (or get) a place\(aqs power status, where action is one of get, on, off, status
+\fBpower (pw)\fP action           Change (or get) a place\(aqs power status, where action is one of get, on, off, cycle
 .sp
 \fBio\fP action                   Interact with GPIO (OneWire, relays, ...) devices, where action is one of high, low, get
 .sp

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -175,7 +175,7 @@ LABGRID-CLIENT COMMANDS
 
 ``env``                         Generate a labgrid environment file for a place
 
-``power (pw)`` action           Change (or get) a place's power status, where action is one of get, on, off, status
+``power (pw)`` action           Change (or get) a place's power status, where action is one of get, on, off, cycle
 
 ``io`` action                   Interact with GPIO (OneWire, relays, ...) devices, where action is one of high, low, get
 


### PR DESCRIPTION
**Description**

In the labgrid-client doc page, where the power option is detailed:

'get' seems to serve the same purpose as 'status', which isn't a valid option, and 'cycle' is not shown in the doc despite being in the CLI help output. This is a quick fix to address that.

**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature - tested the actual power options with a local install from master branch
- [X] Man pages have been regenerated