### PR TITLE
driver/resource: mqtt: use callback API v2, bump paho-mqtt>=2.0.0

### DIFF
--- a/labgrid/driver/mqtt.py
+++ b/labgrid/driver/mqtt.py
@@ -27,7 +27,7 @@ class TasmotaPowerDriver(Driver, PowerProtocol):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
         import paho.mqtt.client as mqtt
-        self._client = mqtt.Client()
+        self._client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
 
     def on_activate(self):
         self._client.on_message = self._on_message
@@ -45,7 +45,7 @@ class TasmotaPowerDriver(Driver, PowerProtocol):
             status = False
         self._status = status
 
-    def _on_connect(self, client, userdata, flags, rc):
+    def _on_connect(self, client, userdata, flags, reason_code, properties):
         client.subscribe(self.power.status_topic)
 
     def _publish(self, topic, payload):

--- a/labgrid/resource/mqtt.py
+++ b/labgrid/resource/mqtt.py
@@ -17,7 +17,7 @@ class MQTTManager(ResourceManager):
 
     def _create_mqtt_connection(self, host):
         import paho.mqtt.client as mqtt
-        client = mqtt.Client()
+        client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2)
         client.connect(host)
         client.on_message = self._on_message
         client.loop_start()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ graph = ["graphviz>=0.17.0"]
 kasa = ["python-kasa>=0.4.0"]
 modbus = ["pyModbusTCP>=0.2.0"]
 modbusrtu = ["minimalmodbus>=1.0.2"]
-mqtt = ["paho-mqtt>=1.5.1"]
+mqtt = ["paho-mqtt>=2.0.0"]
 onewire = ["onewire>=0.2"]
 pyvisa = [
     "pyvisa>=1.11.3",
@@ -101,7 +101,7 @@ dev = [
     "minimalmodbus>=1.0.2",
 
     # labgrid[mqtt]
-    "paho-mqtt>=1.5.1",
+    "paho-mqtt>=2.0.0",
 
     # labgrid[onewire]
     "onewire>=0.2",


### PR DESCRIPTION
**Description**
labgrid's "mqtt" and "dev" extras require `paho-mqtt>=1.5.1`. With [paho-mqtt 2.0.0](https://github.com/eclipse/paho.mqtt.python/releases/tag/v2.0.0) released on 2024-02-10, [breaking changes](https://github.com/eclipse/paho.mqtt.python/blob/master/docs/migrations.rst#change-between-version-1x-and-20) were introduced. This was first detected by the scheduled CI jobs via pylint:
```
************* Module labgrid.resource.mqtt
labgrid/resource/mqtt.py:20:17: E1120: No value for argument 'callback_api_version' in constructor call (no-value-for-parameter)
************* Module labgrid.driver.mqtt
labgrid/driver/mqtt.py:30:23: E1120: No value for argument 'callback_api_version' in constructor call (no-value-for-parameter)
```

When using 'labgrid-client pw get' with a TasmotaPowerPort resource, the errors looks like this:
```python
Exception ignored in: <function Client.__del__ at 0x7fd594564a40>
Traceback (most recent call last):
  File "/path/to/venv/lib/python3.11/site-packages/paho/mqtt/client.py", line 874, in __del__
    self._reset_sockets()
  File "/path/to/venv/lib/python3.11/site-packages/paho/mqtt/client.py", line 1133, in _reset_sockets
    self._sock_close()
  File "/path/to/venv/lib/python3.11/site-packages/paho/mqtt/client.py", line 1119, in _sock_close
    if not self._sock:
           ^^^^^^^^^^
AttributeError: 'Client' object has no attribute '_sock'
Traceback (most recent call last):
  File "/path/to/labgrid/labgrid/factory.py", line 124, in make_resource
    r = cls(target, name, **args)
        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<attrs generated init labgrid.resource.mqtt.TasmotaPowerPort>", line 19, in __init__
    self.__attrs_post_init__()
  File "/path/to/labgrid/labgrid/resource/mqtt.py", line 61, in __attrs_post_init__
    super().__attrs_post_init__()
  File "/path/to/labgrid/labgrid/resource/common.py", line 157, in __attrs_post_init__
    self.manager._add_resource(self)
  File "/path/to/labgrid/labgrid/resource/common.py", line 133, in _add_resource
    self.on_resource_added(resource)
  File "/path/to/labgrid/labgrid/resource/mqtt.py", line 29, in on_resource_added
    self._clients[host] = self._create_mqtt_connection(host)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/resource/mqtt.py", line 20, in _create_mqtt_connection
    client = mqtt.Client()
             ^^^^^^^^^^^^^
TypeError: Client.__init__() missing 1 required positional argument: 'callback_api_version'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/path/to/labgrid/labgrid/remote/client.py", line 1892, in main
    args.func(session)
  File "/path/to/labgrid/labgrid/remote/client.py", line 726, in power
    target = self._get_target(place)
             ^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/remote/client.py", line 687, in _get_target
    RemotePlace(target, name=place.name)
  File "<attrs generated init labgrid.resource.remote.RemotePlace>", line 11, in __init__
    self.__attrs_post_init__()
  File "/path/to/labgrid/labgrid/resource/remote.py", line 101, in __attrs_post_init__
    super().__attrs_post_init__()
  File "/path/to/labgrid/labgrid/resource/common.py", line 157, in __attrs_post_init__
    self.manager._add_resource(self)
  File "/path/to/labgrid/labgrid/resource/common.py", line 133, in _add_resource
    self.on_resource_added(resource)
  File "/path/to/labgrid/labgrid/resource/remote.py", line 53, in on_resource_added
    new = target_factory.make_resource(
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/factory.py", line 126, in make_resource
    raise InvalidConfigError(
labgrid.exceptions.InvalidConfigError: failed to create TasmotaPowerPort for target 'Target(name='test', env=None)' using {'host': 'mqtt', 'status_topic': 'stat/03374/POWER', 'power_topic': 'cmnd/03374/POWER', 'avail_topic': 'tele/03374/LWT'}
```

To fix this, use paho-mqtt's callback API v2 and migrate the `on_connect()` callback. Require paho-mqtt>=2.0.0 from now on.

**Checklist**
- [x] PR has been tested (`labgrid-client pw get/on/off` on a TasmotaPowerPort)

Fixes #1327