### PR TITLE
coordinator: Initialize txaio with asyncio to fix runtime error

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -10,6 +10,8 @@ from enum import Enum
 from functools import wraps
 
 import attr
+import txaio
+txaio.use_asyncio()
 from autobahn import wamp
 from autobahn.asyncio.wamp import ApplicationRunner, ApplicationSession
 from autobahn.wamp.types import RegisterOptions


### PR DESCRIPTION
This commit fixes a RuntimeError by explicitly initializing txaio to use asyncio before its usage in the coordinator module. This ensures compatibility with the asyncio framework, addressing the issue where txaio required an explicit framework selection.