### PR TITLE
pyproject.yaml: limit pysnmp to versions < 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pyvisa = [
     "pyvisa>=1.11.3",
     "PyVISA-py>=0.5.2",
 ]
-snmp = ["pysnmp-lextudio>=4.4.12"]
+snmp = ["pysnmp-lextudio>=4.4.12, <6"]
 vxi11 = ["python-vxi11>=0.9"]
 xena = ["xenavalkyrie>=3.0.1"]
 deb = [
@@ -77,7 +77,7 @@ deb = [
     "onewire>=0.2",
 
     # labgrid[snmp]
-    "pysnmp-lextudio>=4.4.12",
+    "pysnmp-lextudio>=4.4.12, <6",
 ]
 dev = [
     # references to other optional dependency groups
@@ -111,7 +111,7 @@ dev = [
     "PyVISA-py>=0.5.2",
 
     # labgrid[snmp]
-    "pysnmp-lextudio>=4.4.12",
+    "pysnmp-lextudio>=4.4.12, <6",
 
     # labgrid[vxi11]
     "python-vxi11>=0.9",


### PR DESCRIPTION
**Description**
The new major release 6.0 introduces breaking changes (functions are now async), limit the dependency until we fix this properly.

**Checklist**
- [x] PR has been tested

