### PR TITLE
driver/usbvideodriver: use playbin3 element

### DIFF
--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -131,7 +131,7 @@ class USBVideoDriver(Driver, VideoProtocol):
         tx_cmd = self.video.command_prefix + ["gst-launch-1.0", "-q"]
         tx_cmd += pipeline.split()
         rx_cmd = ["gst-launch-1.0"]
-        rx_cmd += "playbin uri=fd://0".split()
+        rx_cmd += "playbin3 uri=fd://0".split()
 
         tx = subprocess.Popen(
             tx_cmd,


### PR DESCRIPTION
**Description**

Decoding via VA-API fails for the C920 model and the playbin element on AMD graphic cards, playbin3 has no problems though - so lets switch to that.

Tested on Fedora 39 running GStreamer 1.22.9. 

Current Debian stable ships with [GStreamer 1.22.0](https://packages.debian.org/bookworm/libgstreamer1.0-0) which supports playbin3.


**Error log**

The error output with a failed VA-API pipeline:

<details>
  <summary>labgrid-client video</summary>

```
> labgrid-client video
(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.192: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink

(gst-launch-1.0:17414): GStreamer-Base-CRITICAL **: 16:15:20.193: basetransform: second attempt to fixate caps returned invalid (NULL) caps on pad vaapipostproc0:sink
ERROR: from element /GstPlayBin:playbin0/GstURIDecodeBin:uridecodebin0/GstFdSrc:source: Internal data stream error.
Additional debug info:
../libs/gst/base/gstbasesrc.c(3132): gst_base_src_loop (): /GstPlayBin:playbin0/GstURIDecodeBin:uridecodebin0/GstFdSrc:source:
streaming stopped, reason not-negotiated (-4)
ERROR: pipeline doesn't want to preroll.
```

</details>

This is the output of vainfo:

<details>
  <summary>vainfo -a</summary>

```
❯ vainfo -a
Trying display: wayland
Trying display: x11
libva info: VA-API version 1.20.0
libva info: Trying to open /usr/lib64/dri/radeonsi_drv_video.so
libva info: Found init function __vaDriverInit_1_20
libva info: va_openDriver() returns 0
vainfo: VA-API version: 1.20 (libva 2.20.1)
vainfo: Driver version: Mesa Gallium driver 23.3.6 for AMD Radeon RX 6900 XT (radeonsi, navi21, LLVM 17.0.6, DRM 3.57, 6.7.6-200.fc39.x86_64)
vainfo: Supported config attributes per profile/entrypoint pair
VAProfileMPEG2Simple/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileMPEG2Main/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileVC1Simple/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileVC1Main/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileVC1Advanced/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileH264ConstrainedBaseline/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileH264ConstrainedBaseline/VAEntrypointEncSlice
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribRateControl              : VA_RC_CBR
                                             VA_RC_VBR
                                             VA_RC_CQP
    VAConfigAttribEncPackedHeaders         : VA_ENC_PACKED_HEADER_SEQUENCE
    VAConfigAttribEncMaxRefFrames          : l0=1
                                             l1=1
    VAConfigAttribEncMaxSlices             : 128
    VAConfigAttribEncSliceStructure        : VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS
                                             VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 2160
    VAConfigAttribEncQualityRange          : number of supported quality levels is 32
    VAConfigAttribEncRateControlExt        : max_num_temporal_layers_minus1=3 temporal_layer_bitrate_control_flag=1
    VAConfigAttribMaxFrameSize             : max_frame_size=1
                                             multiple_pass=0

VAProfileH264Main/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileH264Main/VAEntrypointEncSlice
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribRateControl              : VA_RC_CBR
                                             VA_RC_VBR
                                             VA_RC_CQP
    VAConfigAttribEncPackedHeaders         : VA_ENC_PACKED_HEADER_SEQUENCE
    VAConfigAttribEncMaxRefFrames          : l0=1
                                             l1=1
    VAConfigAttribEncMaxSlices             : 128
    VAConfigAttribEncSliceStructure        : VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS
                                             VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 2160
    VAConfigAttribEncQualityRange          : number of supported quality levels is 32
    VAConfigAttribEncRateControlExt        : max_num_temporal_layers_minus1=3 temporal_layer_bitrate_control_flag=1
    VAConfigAttribMaxFrameSize             : max_frame_size=1
                                             multiple_pass=0

VAProfileH264High/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileH264High/VAEntrypointEncSlice
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
                                             VA_RT_FORMAT_YUV420_10
                                             VA_RT_FORMAT_YUV420_10BPP
    VAConfigAttribRateControl              : VA_RC_CBR
                                             VA_RC_VBR
                                             VA_RC_CQP
    VAConfigAttribEncPackedHeaders         : VA_ENC_PACKED_HEADER_SEQUENCE
    VAConfigAttribEncMaxRefFrames          : l0=1
                                             l1=1
    VAConfigAttribEncMaxSlices             : 128
    VAConfigAttribEncSliceStructure        : VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS
                                             VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 2160
    VAConfigAttribEncQualityRange          : number of supported quality levels is 32
    VAConfigAttribEncRateControlExt        : max_num_temporal_layers_minus1=3 temporal_layer_bitrate_control_flag=1
    VAConfigAttribMaxFrameSize             : max_frame_size=1
                                             multiple_pass=0

VAProfileHEVCMain/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 8192
    VAConfigAttribMaxPictureHeight         : 4352

VAProfileHEVCMain/VAEntrypointEncSlice
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribRateControl              : VA_RC_CBR
                                             VA_RC_VBR
                                             VA_RC_CQP
    VAConfigAttribEncPackedHeaders         : VA_ENC_PACKED_HEADER_SEQUENCE
    VAConfigAttribEncMaxRefFrames          : l0=1
                                             l1=0
    VAConfigAttribEncMaxSlices             : 128
    VAConfigAttribEncSliceStructure        : VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS
                                             VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS
    VAConfigAttribMaxPictureWidth          : 7680
    VAConfigAttribMaxPictureHeight         : 4352
    VAConfigAttribEncQualityRange          : number of supported quality levels is 32
    VAConfigAttribMaxFrameSize             : max_frame_size=1
                                             multiple_pass=0

VAProfileHEVCMain10/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
                                             VA_RT_FORMAT_YUV420_10
                                             VA_RT_FORMAT_YUV420_10BPP
    VAConfigAttribMaxPictureWidth          : 8192
    VAConfigAttribMaxPictureHeight         : 4352

VAProfileHEVCMain10/VAEntrypointEncSlice
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
                                             VA_RT_FORMAT_YUV420_10
                                             VA_RT_FORMAT_YUV420_10BPP
    VAConfigAttribRateControl              : VA_RC_CBR
                                             VA_RC_VBR
                                             VA_RC_CQP
    VAConfigAttribEncPackedHeaders         : VA_ENC_PACKED_HEADER_SEQUENCE
    VAConfigAttribEncMaxRefFrames          : l0=1
                                             l1=0
    VAConfigAttribEncMaxSlices             : 128
    VAConfigAttribEncSliceStructure        : VA_ENC_SLICE_STRUCTURE_POWER_OF_TWO_ROWS
                                             VA_ENC_SLICE_STRUCTURE_EQUAL_ROWS
    VAConfigAttribMaxPictureWidth          : 7680
    VAConfigAttribMaxPictureHeight         : 4352
    VAConfigAttribEncQualityRange          : number of supported quality levels is 32
    VAConfigAttribMaxFrameSize             : max_frame_size=1
                                             multiple_pass=0

VAProfileJPEGBaseline/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
                                             VA_RT_FORMAT_YUV422
                                             VA_RT_FORMAT_YUV444
                                             VA_RT_FORMAT_YUV400
    VAConfigAttribMaxPictureWidth          : 4096
    VAConfigAttribMaxPictureHeight         : 4096

VAProfileVP9Profile0/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
    VAConfigAttribMaxPictureWidth          : 8192
    VAConfigAttribMaxPictureHeight         : 4352

VAProfileVP9Profile2/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420_10
                                             VA_RT_FORMAT_YUV420_10BPP
    VAConfigAttribMaxPictureWidth          : 8192
    VAConfigAttribMaxPictureHeight         : 4352

VAProfileAV1Profile0/VAEntrypointVLD
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
                                             VA_RT_FORMAT_YUV420_10
                                             VA_RT_FORMAT_YUV420_10BPP
    VAConfigAttribMaxPictureWidth          : 8192
    VAConfigAttribMaxPictureHeight         : 4352

VAProfileNone/VAEntrypointVideoProc
    VAConfigAttribRTFormat                 : VA_RT_FORMAT_YUV420
                                             VA_RT_FORMAT_YUV422
                                             VA_RT_FORMAT_YUV444
                                             VA_RT_FORMAT_YUV400
                                             VA_RT_FORMAT_YUV420_10
                                             VA_RT_FORMAT_RGB32
                                             VA_RT_FORMAT_RGBP
                                             VA_RT_FORMAT_YUV420_10BPP
```

</details>

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
