### PR TITLE
Resource: add udev based Sysfs GPIO support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -539,6 +539,32 @@ Arguments:
 Used by:
   - `GpioDigitalOutputDriver`_
 
+MatchedSysfsGpio
+++++++++++++++++
+A MatchedSysfsGpio resource describes a GPIO line, like a SysfsGPIO.
+The gpiochip is identified by matching udev properties. This allows
+identification through hot-plugging or rebooting for controllers like
+USB based gpiochips.
+
+.. code-block:: yaml
+
+   MatchedSysfsGpio:
+     match:
+       '@SUBSYSTEM': 'usb'
+       '@ID_SERIAL_SHORT': 'D38EJ8LF'
+     pin: 0
+
+The example would search for a USB gpiochip with the key `ID_SERIAL_SHORT`
+and the value `D38EJ8LF` and use the pin 0 of this device.
+The `ID_SERIAL_SHORT` property is set by the usb_id builtin helper program.
+
+Arguments:
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+  - pin (int): gpio pin number within the matched gpiochip.
+
+Used by:
+  - `GpioDigitalOutputDriver`_
+
 NetworkService
 ~~~~~~~~~~~~~~
 A :any:`NetworkService` describes a remote SSH connection.
@@ -2139,6 +2165,7 @@ While the driver automatically exports the GPIO, it does not configure it in any
 Binds to:
   gpio:
     - `SysfsGPIO`_
+    - `MatchedSysfsGPIO`_
     - NetworkSysfsGPIO
 
 Implements:

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -523,6 +523,22 @@ NetworkHIDRelay
 +++++++++++++++
 A :any:`NetworkHIDRelay` describes an `HIDRelay`_ exported over the network.
 
+SysfsGPIO
++++++++++
+
+A :any:`SysfsGPIO` resource describes a GPIO line.
+
+.. code-block:: yaml
+
+   SysfsGPIO:
+     index: 12
+
+Arguments:
+  - index (int): index of the GPIO line
+
+Used by:
+  - `GpioDigitalOutputDriver`_
+
 NetworkService
 ~~~~~~~~~~~~~~
 A :any:`NetworkService` describes a remote SSH connection.
@@ -954,21 +970,6 @@ Arguments:
 
 Used by:
   - `USBVideoDriver`_
-
-SysfsGPIO
-~~~~~~~~~
-A :any:`SysfsGPIO` resource describes a GPIO line.
-
-.. code-block:: yaml
-
-   SysfsGPIO:
-     index: 12
-
-Arguments:
-  - index (int): index of the GPIO line
-
-Used by:
-  - `GpioDigitalOutputDriver`_
 
 NetworkUSBVideo
 ~~~~~~~~~~~~~~~

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -579,11 +579,13 @@ class GPIOSysFSExport(ResourceExport):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        local_cls_name = self.cls
-        self.data['cls'] = f"Network{self.cls}"
-        from ..resource import base
-        local_cls = getattr(base, local_cls_name)
-        self.local = local_cls(target=None, name=None, **self.local_params)
+        if self.cls == "SysfsGPIO":
+            from ..resource.base import SysfsGPIO
+            self.local = SysfsGPIO(target=None, name=None, **self.local_params)
+        elif self.cls == "MatchedSysfsGPIO":
+            from ..resource.udev import MatchedSysfsGPIO
+            self.local = MatchedSysfsGPIO(target=None, name=None, **self.local_params)
+        self.data['cls'] = "NetworkSysfsGPIO"
         self.export_path = Path(GPIOSysFSExport._gpio_sysfs_path_prefix,
                                 f'gpio{self.local.index}')
         self.system_exported = False
@@ -624,6 +626,7 @@ class GPIOSysFSExport(ResourceExport):
             unexport.write(str(index).encode('utf-8'))
 
 exports["SysfsGPIO"] = GPIOSysFSExport
+exports["MatchedSysfsGPIO"] = GPIOSysFSExport
 
 
 @attr.s

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -15,6 +15,7 @@ from .udev import (
     HIDRelay,
     IMXUSBLoader,
     LXAUSBMux,
+    MatchedSysfsGPIO,
     MXSUSBLoader,
     RKUSBLoader,
     SiSPMPowerPort,

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -23,6 +23,7 @@ from .udev import (
     HIDRelay,
     USBDebugger,
     USBPowerPort,
+    MatchedSysfsGPIO
 )
 from ..util import dump
 
@@ -56,6 +57,7 @@ class Suggester:
         self.resources.append(HIDRelay(**args))
         self.resources.append(USBDebugger(**args))
         self.resources.append(USBPowerPort(**args, index=0))
+        self.resources.append(MatchedSysfsGPIO(**args, pin=0))
 
     def suggest_callback(self, resource, meta, suggestions):
         cls = type(resource).__name__
@@ -84,6 +86,8 @@ class Suggester:
             ))
             if cls == 'USBPowerPort':
                 print('    index: ?')
+            if cls == 'MatchedSysfsGPIO':
+                print('    pin: ?')
         print("  ---")
         print()
 


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
This PR adds support for GPIOs for which the gpiochip is identified using udev.

This is useful when the probe order of the gpiochip is not predictable. 
In this case, this is case it is not possible to know the global gpio number required by SysfsGPIO resource.

With MatchedSysfsGPIO, the pin number is local to the gpiochip and gpiochip is identified with udev

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature : No obvious test for udev based resources ?
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated

<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

