### PR TITLE
doc/overview: mention SSH requirement

### DIFF
--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -319,6 +319,12 @@ published as declared in the configuration file.
 This is useful to register externally configured resources such as network
 power switches or serial port servers with a labgrid coordinator.
 
+.. note::
+  Users will require SSH access to the exporter to access services and command
+  line utilities. You also have to ensure that users can access usb devices for
+  i.e. imx-usb-loader. To test a SSH jump to a device over the exporter outside
+  of labgrid, `ssh -J EXPORTER USER@DEVICE` can be used.
+
 .. _overview-client:
 
 Client


### PR DESCRIPTION
**Description**
Mention that SSH access to the exporter is required. Also document how the SSH jump host function can be used with plain SSH.

**Checklist**
- [x] Documentation for the feature
