### PR TITLE
driver/sigrok: various fixes

### DIFF
--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -212,7 +212,7 @@ class SigrokDriver(SigrokCommon):
     def analyze(self, args, filename=None):
         annotation_regex = re.compile(r'(?P<startnum>\d+)-(?P<endnum>\d+) (?P<decoder>[\w\-]+): (?P<annotation>[\w\-]+): (?P<data>".*)')  # pylint: disable=line-too-long
         if not filename and self._filename:
-            filename = self._filename
+            filename = os.path.join(self._tmpdir, self._basename)
         else:
             filename = os.path.abspath(filename)
         check_file(filename, command_prefix=self.sigrok.command_prefix)

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -2,7 +2,6 @@ import os.path
 import re
 import subprocess
 import shutil
-import signal
 import tempfile
 import time
 import uuid
@@ -171,8 +170,8 @@ class SigrokDriver(SigrokCommon):
         fnames.extend(self.sigrok.channels.split(','))
         csv_filename = f'{os.path.splitext(self._basename)[0]}.csv'
 
-        self._process.send_signal(signal.SIGINT)
-        stdout, stderr = self._process.communicate()
+        # sigrok-cli can be quit through any keypress
+        stdout, stderr = self._process.communicate(input="q")
         self.logger.debug("stdout: %s", stdout)
         self.logger.debug("stderr: %s", stderr)
 

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -179,7 +179,7 @@ class SigrokDriver(SigrokCommon):
         if isinstance(self.sigrok, NetworkSigrokUSBDevice):
             subprocess.call([
                 'scp', f'{self.sigrok.host}:{os.path.join(self._tmpdir, self._basename)}',
-                os.path.join(self._local_tmpdir, self._filename)
+                os.path.abspath(self._filename)
             ],
                             stdin=subprocess.DEVNULL,
                             stdout=subprocess.DEVNULL,

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -169,7 +169,7 @@ class SigrokDriver(SigrokCommon):
         # Convert from .sr to .csv
         cmd = [
             '-i',
-            os.path.join(self._tmpdir, self._basename), '-O', 'csv', '-o',
+            os.path.join(self._tmpdir, self._basename), '-O', 'csv:time=true', '-o',
             os.path.join(self._tmpdir, csv_filename)
         ]
         self._call(*cmd)


### PR DESCRIPTION
**Description**

This fixes some things in the sigrok driver implementation:

- explicitly set time field in csv conversion,
    apparently some versions of sigrok-cli on some distros (for example Ubuntu 22.04) default to false,
    resulting in invalid parsing
- analyze method checks/uses wrong (local) file path when the resource is remote
- capture file is transferred to wrong path when specified filename is not absolute and using a remote sigrok resource.
- avoid deadlock when sigrok-cli process failed
- unsuccessful sigrok-cli termination when using sigrok driver remotely

**Checklist**
- [x] PR has been tested

