### PR TITLE
driver/sshdriver: redirect /dev/null to stdin in run()

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -214,7 +214,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             stderr_pipe = subprocess.PIPE
         try:
             sub = subprocess.Popen(
-                complete_cmd, stdout=subprocess.PIPE, stderr=stderr_pipe
+                complete_cmd, stdin=subprocess.DEVNULL, stdout=subprocess.PIPE, stderr=stderr_pipe
             )
         except:
             raise ExecutionError(


### PR DESCRIPTION
**Description**
By default, no redirection will occur. That means a command run on the target consumes the stdin of our process. That is especially unfortunate if we expect interactive input, such as for the ManualPowerDriver, ManualSwitchDriver or in a REPL:

```python
shell.run_check("sleep 100 &")
pidfile = "/tmp/pidfile"
shell.run_check(f"pgrep sleep > {pidfile}")
try:
    ssh.run(f"pwait --pidfile {pidfile}", timeout=1)
except:
    from IPython import embed
    embed()
```

This example shows that not all input reaches the IPython REPL.

Fix this by redirecting `/dev/null` to stdin, so the command run via SSH do not receive unexpected input and do not compete over it.


**Checklist**
- [x] PR has been tested