### PR TITLE
examples/network-test: simplify ethernet frame generation

### DIFF
--- a/examples/network-test/pkg-replay-record.py
+++ b/examples/network-test/pkg-replay-record.py
@@ -12,9 +12,9 @@ from labgrid import Environment
 from labgrid.logging import basicConfig, StepLogger
 
 def generate_frame():
-    frame = [Ether(dst="11:22:33:44:55:66", src="66:55:44:33:22:11", type=0x9000)]
+    frame = Ether(dst="11:22:33:44:55:66", src="66:55:44:33:22:11", type=0x9000)
     padding = "\x00" * (conf.min_pkt_size - len(frame))
-    frame = frame[0] / Raw(load=padding)
+    frame /= Raw(load=padding)
     return frame
 
 


### PR DESCRIPTION
**Description**
There is no need to put the frame as a single item into a list.

**Checklist**
- [x] PR has been tested