### PR TITLE
udisks2: Be more tolerant of device-startup time

### DIFF
--- a/labgrid/util/agents/udisks2.py
+++ b/labgrid/util/agents/udisks2.py
@@ -15,8 +15,15 @@ class UDisks2Device:
     def __init__(self, devpath):
         self._logger = logging.getLogger("Device: ")
         self.devpath = devpath
-        client = UDisks.Client.new_sync(None)
+        self.fs = None
 
+    def _setup(self):
+        """Try to find the devpath
+
+        Raises:
+            ValueError: no udisks2 device or no filesystem found on devpath
+        """
+        client = UDisks.Client.new_sync(None)
         manager = client.get_object_manager()
         for obj in manager.get_objects():
             block = obj.get_block()
@@ -24,16 +31,16 @@ class UDisks2Device:
                 continue
 
             device_path = block.get_cached_property("Device").get_bytestring().decode('utf-8')
-            if device_path == devpath:
+            if device_path == self.devpath:
                 self.fs = obj.get_filesystem()
                 if self.fs is None:
-                    raise ValueError(f"no filesystem found on {devpath}")
+                    raise ValueError(f"no filesystem found on {self.devpath}")
 
                 return
 
-        raise ValueError(f"No udisks2 device found for {devpath}")
+        raise ValueError(f"No udisks2 device found for {self.devpath}")
 
-    def mount(self, readonly=False):
+    def mount(self, readonly=False, retries=0):
         opts = GLib.Variant('a{sv}', {'options': GLib.Variant('s', 'ro' if readonly else 'rw')})
 
         try:
@@ -83,17 +90,39 @@ class UDisks2Device:
 
 _devs = {}
 
-def _get_udisks2_dev(devpath):
+def _get_udisks2_dev(devpath, retries):
+    """Try to get the udisks2 device
+
+    Args:
+        devpath (str): Device name
+        retries (int): Number of retries to allow
+
+    Raises:
+        ValueError: Failed to obtain the device (e.g. does not exist)
+    """
     if devpath not in _devs:
-        _devs[devpath] = UDisks2Device(devpath=devpath)
+        dev = UDisks2Device(devpath=devpath)
+        while True:
+            try:
+                dev._setup()
+                break
+            except ValueError as exc:
+                if 'No udisks2 device' not in str(exc) or not retries:
+                    raise
+                retries -= 1
+            dev._logger.warning('udisks2: Retrying %s...', devpath)
+            time.sleep(1)
+
+        # Success, so record the new device
+        _devs[devpath] = dev
     return _devs[devpath]
 
-def handle_mount(devpath):
-    dev = _get_udisks2_dev(devpath)
+def handle_mount(devpath, retries=0):
+    dev = _get_udisks2_dev(devpath, retries)
     return dev.mount()
 
 def handle_unmount(devpath, lazy=False):
-    dev = _get_udisks2_dev(devpath)
+    dev = _get_udisks2_dev(devpath, 0)
     return dev.unmount(lazy=lazy)
 
 methods = {


### PR DESCRIPTION
When switching an SDWire to 'host' mode, it may take time for the partition to appear.

During that time the device (e.g. '/dev/sdo1') may not exist, so trying to cat e.g. '/sys/call/block/sdo1' fails. Handle this by returning a zero size in that case, as is done when the returned size is empty.

Even when the block device is present, udisks2 may take a short time to make the device available. Handle this by retrying a few times, until things settle.

Add the call to _wait_for_medium() in write_files() while we are here, to match what is done in write_image(). Also fix the parameter type for write_files() and mention the exception it may raise.

This change has been manually tested since there are no tests available for the code being modified.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
(I cannot find any tests for USBStorage)
- [ ] The arguments and description in doc/configuration.rst have been updated
(not needed, I think)
--->
- [X] PR has been tested
- [ ] Man pages have been regenerated
(it seems that these were out-of-sync before my PR)

Fixes: #1357
