### PR TITLE
Add py version to dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,7 @@ dev = [
 
     # additional dev dependencies
     "psutil>=5.8.0",
+    "py>=1.11",
     "pytest-cov>=3.0.0",
     "pytest-dependency>=0.5.1",
     "pytest-isort>=2.0.0",


### PR DESCRIPTION
This seems to need a later version than is present on my system, without which 'tox -r' fails.

Add an explicit dependency for version 1.11 which I believe is the minimum version with the py.io feature.

Fixes #1361

(none of the template seems to be relevant for this fix)