### PR TITLE
dockerfiles: replace wait-for-it dependency with simple bash loop

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -11,8 +11,7 @@ RUN set -e ;\
     apt install -q=2 --yes --no-install-recommends python3 python3-dev python3-pip python3-setuptools git build-essential libsnappy-dev ;\
     pip3 install --break-system-packages -U pip;\
     apt clean ;\
-    rm -rf /var/lib/apt/lists/* ;\
-    git clone https://github.com/vishnubob/wait-for-it.git opt/wait-for-it && cd opt/wait-for-it  && git reset --hard 54d1f0bfeb6557adf8a3204455389d0901652242
+    rm -rf /var/lib/apt/lists/*
 
 #
 # Client

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -17,12 +17,12 @@ services:
     stdin_open: true
     network_mode: "host"
     tmpfs: "/tmp"
-    # Use wait-for-it to ensure exporter service is up, as exporter is assuming exporter to
+    # Wait until coordinator is up
     # Use labgrid-client r to ensure the exporter has populated the resource list in the coordinator
     # Use sleep to fix the problem that sometimes the coordinator is not ready even though the service is up
     command: timeout 60 bash -c "set -e &&
       cd /simple-test &&
-      /opt/wait-for-it/wait-for-it.sh 127.0.0.1:20408 &&
+      until echo > /dev/tcp/localhost/20408; do sleep 1; done &&
       sleep 5 &&
       while [ -z $$(/usr/local/bin/labgrid-client r) ]; do echo 'Wait one sec on coordinator' && sleep 1; done &&
       /usr/local/bin/labgrid-client -p example-place lock &&
@@ -43,7 +43,7 @@ services:
     network_mode: "host"
     stdin_open: true
     command: bash -c "set -e &&
-      /opt/wait-for-it/wait-for-it.sh 127.0.0.1:20408 -- labgrid-exporter /opt/conf/exporter.yaml"
+      until echo > /dev/tcp/localhost/20408; do sleep 1; done && labgrid-exporter /opt/conf/exporter.yaml"
   dut:
     build:
       context: "./dut"


### PR DESCRIPTION
**Description**
Instead of relying on an external repository that basically does the same job, use a simple loop opening a socket via bash's pseudo-device files below `/dev/tcp` instead.                                        


**Checklist**
- [x] PR has been tested