### PR TITLE
doc: Install [dev] so that docs can be built

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -679,7 +679,7 @@ When contributing to documentation it's practical to be able to build it also lo
 
     git clone https://github.com/labgrid-project/labgrid.git
     cd labgrid
-    pip install -e ".[doc]"
+    pip install -e ".[dev]"
     cd doc
     make html
 


### PR DESCRIPTION
The 'make html' command fails with the [doc] build. Update the documentation to show how to resolve this.

Fixes #1352

