### PR TITLE
doc/configuration: UUUDriver: align example with reality

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2493,7 +2493,7 @@ Implements:
        drivers:
          UUUDriver:
            image: 'mybootloaderkey'
-           cmd: 'spl'
+           script: 'spl'
 
    images:
      mybootloaderkey: 'path/to/mybootloader.img'
@@ -2501,7 +2501,7 @@ Implements:
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
     of an image to bootstrap onto the target
-  - script (str): run built-in script with ``uuu -b``, called with image as arg0
+  - script (str): optional, run built-in script with ``uuu -b``, called with image as arg0
 
 USBStorageDriver
 ~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Besides the image name, the `UUUDriver` supports a `script` attribute. This is described in the Arguments: section, but not in the example, which uses the non-existent `cmd` attribute instead.

Fix that and while at it, correctly indicate that script is optional. Omitting it will just remove the `-b $script` from the `uuu` invocation.

Fixes #1090