### PR TITLE
shelldriver: allow dashes and dots in device names

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -596,7 +596,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             device = self.get_default_interface_device_name()
 
         regex = r"""\d+: # leading number
-                \s+\w+ # interface name
+                \s+[\w\.-]+ # interface name
                 \s+inet6?\s+(\S+) # IP address, prefix
                 .*global # global scope, not host scope"""
 


### PR DESCRIPTION
**Description**

The `get_ip_addresses` may be called with a specific device and returns alls IP addresses on that interface. Due to a limitation in the regex, devices including either dashes or dots aren't detected.

On the OpenWrt distributions the default device is called `br-lan`, usually connecting ethernet ports and WiFi devices. Likewise dots are attached to the device name to specify VLANs.

This commit extends the regex to support both dashes and dots.

**Checklist**
- [ ] Documentation for the feature
  - This is just an extension of the feature, should it still be documented?
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
  - No changes
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
  - No changes
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
  - No changes
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->

