### PR TITLE
qemudriver: add support for netdev option in `add_port_forward`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,10 @@ New Features in 24.0
   used to pass additional options for the disk directly to QEMU
 - labgrid-client now has a ``write-files`` subcommand to copy files onto mass
   storage devices.
+- The `QEMUDriver` now supports a ``netdev`` argumet which can be added to the
+  ``tadd_port_forward`` in case there are more than one network interfaces
+  defined.
+
 
 Bug fixes in 24.0
 ~~~~~~~~~~~~~~~~~

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -310,15 +310,15 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 "Can't use monitor command on non-running target")
         return self.qmp.execute(command, arguments)
 
-    def _add_port_forward(self, proto, local_address, local_port, remote_address, remote_port):
+    def _add_port_forward(self, proto, local_address, local_port, remote_address, remote_port, netdev):
         self.monitor_command(
             "human-monitor-command",
-            {"command-line": f"hostfwd_add {proto}:{local_address}:{local_port}-{remote_address}:{remote_port}"},
+            {"command-line": f"hostfwd_add {netdev} {proto}:{local_address}:{local_port}-{remote_address}:{remote_port}" },
         )
 
-    def add_port_forward(self, proto, local_address, local_port, remote_address, remote_port):
-        self._add_port_forward(proto, local_address, local_port, remote_address, remote_port)
-        self._forwarded_ports[(proto, local_address, local_port)] = (proto, local_address, local_port, remote_address, remote_port)
+    def add_port_forward(self, proto, local_address, local_port, remote_address, remote_port, netdev=""):
+        self._add_port_forward(proto, local_address, local_port, remote_address, remote_port, netdev)
+        self._forwarded_ports[(proto, local_address, local_port)] = (proto, local_address, local_port, remote_address, remote_port, netdev)
 
     def remove_port_forward(self, proto, local_address, local_port):
         del self._forwarded_ports[(proto, local_address, local_port)]


### PR DESCRIPTION
**Description**

In case there are more `user` network interfaces defined, allow to specific the netdev. If omitted, an empty string is passed and the behaviour is like before.

This is useful for testing OpenWrt inside a QEMU instance, since OpenWrt expects by default a LAN interface on eth0 and a WAN interface (with uplink) on eth1. Previously the port forward would always be added to eth1, which doesn't support SSH due to firewall policies. By adding the netdev to the forward function, the SSHDriver works as expected.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
