### PR TITLE
driver: add ability to customize the line separator in drivers using ConsoleProtocol

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1974,6 +1974,7 @@ Arguments:
   - txchunk (int, default=1): number of bytes the `txdelay` should apply to
   - timeout (float, default=3.0): time in seconds to wait for a network serial port before
     an error occurs
+  - linesep (str, default="\n"): the separator when sending complete lines
 
 ModbusRTUDriver
 ~~~~~~~~~~~~~~~
@@ -2231,6 +2232,7 @@ Arguments:
   - cmd (str): command to execute and then bind to.
   - txdelay (float, default=0.0): time in seconds to wait before sending a chunk
   - txchunk (int, default=1): number of bytes the `txdelay` should apply to
+  - linesep (str, default="\n"): the separator when sending complete lines
 
 AndroidFastbootDriver
 ~~~~~~~~~~~~~~~~~~~~~
@@ -3099,6 +3101,7 @@ Arguments:
     - qemu-default: Don't override QEMU default settings
 
   - nic (str): optional, configuration string to pass to QEMU to create a network interface
+  - linesep (str, default="\n"): the separator when sending complete lines
 
 The QEMUDriver also requires the specification of:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -147,7 +147,7 @@ specific driver set a binding mapping before creating the driver:
   >>> t.set_binding_map({"port": "Second"})
   >>> sd = SerialDriver(t, "Driver")
   >>> sd
-  SerialDriver(target=Target(name='Test', env=None), name='Driver', state=<BindingState.bound: 1>, txdelay=0.0, txchunk=1, timeout=3.0)
+  SerialDriver(target=Target(name='Test', env=None), name='Driver', state=<BindingState.bound: 1>, txdelay=0.0, txchunk=1, timeout=3.0, linesep='\n')
   >>> sd.port
   SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -283,9 +283,9 @@ Active drivers can be accessed by class (any :any:`Driver <labgrid.driver>` or
   >>> console = FakeConsoleDriver(target, 'console')
   >>> target.activate(console)
   >>> target[FakeConsoleDriver]
-  FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1)
+  FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1, linesep='\n')
   >>> target[FakeConsoleDriver, 'console']
-  FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1)
+  FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1, linesep='\n')
 
 Driver Deactivation
 ^^^^^^^^^^^^^^^^^^^
@@ -302,7 +302,7 @@ Driver deactivation works in a similar manner:
 .. doctest:: driver-deactivation
 
   >>> target.deactivate(console)
-  [FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.bound: 1>, txdelay=0.0, txchunk=1)]
+  [FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.bound: 1>, txdelay=0.0, txchunk=1, linesep='\n')]
 
 Drivers need to be deactivated in the following cases:
 
@@ -393,7 +393,7 @@ To access the target's console, the correct driver object can be found by using
 
   >>> cp = t.get_driver('ConsoleProtocol')
   >>> cp
-  SerialDriver(target=Target(name='example', env=Environment(config_file='example-env.yaml')), name=None, state=<BindingState.active: 2>, txdelay=0.0, txchunk=1, timeout=3.0)
+  SerialDriver(target=Target(name='example', env=Environment(config_file='example-env.yaml')), name=None, state=<BindingState.active: 2>, txdelay=0.0, txchunk=1, timeout=3.0, linesep='\n')
   >>> cp.write(b'test')
   4
 

--- a/labgrid/driver/consoleexpectmixin.py
+++ b/labgrid/driver/consoleexpectmixin.py
@@ -11,12 +11,12 @@ class ConsoleExpectMixin:
     Console driver mixin to implement the read, write, expect and sendline methods. It uses
     the internal _read and _write methods.
 
-    The class using the ConsoleExpectMixin must provide a logger and a txdelay attribute.
+    The class using the ConsoleExpectMixin must provide a logger, txdelay and linesep attribute.
     """
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        self._expect = PtxExpect(self)
+        self._expect = PtxExpect(self, self.linesep.encode("ASCII"))
 
     @Driver.check_active
     @step(result=True, tag='console')

--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -22,6 +22,7 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     cmd = attr.ib(validator=attr.validators.instance_of(str))
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
     txchunk = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    linesep = attr.ib(default="\n", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/fake.py
+++ b/labgrid/driver/fake.py
@@ -15,6 +15,7 @@ from .consoleexpectmixin import ConsoleExpectMixin
 class FakeConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
     txchunk = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    linesep = attr.ib(default="\n", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/laadriver.py
+++ b/labgrid/driver/laadriver.py
@@ -34,6 +34,7 @@ class LAASerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
 
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
     timeout = attr.ib(default=3.0, validator=attr.validators.instance_of(float))
+    linesep = attr.ib(default="\n", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -94,6 +94,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
     nic = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)))
+    linesep = attr.ib(default="\n", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -22,6 +22,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
     txdelay = attr.ib(default=0.0, validator=attr.validators.instance_of(float))
     txchunk = attr.ib(default=1, validator=attr.validators.instance_of(int))
     timeout = attr.ib(default=3.0, validator=attr.validators.instance_of(float))
+    linesep = attr.ib(default="\n", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -264,9 +264,9 @@ class Target:
         >>> console = FakeConsoleDriver(target, 'console')
         >>> target.activate(console)
         >>> target[FakeConsoleDriver]
-        FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1)
+        FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1, linesep='\\n')
         >>> target[FakeConsoleDriver, 'console']
-        FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1)
+        FakeConsoleDriver(target=Target(name='main', env=None), name='console', state=<BindingState.active: 2>, txdelay=0.0, txchunk=1, linesep='\\n')
         """
         name = None
         if not isinstance(key, tuple):

--- a/labgrid/util/expect.py
+++ b/labgrid/util/expect.py
@@ -10,11 +10,12 @@ class PtxExpect(pexpect.spawn):
     driver: ConsoleProtocol object to be passed in
     """
 
-    def __init__(self, driver):
+    def __init__(self, driver, linesep=b"\n"):
         "Initializes a pexpect spawn instance with the required configuration"
         self.driver = driver
-        self.linesep = b"\n"
         pexpect.spawn.__init__(self, None, maxread=1)
+        # the linesep needs to be set *after* pexpect is initialized, otherwise it would be overwritten
+        self.linesep = linesep
 
     def send(self, s):
         "Write to underlying transport, return number of bytes written"


### PR DESCRIPTION
**Description**

This adds the ability to customize the line separator in drivers that implement `ConsoleProtocol` (through the `ConsoleExpectMixin` class).

These are:
- SerialDriver
- ExternalConsoleDriver
- QemuDriver

It is useful when certain systems expect a `\r\n` instead of the usual `\n` .

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested

