### PR TITLE
Driver for openFPGALoader

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -854,6 +854,7 @@ Arguments:
 
 Used by:
   - `OpenOCDDriver`_
+  - `OpenFPGALoaderDriver`_
 
 SNMPEthernetPort
 ~~~~~~~~~~~~~~~~
@@ -1942,6 +1943,39 @@ Arguments:
   - interface_config (str): optional, interface config in the ``openocd/scripts/interface/`` directory
   - board_config (str): optional, board config in the ``openocd/scripts/board/`` directory
   - load_commands (list of str): optional, load commands to use instead of ``init``, ``bootstrap {filename}``, ``shutdown``
+
+OpenFPGALoaderDriver
+~~~~~~~~~~~~~
+
+An :any:`OpenFPGALoaderDriver` controls the openFPGALoader tool to bootstrap an FPGA chip with a
+bitstream.
+
+A list of supported FPGA chips, boards and programming cables can be found on the project's page:
+- https://trabucayre.github.io/openFPGALoader/compatibility/fpga.html
+- https://trabucayre.github.io/openFPGALoader/compatibility/board.html
+- https://trabucayre.github.io/openFPGALoader/compatibility/cable.html
+
+Binds to:
+  interface:
+    - `AlteraUSBBlaster`_
+    - NetworkAlteraUSBBlaster
+    - `USBDebugger`_
+    - NetworkUSBDebugger
+
+Implements:
+  - :any:`BootstrapProtocol`
+
+.. code-block:: yaml
+
+  OpenFPGALoaderDriver:
+    board: vcu118
+    image: 'bitstream.bit'
+    frequency: 20000000
+
+Arguments:
+- image (str): optional, the default bitstream image file if not specified when calling load()
+- board (str): optional, the FPGA board identifier
+- frequency (int): optional, force a non-default programmer frequency in Hz
 
 QuartusHPSDriver
 ~~~~~~~~~~~~~~~~

--- a/labgrid/driver/openfpgaloaderdriver.py
+++ b/labgrid/driver/openfpgaloaderdriver.py
@@ -1,0 +1,71 @@
+import attr
+
+from ..factory import target_factory
+from ..protocol import BootstrapProtocol
+from ..step import step
+from ..util.managedfile import ManagedFile
+from ..util.helper import processwrapper
+from .common import Driver
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class OpenFPGALoaderDriver(Driver, BootstrapProtocol):
+    """OpenFPGALoaderDriver - Driver to bootstrap FPGA boards with a bitstream file
+
+    Arguments:
+        image (str): optional, the default bitstream image file if not specified when calling load()
+        board (str): optional, the FPGA board identifier
+        frequency (int): optional, force a non-default programmer frequency in Hz
+    """
+    bindings = {
+        "interface": {
+            "AlteraUSBBlaster", "NetworkAlteraUSBBlaster",
+            "USBDebugger", "NetworkUSBDebugger",
+        },
+    }
+
+    image = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    board = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    frequency = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(int))
+    )
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('openFPGALoader')
+        else:
+            self.tool = 'openFPGALoader'
+
+    @Driver.check_active
+    @step(args=['filename'])
+    def load(self, filename=None):
+        cmd = [self.tool]
+
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        mf = ManagedFile(filename, self.interface)
+        mf.sync_to_resource()
+        cmd += ["--bitstream", mf.get_remote_path() ]
+
+        cmd += ["--busdev-num", f"{self.interface.busnum}:{self.interface.devnum}" ]
+
+        if self.board:
+            cmd += ["--board", self.board]
+
+        if self.frequency:
+            cmd += ["--freq", str(self.frequency)]
+
+        processwrapper.check_output(
+            self.interface.wrap_command(cmd),
+            print_on_silent_log=True
+        )


### PR DESCRIPTION
A driver interfacing with the openFPGADriver universal FPGA programming tool.                                                                                                                                                                 
                                                                                                                                                                                                                                              
**Description**                                                                                                                                                                                                                               
                                                                                                                                                                                                                                              
This driver adds support for bootstraping FPGA boards using the openFPGALoader universal FPGA programming utility (https://github.com/trabucayre/openFPGALoader).                                                                             
                                                                                                                                                                                                                                              
OpenFPGALoader supports a large number of FPGA boards, boards and programming cables. It is a useful addition to the openocd support greatly expanding the amount of FPGA hardware that can be worked with using labgrid.

The code has been tested locally on a Xilinx VCU118 board.

There are no tests currently for the driver as it is not clear to me how it could be tested without real HW.

**Checklist**
- [X] Documentation for the feature
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested