### PR TITLE
resource: udev: new USB ID for USBDebugger

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -704,6 +704,7 @@ class USBDebugger(USBResource):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
 
         if match not in [("0403", "6010"),  # FT2232C/D/H Dual UART/FIFO IC
+                         ("0403", "6014"),  # FT232HL/Q
                          ("0483", "374b"),  # STLINK-V3
                          ("0483", "374f"),  # STLINK-V3
                          ("15ba", "0003"),  # Olimex ARM-USB-OCD


### PR DESCRIPTION
Add the USB IDs for an FT232HL chip in the Digilent JTAG-SMT2 surface-mount programming module used as a JTAG programmer on FPGA boards.