### PR TITLE
console: Make settle() indicate success/failure

### DIFF
--- a/labgrid/driver/consoleexpectmixin.py
+++ b/labgrid/driver/consoleexpectmixin.py
@@ -61,13 +61,14 @@ class ConsoleExpectMixin:
 
     @Driver.check_active
     @step(args=['quiet_time'])
-    def settle(self, quiet_time, timeout=120.0):
+    def settle(self, quiet_time, timeout=120.0) -> bool:
         t = Timeout(timeout)
         while not t.expired:
             try:
                 self.read(timeout=quiet_time)
             except pexpect.TIMEOUT:
-                break
+                return True
+        return False
 
     def resolve_conflicts(self, client):
         for other in self.clients:


### PR DESCRIPTION
**Description**

This code adds a simple return value to the settle() call which is useful in scenarios where a command or key sequence needs to be sent to quiet large amounts of console spam (for example linux kernel dmesg). In such cases this action may have to be retried multiple times and it's good to get an indication from settle() whether the console has really settled or a timeout has been reached.

This code is currently used in our deployment, before the change settle() does not have a return value at all therefore this change should not introduce regressions. The testsuite has been run with the change applied without any tests failing.

No changes to the documentation have been performed as the API of ConsoleExpectMixin is not documented there in detail.

**Checklist**
- [x] PR has been tested
