### PR TITLE
labgrid/driver/power: Backend for tinycontrol.eu IP Power Socket 6G10A v2

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -231,6 +231,11 @@ Currently available are:
   Controls *TP-Link power strips* via `python-kasa
   <https://github.com/python-kasa/python-kasa>`_.
 
+``tinycontrol``
+  Controls a tinycontrol.eu IP Power Socket via HTTP.
+  It was tested on the *6G10A v2* model.
+  `Manual <https://tinycontrol.pl/media/documents/manual_IP_Power_Socket__6G10A_v2_LANLIS-010-015_En-1.pdf>`__
+
 ``poe_mib``
   Controls PoE switches using the PoE SNMP administration MiBs.
 

--- a/labgrid/driver/power/tinycontrol.py
+++ b/labgrid/driver/power/tinycontrol.py
@@ -1,0 +1,34 @@
+""" A driver to control the Tinycontrol IP Power Socket 6G10A v2
+    Reference: https://tinycontrol.pl/media/documents/manual_IP_Power_Socket__6G10A_v2_LANLIS-010-015_En-1.pdf
+
+    Example configuration to use port #3 on a device with URL 'http://172.17.180.53:9999/'
+
+    NetworkPowerPort:
+      model: tinycontrol
+      host: 'http://172.17.180.53:9999/'
+      index: 3
+"""
+
+import requests
+from urllib.parse import urljoin
+import xml.etree.ElementTree as ET
+
+
+def power_set(host, port, index, value):
+    assert port is None
+
+    index = int(index)
+    value = 1 if value else 0
+    r = requests.get(urljoin(host, f"/outs.cgi?out{index}={value}"))
+    r.raise_for_status()
+
+
+def power_get(host, port, index):
+    assert port is None
+
+    index = int(index)
+    r = requests.get(urljoin(host, "/st0.xml"))
+    r.raise_for_status()
+    root = ET.fromstring(r.text)
+    output = root.find(f"out{index}")
+    return output.text == '1'


### PR DESCRIPTION
**Description**

This PR adds a power control backend for the IP Power Socket 6G10A manufactured by tinycontrol.eu. It is integrated in the current network power control framework with the `tinycontrol` model name.

No tests have been provided as it's not clear to me how this can be tested without real HW.

This code is being currently used in our deployment, running the labgrid test suite with this change does not result in any failed tests.

**Checklist**
- [X] Documentation for the feature
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested
