### PR TITLE
feat: add ability to provide password for networkresources

### DIFF
--- a/labgrid/resource/common.py
+++ b/labgrid/resource/common.py
@@ -86,18 +86,21 @@ class NetworkResource(Resource):
 
     Args:
         host (str): remote host the resource is available on
+        sshpassword (str): remote host ssh password
     """
     host = attr.ib(validator=attr.validators.instance_of(str))
+    sshpassword = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)), kw_only=True)
 
     @property
     def command_prefix(self):
         host = self.host
+        sshpassword = self.sshpassword
 
         if hasattr(self, 'extra'):
             if self.extra.get('proxy_required'):
                 host = self.extra.get('proxy')
 
-        conn = sshmanager.get(host)
+        conn = sshmanager.get(host, sshpassword)
         prefix = conn.get_prefix()
 
         return prefix + ['--']

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -302,6 +302,17 @@ def test_proxymanager_local_forced_proxy(target):
     assert (host, port) != (nhost, nport)
 
 @pytest.mark.localsshmanager
+def test_remote_networkresource(target, tmpdir):
+    name = "test"
+    host = "localhost"
+    sshpassword = "foo"
+    res = NetworkResource(target, name, host, sshpassword=sshpassword)
+
+    assert res.name == name
+    assert res.host == host
+    assert res.sshpassword == sshpassword
+
+@pytest.mark.localsshmanager
 def test_remote_managedfile(target, tmpdir):
     import hashlib
     import getpass


### PR DESCRIPTION
**Description**

This adds the ability to specify a connection ssh password for resources that derive `NetworkResource` in order to use them on hosts where adding a ssh key is not possible or where the host key is regenerated after a reboot.

The implementation uses `SSH_ASK_PASS` in the same way as it is already done in `SSHDriver`.

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested
