### PR TITLE
power: add ubus NetworkPowerPort

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -234,6 +234,10 @@ Currently available are:
 ``poe_mib``
   Controls PoE switches using the PoE SNMP administration MiBs.
 
+``ubus``
+  Controls *PoE switches* running OpenWrt using the *ubus* interface.
+  Further infromation available at <https://openwrt.org/docs/techref/ubus>
+
 Used by:
   - `NetworkPowerDriver`_
 

--- a/labgrid/driver/power/ubus.py
+++ b/labgrid/driver/power/ubus.py
@@ -1,0 +1,48 @@
+"""
+  UBUS jsonrpc interface for PoE management on OpenWrt devices. This comes in
+  handy if devices are connected to a PoE switch running OpenWrt.
+
+  The URL given in hosts in exporter.yaml must accept unauthenticated UBUS
+  calls for the two `poe` calls `info` and `manage`.
+
+  Further information is availbe at https://openwrt.org/docs/techref/ubus#acls
+
+  NetworkPowerPort:
+      model: ubus
+      host: 'http://192.168.1.1/ubus'
+      index: 1
+"""
+
+import requests
+
+
+def jsonrpc_call(host, path, method, message):
+    r = requests.post(
+        host,
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "call",
+            "params": ["00000000000000000000000000000000", path, method, message],
+        },
+    )
+    r.raise_for_status()
+    return r.json()["result"]
+
+
+def power_set(host, port, index, value):
+    assert port is None
+
+    jsonrpc_call(host, "poe", "manage", {"port": f"lan{index}", "enable": value == 1})
+
+
+def power_get(host, port, index):
+    assert port is None
+
+    poe_info = jsonrpc_call(host, "poe", "info", {})[1]
+
+    assert (
+        f"lan{index}" in poe_info["ports"]
+    ), f"Port lan{index} not found in {poe_info['ports']}"
+
+    return poe_info["ports"][f"lan{index}"] != "Disabled"


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Using PoE switches as power supply is convenient since a switch is needed in many cases anyway and with the right adapter most embedded devices can be powered.

OpenWrt offers `ubus` as micro bus system to control the system, including PoE ports on switches.

This commit adds a driver to handle PoE switches running OpenWrt.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [x] Add a section on how to use the feature to doc/usage.rst

> Same as for all other NetworkPowerPorts

<!---
A library feature which other developers can use:
--->
- [x] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated
> no changes

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
