### PR TITLE
remote/client: fallback to telnet when microcom is not available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -47,6 +47,7 @@ New Features in 24.0
   switches running OpenWrt using the ubus interface.
 - The pyproject.toml gained a config for `ruff <https://github.com/astral-sh/ruff>`_.
 - ``setuptools_scm`` is now used to generate a version file.
+- labgrid-client console will fallback to telnet if microcom is not available.
 
 
 Bug fixes in 24.0

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -349,8 +349,8 @@ Now we can connect to the serial console:
 
     labgrid-venv $ labgrid-client -p example-place console
 
-.. note:: Using remote connection requires ``microcom`` installed on the host
-   where the labgrid-client is called.
+.. note:: Using remote connection requires ``microcom`` or ``telnet`` installed
+   on the host where the labgrid-client is called.
 
 See :ref:`remote-usage` for some more advanced features.
 For a complete reference have a look at the :doc:`labgrid-client(1) <man/client>`


### PR DESCRIPTION
microcom is generally not available on rpm based distributions[1], making it hard to setup labgrid client on them.

[1] https://repology.org/project/microcom/versions

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
Tested the telnet code path in a fedora container.
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
