### PR TITLE
agent: add argument to specify python virutal env

### DIFF
--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -38,7 +38,7 @@ class ModuleProxy:
 
 class AgentWrapper:
 
-    def __init__(self, host=None):
+    def __init__(self, host=None, pyvirtenv=None):
         self.agent = None
         self.loaded = {}
         self.logger = logging.getLogger(f"ResourceExport({host})")
@@ -58,8 +58,12 @@ class AgentWrapper:
                 ['rsync', '-e', ' '.join(ssh_opts), '-tq', agent,
                  f'{host}:{agent_remote}'],
             )
+            select_virtenv = []
+            if pyvirtenv is not None:
+                select_virtenv = f'source {pyvirtenv}/bin/activate &&'.split()
+            cmd = select_virtenv + ['python3', agent_remote]
             self.agent = subprocess.Popen(
-                ssh_opts + [host, '--', 'python3', agent_remote],
+                ssh_opts + [host, '--'] + cmd,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 start_new_session=True,


### PR DESCRIPTION
When using agentwrapper, the python packages used are the one installed on the machine.
This commit add an argument to specify the path to a virtual env which will be used by the agent.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
I have not seen documentation about `AgentWrapper` (`git grep -i agentwrapper` did not yield any .rst)
- [ ] Tests for the feature
I would need help with that
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
Not applicable as far as I understand
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
Let me know if you think this is necessary, I think it is an advanced feature which might be confusing for first time readers.
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
Not applicable
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
I tested with our internal fork of labgrid which adds a driver to make https requests from the exporter to the DUT.
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated
Not applicable

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->

I developped this feature in order to be able to use the `urllib3` module pinned at a version (see https://github.com/labgrid-project/labgrid/discussions/1301#discussioncomment-9447382).
The driver using this feature is not (yet) public but a first version is available here:
https://github.com/SiemaApplications-attic/labgrid/commit/81918df3ec8f48efbab8a0c67b2a7b9b63afa983

Here is the modification added to the above patch in order to be able to specify the virtual env necessary for `pyrequests` labgrid driver:
```patch
commit 921bd05c2668993dfb64342d78898d215ecd9a86
Author: Nicolas VINCENT <nicolas.vincent@vossloh.com>
Date:   Fri May 24 11:37:13 2024 +0200

    pyrequest: Adds option to specify virtual env
    
    adds pyvirtenv option to be able to specify the virtual env used by
    pyrequests
    
    Signed-off-by: Nicolas VINCENT <nicolas.vincent@vossloh.com>

diff --git a/labgrid/driver/pyrequestsdriver.py b/labgrid/driver/pyrequestsdriver.py
index 0de22b6..f07e6d6 100644
--- a/labgrid/driver/pyrequestsdriver.py
+++ b/labgrid/driver/pyrequestsdriver.py
@@ -17,6 +18,8 @@ class PyRequestsDriver(Driver):
     bindings = {
         "iface": {"RemoteNetworkInterface", "NetworkInterface", "USBNetworkInterface"},
     }
+    pyvirtenv = attr.ib(default=None,
+                        validator=attr.validators.optional(attr.validators.instance_of(str)))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -27,7 +30,7 @@ class PyRequestsDriver(Driver):
             host = self.iface.host
         else:
             host = None
-        self.wrapper = AgentWrapper(host)
+        self.wrapper = AgentWrapper(host, self.pyvirtenv)
         self.proxy = self.wrapper.load('pyrequests')
 
     def on_deactivate(self):
```

Then the env yaml file use looks like this:
```yaml
- targets:
  main:
    drivers:
      - PyRequestsDRiver:
        pyvirtenv: '/path/to/virt/env/'
```

I tried to run developper test without success... `tox` would return an error and I did not know which env file to provide to `pytest`.

I did not know if I should update all drivers using an instance of `AgentWrapper` in order to use this new feature. Just let me know.

I feel a little bit embarrassed with this PR as I have not been able to test it and document it according to the development guidelines, my intent is not to burden you but rather to give something back to this project.

Thanks in advance for your guidance.
