### PR TITLE
use setuptools_scm to generate a version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 /dist
 /.pytest_cache/
 /htmlcov/
+/labgrid/_version.py
 /dockerfiles/staging/crossbar/*
 !/dockerfiles/staging/crossbar/places_example.yaml
 /.idea

--- a/labgrid/__init__.py
+++ b/labgrid/__init__.py
@@ -6,3 +6,8 @@ from .factory import target_factory
 from .step import step, steps
 from .stepreporter import StepReporter
 from .consoleloggingreporter import ConsoleLoggingReporter
+
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "unknown"

--- a/labgrid/util/version.py
+++ b/labgrid/util/version.py
@@ -4,6 +4,12 @@ This module contains helper functions for working with version.
 
 
 def labgrid_version():
+    try:
+        from .._version import __version__
+        return __version__
+    except ModuleNotFoundError:
+        pass
+
     import contextlib
     from importlib.metadata import PackageNotFoundError, version
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ packages = [
 
 [tool.setuptools_scm]
 local_scheme = "no-local-version"
+version_file = "labgrid/_version.py"
 
 [tool.pytest.ini_options]
 testpaths = [


### PR DESCRIPTION
This avoids the overhead of using `importlib.metadata` to search for the version.