### PR TITLE
Exporter: always use tcp for ser2net

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -248,7 +248,7 @@ class SerialPortExport(ResourceExport):
                 "-d",
                 "-n",
                 "-Y",
-                f"connection: &con01#  accepter: telnet(rfc2217,mode=server),{self.port}",
+                f"connection: &con01#  accepter: telnet(rfc2217,mode=server),tcp,{self.port}",
                 "-Y",
                 f'  connector: serialdev(nouucplock=true),{start_params["path"]},{self.local.speed}n81,local',  # pylint: disable=line-too-long
                 "-Y",

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -233,16 +233,16 @@ class SerialPortExport(ResourceExport):
         # Ser2net has switched to using YAML format at version 4.0.0.
         result = subprocess.run([self.ser2net_bin, "-v"], capture_output=True, text=True)
         _, _, version = str(result.stdout).split(" ")
-        major_version = version.split(".")[0]
+        version = tuple(map(int, version.strip().split(".")))
 
         # There is a bug in ser2net between 4.4.0 and 4.6.1 where it
         # returns 1 on a successful call to 'ser2net -v'. We don't want
         # a failure because of this, so raise an error only if ser2net
         # is not one of those versions.
-        if version.strip() not in ["4.4.0", "4.5.0", "4.5.1", "4.6.0", "4.6.1"] and result.returncode == 1:
+        if version not in [(4, 4, 0), (4, 5, 0), (4, 5, 1), (4, 6, 0), (4, 6, 1)] and result.returncode == 1:
             raise ExporterError(f"ser2net {version} returned a nonzero code during version check.")
 
-        if int(major_version) >= 4:
+        if version >= (4, 0, 0):
             cmd = [
                 self.ser2net_bin,
                 "-d",

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -242,7 +242,7 @@ class SerialPortExport(ResourceExport):
         if version not in [(4, 4, 0), (4, 5, 0), (4, 5, 1), (4, 6, 0), (4, 6, 1)] and result.returncode == 1:
             raise ExporterError(f"ser2net {version} returned a nonzero code during version check.")
 
-        if version >= (4, 0, 0):
+        if version >= (4, 2, 0):
             cmd = [
                 self.ser2net_bin,
                 "-d",


### PR DESCRIPTION
Fix the ser2net version check and support ser2net >=4.6.0.

**Checklist**
- [ ] PR has been tested

Fixes #1416