### PR TITLE
util/ssh: stop keepalive in disconnect() when existing connection is used

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -521,9 +521,10 @@ class SSHConnection:
     def disconnect(self):
         assert self._connected
         try:
+            self._stop_keepalive()
+
             if self._socket:
                 self._logger.info("Closing SSH connection to %s", self.host)
-                self._stop_keepalive()
                 self._stop_own_master()
         finally:
             self._connected = False


### PR DESCRIPTION
**Description**
SSHConnection does not open a new connection if an existing connection is open. It reuses the connection and starts a keepalive command (cat).

On `disconnect()`, the keepalive command is only stopped for newly initiated connections, not for existing ones. Fix that.

**Checklist**
- [x] PR has been tested