### PR TITLE
driver/power/tplink: use IotStrip instead of deprecated SmartStrip

### DIFF
--- a/labgrid/driver/power/tplink.py
+++ b/labgrid/driver/power/tplink.py
@@ -1,14 +1,14 @@
 """ Tested with TP Link KP303, and should be compatible with any strip supported by kasa """
 
 import asyncio
-from kasa import SmartStrip
+from kasa.iot import IotStrip
 
 
 async def _power_set(host, port, index, value):
     """We embed the coroutines in an `async` function to minimise calls to `asyncio.run`"""
     assert port is None
     index = int(index)
-    strip = SmartStrip(host)
+    strip = IotStrip(host)
     await strip.update()
     assert (
         len(strip.children) > index
@@ -26,7 +26,7 @@ def power_set(host, port, index, value):
 def power_get(host, port, index):
     assert port is None
     index = int(index)
-    strip = SmartStrip(host)
+    strip = IotStrip(host)
     asyncio.run(strip.update())
     assert (
         len(strip.children) > index

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ doc = [
 ]
 docker = ["docker>=5.0.2"]
 graph = ["graphviz>=0.17.0"]
-kasa = ["python-kasa>=0.4.0"]
+kasa = ["python-kasa>=0.7.0"]
 modbus = ["pyModbusTCP>=0.2.0"]
 modbusrtu = ["minimalmodbus>=1.0.2"]
 mqtt = ["paho-mqtt>=2.0.0"]


### PR DESCRIPTION
**Description**
Increase the minimum python-kasa version to 0.7.0. This allows us to use a newly introduced and not deprecated replacement for the kasa.SmartStrip class.

Since python-kasa 0.7.0, the SmartStrip class [is deprecated](https://python-kasa.readthedocs.io/en/stable/smartstrip.html).

The docs state:

  "If you want to continue to use the old API for older devices, you can use the classes in the iot module to avoid deprecation warnings."

https://python-kasa.readthedocs.io/en/stable/deprecated.html#deprecated-api-reference

Do that.

**Checklist**
- [ ] PR has been tested (untested, I don't have the required hardware)