### PR TITLE
driver/serialdigitaloutput: fix get() for DTR signal

### DIFF
--- a/labgrid/driver/serialdigitaloutput.py
+++ b/labgrid/driver/serialdigitaloutput.py
@@ -41,7 +41,7 @@ class SerialPortDigitalOutputDriver(Driver, DigitalOutputProtocol):
     def get(self):
         if self.signal == "dtr":
             val =  self._p.dtr
-        if self.signal == "rts":
+        elif self.signal == "rts":
             val = self._p.rts
         else:
             raise ValueError("Expected signal to be dtr or rts")


### PR DESCRIPTION
**Description**
If self.signal is "dtr", a ValueError is raised.  That happens because the if/else logic is wrong for that case. Fix that.

**Checklist**
- [x] PR has been tested

Fixes #577

