### PR TITLE
driver/externalconsoledriver: use bufsize=0 for opening external process

### DIFF
--- a/labgrid/driver/externalconsoledriver.py
+++ b/labgrid/driver/externalconsoledriver.py
@@ -33,7 +33,7 @@ class ExternalConsoleDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
             return
         cmd = shlex.split(self.cmd)
         self._child = subprocess.Popen(
-            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None
+            cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=None, bufsize=0
         )
 
         # make stdout non-blocking


### PR DESCRIPTION
**Description**
The ExternalConsoleDriver works on top of a command executed on the local computer. Until now the system default of `io.DEFAULT_BUFFER_SIZE` (typically 8192 bytes) was used for bufsize. This does not work well for this use case, we want unbuffered reads and writes. So set the bufsize to 0, see https://docs.python.org/3/library/subprocess.html#popen-constructor .

**Checklist**
- [x] PR has been tested (tested with microcom and barebox sandbox)
