### PR TITLE
client: names in compact output when listing resources

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -364,11 +364,11 @@ class ClientSession:
                         else:
                             places = None
 
-                        results.append((places, exporter, group_name, resource.cls))
+                        results.append((places, exporter, group_name, resource.cls, resource_name))
 
             results = sorted(results, key=lambda res: res[0][0].changed if res[0] else 0)
 
-            for places, exporter, group_name, resource_cls in results:
+            for places, exporter, group_name, resource_cls, resource_name in results:
                 if self.args.sort_by_matched_place_change:
                     places_strs = [f"{p.name}: {datetime.fromtimestamp(p.changed):%Y-%m-%d}" for p in places]
                     places_info = ", ".join(places_strs) if places_strs else "not used by any place"
@@ -376,7 +376,7 @@ class ClientSession:
                 else:
                     places_info = None
 
-                line = f"{exporter}/{group_name}/{resource_cls}"
+                line = f"{exporter}/{group_name}/{resource_cls}[/{resource_name}]"
                 if places_info is not None:
                     print(f"{line:<50s} {places_info}")
                 else:

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -367,11 +367,11 @@ class ClientSession:
                         else:
                             places = None
 
-                        results.append((places, exporter, group_name, resource.cls))
+                        results.append((places, exporter, group_name, resource.cls, resource_name))
 
             results = sorted(results, key=lambda res: res[0][0].changed if res[0] else 0)
 
-            for places, exporter, group_name, resource_cls in results:
+            for places, exporter, group_name, resource_cls, resource_name in results:
                 if self.args.sort_by_matched_place_change:
                     places_strs = [f"{p.name}: {datetime.fromtimestamp(p.changed):%Y-%m-%d}" for p in places]
                     places_info = ", ".join(places_strs) if places_strs else "not used by any place"
@@ -379,7 +379,7 @@ class ClientSession:
                 else:
                     places_info = None
 
-                line = f"{exporter}/{group_name}/{resource_cls}"
+                line = f"{exporter}/{group_name}/{resource_cls}[/{resource_name}]"
                 if places_info is not None:
                     print(f"{line:<50s} {places_info}")
                 else:


### PR DESCRIPTION
**Description**

This adds that resources names are printed in the compact output of the `labgrid-client resources` command.

For example, instead of:

```
exporter-01/usbhub-p01/NetworkSerialPort
exporter-01/usbhub-p01/NetworkSerialPort
```

the output becomes

```
exporter-01/usbhub-p01/NetworkSerialPort[/modbus]
exporter-01/usbhub-p01/NetworkSerialPort[/serial-115200]
```

which makes it easier to differentiate between resources that have the same class.

The alternative would be to enable verbose printing with `labgrid-client -v resources`, but that adds a lot of other information and makes is quite hard to pick out the name quickly.

At least in my experience the resource name is the only info that I need 95% of the time, so I think it would be beneficial to add it to the default output.

What do you think?


- [x] PR has been tested

