### PR TITLE
driver/power/tinycontrol: fix import order

### DIFF
--- a/labgrid/driver/power/tinycontrol.py
+++ b/labgrid/driver/power/tinycontrol.py
@@ -9,10 +9,10 @@
       index: 3
 """
 
-import requests
 from urllib.parse import urljoin
 import xml.etree.ElementTree as ET
 
+import requests
 
 def power_set(host, port, index, value):
     assert port is None


### PR DESCRIPTION
**Description**
Fixes the import order in the new tinycontrol power backend found by pylint:
```
labgrid/driver/power/tinycontrol.py:13:0: C0411: standard import "urllib.parse.urljoin" should be placed before third party import "requests" (wrong-import-order)
labgrid/driver/power/tinycontrol.py:14:0: C0411: standard import "xml.etree.ElementTree" should be placed before third party import "requests" (wrong-import-order)
```

**Checklist**
- [x] PR has been tested

Fixes #1405