### PR TITLE
doc/usage: adjust docs for legacy --lg-colored-steps, LG_COLOR_SCHEME

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -447,12 +447,9 @@ Other labgrid-related pytest plugin options are:
   If option is specified without path the current working directory is used.
 
 ``--lg-colored-steps``
-  Enables the ColoredStepReporter.
-  Different events have different colors.
-  The more colorful, the more important.
-  In order to make less important output "blend into the background" different
-  color schemes are available.
-  See :ref:`LG_COLOR_SCHEME <usage-lgcolorscheme>`.
+  Previously enabled the ColoredStepReporter, which has been removed with the
+  StepLogger introduction.
+  Kept for compatibility reasons without effect.
 
 ``--lg-initial-state=STATE_NAME``
   Sets the Strategy's initial state.
@@ -469,19 +466,6 @@ Environment Variables
 LG_ENV
 ^^^^^^
 Behaves like ``LG_ENV`` for :doc:`labgrid-client <man/client>`.
-
-.. _usage-lgcolorscheme:
-
-LG_COLOR_SCHEME
-^^^^^^^^^^^^^^^
-Influences the color scheme used for the Colored Step Reporter.
-``dark`` is meant for dark terminal background.
-``light`` is optimized for light terminal background.
-``dark-256color`` and ``light-256color`` are respective variants for terminals
-that support 256 colors.
-By default, ``dark`` or ``dark-256color`` (depending on the terminal) are used.
-
-Takes effect only when used with ``--lg-colored-steps``.
 
 LG_PROXY
 ^^^^^^^^


### PR DESCRIPTION
**Description**
Explain that neither  `--lg-colored-steps` nor `LG_COLOR_SCHEME` have an effect anymore.