### PR TITLE
examples: fixes, cleanup, use StepLogger instead of StepReporter

### DIFF
--- a/examples/deditec-relais8/deditec.py
+++ b/examples/deditec-relais8/deditec.py
@@ -3,8 +3,7 @@ import labgrid
 import logging
 import time
 
-from labgrid import Environment, StepReporter
-from labgrid.strategy.bareboxstrategy import Status
+from labgrid import StepReporter
 from labgrid.driver.deditecrelaisdriver import DeditecRelaisDriver
 
 # enable debug logging

--- a/examples/deditec-relais8/deditec.py
+++ b/examples/deditec-relais8/deditec.py
@@ -1,10 +1,10 @@
 import sys
-import labgrid
 import logging
 import time
 
-from labgrid import StepReporter
-from labgrid.driver.deditecrelaisdriver import DeditecRelaisDriver
+from labgrid import Target, StepReporter
+from labgrid.resource.udev import DeditecRelais8
+from labgrid.driver import DeditecRelaisDriver
 
 # enable debug logging
 logging.basicConfig(
@@ -16,8 +16,8 @@ logging.basicConfig(
 # show labgrid steps on the console
 StepReporter.start()
 
-t = labgrid.Target('main')
-r = labgrid.resource.udev.DeditecRelais8(t, name=None, index=1)
+t = Target('main')
+r = DeditecRelais8(t, name=None, index=1)
 d = DeditecRelaisDriver(t, name=None)
 
 p = t.get_driver("DigitalOutputProtocol")

--- a/examples/deditec-relais8/deditec.py
+++ b/examples/deditec-relais8/deditec.py
@@ -1,20 +1,16 @@
-import sys
 import logging
 import time
 
-from labgrid import Target, StepReporter
+from labgrid import Target
+from labgrid.logging import basicConfig, StepLogger
 from labgrid.resource.udev import DeditecRelais8
 from labgrid.driver import DeditecRelaisDriver
 
-# enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+# enable info logging
+basicConfig(level=logging.INFO)
 
-# show labgrid steps on the console
-StepReporter.start()
+# log labgrid steps
+StepLogger.start()
 
 t = Target('main')
 r = DeditecRelais8(t, name=None, index=1)

--- a/examples/deditec-relais8/deditec_remote.py
+++ b/examples/deditec-relais8/deditec_remote.py
@@ -3,9 +3,7 @@ import labgrid
 import logging
 import time
 
-from labgrid import Environment, StepReporter
-from labgrid.strategy.bareboxstrategy import Status
-from labgrid.driver.deditecrelaisdriver import DeditecRelaisDriver
+from labgrid import StepReporter
 
 # enable debug logging
 logging.basicConfig(

--- a/examples/deditec-relais8/deditec_remote.py
+++ b/examples/deditec-relais8/deditec_remote.py
@@ -1,9 +1,8 @@
 import sys
-import labgrid
 import logging
 import time
 
-from labgrid import StepReporter
+from labgrid import Environment, StepReporter
 
 # enable debug logging
 logging.basicConfig(
@@ -15,7 +14,7 @@ logging.basicConfig(
 # show labgrid steps on the console
 StepReporter.start()
 
-e = labgrid.Environment('import-dedicontrol.yaml')
+e = Environment('import-dedicontrol.yaml')
 t = e.get_target()
 
 p = t.get_driver("DigitalOutputProtocol")

--- a/examples/deditec-relais8/deditec_remote.py
+++ b/examples/deditec-relais8/deditec_remote.py
@@ -1,18 +1,14 @@
-import sys
 import logging
 import time
 
-from labgrid import Environment, StepReporter
+from labgrid import Environment
+from labgrid.logging import basicConfig, StepLogger
 
-# enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+# enable info logging
+basicConfig(level=logging.INFO)
 
 # show labgrid steps on the console
-StepReporter.start()
+StepLogger.start()
 
 e = Environment('import-dedicontrol.yaml')
 t = e.get_target()

--- a/examples/library/test.py
+++ b/examples/library/test.py
@@ -4,19 +4,16 @@
 import sys
 import logging
 
-from labgrid import Environment, StepReporter
+from labgrid import Environment
+from labgrid.logging import basicConfig, StepLogger
 from labgrid.strategy.bareboxstrategy import Status
 
 
-# enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+# enable info logging
+basicConfig(level=logging.INFO)
 
-# show labgrid steps on the console
-StepReporter.start()
+# log labgrid steps
+StepLogger.start()
 
 def run_once(target):
     s = target.get_driver('BareboxStrategy')

--- a/examples/networkmanager/nm.py
+++ b/examples/networkmanager/nm.py
@@ -1,7 +1,8 @@
-import logging, sys
+import logging
+import sys
 from pprint import pprint
 
-from labgrid import *
+from labgrid import Environment, StepReporter
 
 
 # enable debug logging

--- a/examples/networkmanager/nm.py
+++ b/examples/networkmanager/nm.py
@@ -1,19 +1,15 @@
 import logging
-import sys
 from pprint import pprint
 
-from labgrid import Environment, StepReporter
+from labgrid import Environment
+from labgrid.logging import basicConfig, StepLogger
 
 
 # enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+basicConfig(level=logging.DEBUG)
 
 # show labgrid steps on the console
-StepReporter.start()
+StepLogger.start()
 
 
 e = Environment('nm.env')

--- a/examples/qemu-networking/qemunetworkstrategy.py
+++ b/examples/qemu-networking/qemunetworkstrategy.py
@@ -17,7 +17,7 @@ import enum
 import attr
 
 from labgrid import target_factory, step
-from labgrid.strategy import Strategy
+from labgrid.strategy import Strategy, StrategyError
 from labgrid.util import get_free_port
 
 
@@ -75,7 +75,7 @@ class QEMUNetworkStrategy(Strategy):
                 networkservice.port = local_port
             else:
                 networkservice.address = new_address
-                networkserivce.port = self.__remote_port
+                networkservice.port = self.__remote_port
 
     @step(args=["state"])
     def transition(self, state, *, step):
@@ -83,7 +83,7 @@ class QEMUNetworkStrategy(Strategy):
             state = Status[state]
 
         if state == Status.unknown:
-            raise StrategyError(f"can not transition to {new_status}")
+            raise StrategyError(f"can not transition to {state}")
 
         elif self.status == state:
             step.skip("nothing to do")
@@ -99,4 +99,4 @@ class QEMUNetworkStrategy(Strategy):
             self.target.activate(self.shell)
             self.update_network_service()
 
-        self.status = status
+        self.status = state

--- a/examples/sigrok/main.py
+++ b/examples/sigrok/main.py
@@ -6,13 +6,10 @@ import time
 import logging
 
 from labgrid import Environment
+from labgrid.logging import basicConfig
 
-# enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+# enable info logging
+basicConfig(level=logging.INFO)
 
 env = Environment(sys.argv[1])
 target = env.get_target('main')

--- a/examples/strategy/bareboxrebootstrategy.py
+++ b/examples/strategy/bareboxrebootstrategy.py
@@ -2,11 +2,10 @@ import enum
 
 import attr
 
+from labgrid import target_factory, step
 from labgrid.driver import BareboxDriver, ShellDriver
 from labgrid.protocol import PowerProtocol
-from labgrid.factory import target_factory
-from labgrid.step import step
-from labgrid.strategy.common import Strategy
+from labgrid.strategy import Strategy
 
 
 @attr.s(eq=False)

--- a/examples/strategy/quartusstrategy.py
+++ b/examples/strategy/quartusstrategy.py
@@ -2,11 +2,10 @@ import enum
 
 import attr
 
+from labgrid import target_factory, step
 from labgrid.driver import QuartusHPSDriver, SerialDriver
-from labgrid.factory import target_factory
 from labgrid.protocol import PowerProtocol
-from labgrid.step import step
-from labgrid.strategy.common import Strategy
+from labgrid.strategy import Strategy
 
 
 @attr.s(eq=False)

--- a/examples/strategy/test_barebox_strategy.py
+++ b/examples/strategy/test_barebox_strategy.py
@@ -1,7 +1,5 @@
 import pytest
 
-from labgrid.exceptions import NoDriverFoundError
-
 
 @pytest.fixture(scope="function")
 def in_bootloader(strategy, capsys):

--- a/examples/sysfsgpio/sysfsgpio.py
+++ b/examples/sysfsgpio/sysfsgpio.py
@@ -1,10 +1,10 @@
 import sys
-import labgrid
 import logging
 import time
 
-from labgrid import StepReporter
-from labgrid.driver.gpiodriver import GpioDigitalOutputDriver
+from labgrid import StepReporter, Target
+from labgrid.driver import GpioDigitalOutputDriver
+from labgrid.resource import SysfsGPIO
 
 # enable debug logging
 logging.basicConfig(
@@ -16,8 +16,8 @@ logging.basicConfig(
 # show labgrid steps on the console
 StepReporter.start()
 
-t = labgrid.Target('main')
-r = labgrid.resource.base.SysfsGPIO(t, name=None, index=60)
+t = Target('main')
+r = SysfsGPIO(t, name=None, index=60)
 d = GpioDigitalOutputDriver(t, name=None)
 
 p = t.get_driver("DigitalOutputProtocol")

--- a/examples/sysfsgpio/sysfsgpio.py
+++ b/examples/sysfsgpio/sysfsgpio.py
@@ -3,7 +3,7 @@ import labgrid
 import logging
 import time
 
-from labgrid import Environment, StepReporter
+from labgrid import StepReporter
 from labgrid.driver.gpiodriver import GpioDigitalOutputDriver
 
 # enable debug logging

--- a/examples/sysfsgpio/sysfsgpio.py
+++ b/examples/sysfsgpio/sysfsgpio.py
@@ -1,20 +1,16 @@
-import sys
 import logging
 import time
 
-from labgrid import StepReporter, Target
+from labgrid import Target
+from labgrid.logging import basicConfig, StepLogger
 from labgrid.driver import GpioDigitalOutputDriver
 from labgrid.resource import SysfsGPIO
 
-# enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+# enable info logging
+basicConfig(level=logging.INFO)
 
 # show labgrid steps on the console
-StepReporter.start()
+StepLogger.start()
 
 t = Target('main')
 r = SysfsGPIO(t, name=None, index=60)

--- a/examples/sysfsgpio/sysfsgpio_remote.py
+++ b/examples/sysfsgpio/sysfsgpio_remote.py
@@ -1,9 +1,8 @@
 import sys
-import labgrid
 import logging
 import time
 
-from labgrid import StepReporter
+from labgrid import StepReporter, Environment
 
 # enable debug logging
 logging.basicConfig(
@@ -15,7 +14,7 @@ logging.basicConfig(
 # show labgrid steps on the console
 StepReporter.start()
 
-e = labgrid.Environment('import-gpio.yaml')
+e = Environment('import-gpio.yaml')
 t = e.get_target()
 
 p = t.get_driver("DigitalOutputProtocol")

--- a/examples/sysfsgpio/sysfsgpio_remote.py
+++ b/examples/sysfsgpio/sysfsgpio_remote.py
@@ -3,8 +3,7 @@ import labgrid
 import logging
 import time
 
-from labgrid import Environment, StepReporter
-from labgrid.driver.gpiodriver import GpioDigitalOutputDriver
+from labgrid import StepReporter
 
 # enable debug logging
 logging.basicConfig(

--- a/examples/sysfsgpio/sysfsgpio_remote.py
+++ b/examples/sysfsgpio/sysfsgpio_remote.py
@@ -1,18 +1,14 @@
-import sys
 import logging
 import time
 
-from labgrid import StepReporter, Environment
+from labgrid import Environment
+from labgrid.logging import basicConfig, StepLogger
 
-# enable debug logging
-logging.basicConfig(
-    level=logging.DEBUG,
-    format='%(levelname)7s: %(message)s',
-    stream=sys.stderr,
-)
+# enable info logging
+basicConfig(level=logging.INFO)
 
 # show labgrid steps on the console
-StepReporter.start()
+StepLogger.start()
 
 e = Environment('import-gpio.yaml')
 t = e.get_target()

--- a/examples/usbpower/examplestrategy.py
+++ b/examples/usbpower/examplestrategy.py
@@ -3,9 +3,8 @@ import enum
 import attr
 
 from labgrid.driver import BareboxDriver, ShellDriver, USBSDMuxDriver
-from labgrid.factory import target_factory
+from labgrid import step, target_factory
 from labgrid.protocol import PowerProtocol
-from labgrid.step import step
 from labgrid.strategy import Strategy
 
 

--- a/examples/usbpower/test_example.py
+++ b/examples/usbpower/test_example.py
@@ -1,7 +1,5 @@
 import pytest
 
-from labgrid.exceptions import NoDriverFoundError
-
 
 @pytest.fixture(scope="function")
 def bootloader(target, strategy, capsys):


### PR DESCRIPTION
**Description**
The examples are one of the starting points new users might look into. Don't use deprecated classes there and clean up.

**Checklist**
- [ ] PR has been tested