### PR TITLE
feat: support setting the pythonpath in configuration YAMLs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ New Features in 24.0
 - The pyproject.toml gained a config for `ruff <https://github.com/astral-sh/ruff>`_.
 - ``setuptools_scm`` is now used to generate a version file.
 - labgrid-client console will fallback to telnet if microcom is not available.
+- The ``pythonpath`` key allows specifying additional directories for the
+  Python search path (sys.path). This helps include modules/packages not
+  in the standard library or current directory.
 
 
 Bug fixes in 24.0

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3555,6 +3555,8 @@ The skeleton for an environment consists of:
    imports:
      - <import.py>
      - <python module>
+   pythonpath:
+     - <absolute or relative path>
 
 If you have a single target in your environment, name it "main", as the
 ``get_target`` function defaults to "main".

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -3,12 +3,14 @@
 This class encapsulates access functions to the environment configuration
 
 """
+from typing import List
 import os
 from yaml import YAMLError
 import attr
 
 from .exceptions import NoConfigFoundError, InvalidConfigError
 from .util.yaml import load, resolve_templates
+
 
 @attr.s(eq=False)
 class Config:
@@ -257,6 +259,12 @@ class Config:
                 imports.append(user_import)
 
         return imports
+
+    def get_pythonpath(self) -> List[str]:
+        configured_pythonpath = self.data.get('pythonpath', [])
+        if not isinstance(configured_pythonpath, list):
+            raise KeyError("pythonpath needs to be a list")
+        return [self.resolve_path(p) for p in configured_pythonpath]
 
     def get_paths(self):
         """Helper function that returns the subdict of all paths

--- a/labgrid/environment.py
+++ b/labgrid/environment.py
@@ -1,5 +1,8 @@
-import os
 from typing import Optional
+from importlib.machinery import SourceFileLoader
+import importlib.util
+import os
+import sys
 import attr
 
 from .target import Target
@@ -19,11 +22,12 @@ class Environment:
 
         self.config = Config(self.config_file)
 
-        for user_import in self.config.get_imports():
-            import importlib.util
-            from importlib.machinery import SourceFileLoader
-            import sys
+        # we want configured paths to appear at the beginning of the
+        # PYTHONPATH, so they need to be inserted in reverse order
+        for user_pythonpath in reversed(self.config.get_pythonpath()):
+            sys.path.insert(0, user_pythonpath)
 
+        for user_import in self.config.get_imports():
             if user_import.endswith('.py'):
                 module_name = os.path.basename(user_import)[:-3]
                 loader = SourceFileLoader(module_name, user_import)

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -204,6 +204,29 @@ imports:
 .fi
 .UNINDENT
 .UNINDENT
+.SH PYTHONPATH
+.sp
+The \fBpythonpath\fP key allows specifying additional directories to be added
+to the Python search path (sys.path). This is particularly useful for
+including directories that contain Python modules and packages which are
+not installed in the standard library or not in the current directory.
+Relative paths are resolved relative to the configuration file\(aqs location.
+Specifying this option enables the environment to locate and import modules
+that are not in the default Python path.
+.SS PYTHONPATH EXAMPLE
+.sp
+Extend the Python search path to include the \fIlibs\fP directory:
+.INDENT 0.0
+.INDENT 3.5
+.sp
+.nf
+.ft C
+pythonpath:
+  \- libs
+.ft P
+.fi
+.UNINDENT
+.UNINDENT
 .SH EXAMPLES
 .sp
 A sample configuration with one \fImain\fP target, accessible via SerialPort

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -192,6 +192,25 @@ Import a local `myfunctions.py` file:
    imports:
      - myfunctions.py
 
+PYTHONPATH
+----------
+The ``pythonpath`` key allows specifying additional directories to be added
+to the Python search path (sys.path). This is particularly useful for
+including directories that contain Python modules and packages which are
+not installed in the standard library or not in the current directory.
+Relative paths are resolved relative to the configuration file's location.
+Specifying this option enables the environment to locate and import modules
+that are not in the default Python path.
+
+PYTHONPATH EXAMPLE
+~~~~~~~~~~~~~~~~~~
+Extend the Python search path to include the `libs` directory:
+
+::
+
+   pythonpath:
+     - libs
+
 EXAMPLES
 --------
 A sample configuration with one `main` target, accessible via SerialPort


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

The ``pythonpath`` key allows specifying additional directories to be added to the Python search path (sys.path). This is particularly useful for including directories that contain Python modules and packages which are not installed in the standard library or not in the current directory.

Relative paths are resolved relative to the configuration file's location.

Specifying this option enables the environment to locate and import modules that are not in the default Python path.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [ ] PR has been tested
- [x] Man pages have been regenerated
