### PR TITLE
remote/config: simplify ResourceConfig template loading

### DIFF
--- a/labgrid/remote/config.py
+++ b/labgrid/remote/config.py
@@ -21,9 +21,8 @@ class ResourceConfig:
             line_comment_prefix="##",
         )
         try:
-            with open(self.filename) as file:
-                template = env.from_string(file.read())
-        except FileNotFoundError:
+            template = env.get_template(os.path.basename(self.filename))
+        except jinja2.TemplateNotFound:
             raise NoConfigFoundError(f"{self.filename} could not be found")
         rendered = template.render(self.template_env)
         pprint(("rendered", rendered))


### PR DESCRIPTION
**Description**
ResourceConfig passes a template loader with the directory name of the resource (exporter) config to `jinja2.Environment()`. Instead of using the Environment's loader to load the actual config, the config file is opened and read from manually and its content is then passed to `jinja2.Environment.from_string()`.

Change that by using the designated `jinja2.Environment.get_template()` method to load the config.

**Checklist**
- [x] PR has been tested