### PR TITLE
pyproject.toml: pysnmp-lextudio is now pysnmp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ pyvisa = [
     "pyvisa>=1.11.3",
     "PyVISA-py>=0.5.2",
 ]
-snmp = ["pysnmp-lextudio>=4.4.12, <6"]
+snmp = ["pysnmp>=4.4.12, <6"]
 vxi11 = ["python-vxi11>=0.9"]
 xena = ["xenavalkyrie>=3.0.1"]
 deb = [
@@ -77,7 +77,7 @@ deb = [
     "onewire>=0.2",
 
     # labgrid[snmp]
-    "pysnmp-lextudio>=4.4.12, <6",
+    "pysnmp>=4.4.12, <6",
 ]
 dev = [
     # references to other optional dependency groups
@@ -111,7 +111,7 @@ dev = [
     "PyVISA-py>=0.5.2",
 
     # labgrid[snmp]
-    "pysnmp-lextudio>=4.4.12, <6",
+    "pysnmp>=4.4.12, <6",
 
     # labgrid[vxi11]
     "python-vxi11>=0.9",


### PR DESCRIPTION
**Description**
The original author of pysnmp passed away and the [lextudio](https://github.com/lextudio) folks took over maintenance. While the request to take over the pysnmp PyPi project was pending, the maintained fork was called pysnmp-lextudio (see #1186, aa2549ca). Now that the migration is complete, let's move back to the original package name.

See: https://github.com/etingof/pysnmp/issues/429

**Checklist**
- [ ] PR has been tested