### PR TITLE
docker: move to Docker compose v2

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Build amd64 docker image and validate
       run: |
         ./dockerfiles/build.sh --load
-        docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client
-        docker-compose -f dockerfiles/staging/docker-compose.yml down
+        docker compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client
+        docker compose -f dockerfiles/staging/docker-compose.yml down
         docker images
     - name: Build, tag and push latest image for all platforms
       run: ./dockerfiles/build.sh --platform ${IMAGE_PLATFORMS} --push

--- a/.github/workflows/reusable-unit-tests-docker.yml
+++ b/.github/workflows/reusable-unit-tests-docker.yml
@@ -22,8 +22,8 @@ jobs:
     - name: Build docker images
       run: |
         ./dockerfiles/build.sh
-        docker-compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client || (docker-compose -f dockerfiles/staging/docker-compose.yml logs --timestamps && false)
-        docker-compose -f dockerfiles/staging/docker-compose.yml down
+        docker compose -f dockerfiles/staging/docker-compose.yml up --exit-code-from client client || (docker compose -f dockerfiles/staging/docker-compose.yml logs --timestamps && false)
+        docker compose -f dockerfiles/staging/docker-compose.yml down
     - name: Show docker images
       run: |
         docker images

--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -141,10 +141,10 @@ client:
 .. code-block:: bash
 
    $ cd dockerfiles/staging
-   $ CURRENT_UID=$(id -u):$(id -g) docker-compose up -d coordinator exporter dut
+   $ CURRENT_UID=$(id -u):$(id -g) docker compose up -d coordinator exporter dut
 
 To run the smoke test just run the client:
 
 .. code-block:: bash
 
-   $ docker-compose up client
+   $ docker compose up client

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 services:
   coordinator:
     image: "${IMAGE_PREFIX:-docker.io/labgrid/}coordinator"


### PR DESCRIPTION
**Description**
Docker compose v1 has been deprecated since July 2023 [1]. Now the GitHub actions Ubuntu runner images removed it, too [2]. So move to v2.

labgrid is obviously not affected by any changes between v1 and v2 other than the compose call `docker-compose` -> `docker compose`.

While at it, drop the obsolete version element [3] from the docker compose config.

[1] https://docs.docker.com/compose/migrate/
[2] https://github.com/actions/runner-images/issues/9692
[3] https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional

**Checklist**
- [x] PR has been tested (CI only)