### PR TITLE
workflows/reusable-unit-tests: do not install ncurses-term, drop TERM setting

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -30,7 +30,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
-        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev ncurses-term graphviz openocd
+        sudo apt-get install -yq libow-dev openssh-server openssh-client libsnappy-dev graphviz openocd
         sudo mkdir -p /var/cache/labgrid/runner && sudo chown runner /var/cache/labgrid/runner
     - name: Prepare local SSH
       run: |
@@ -56,7 +56,7 @@ jobs:
         pylint labgrid
     - name: Test with pytest
       run: |
-        TERM=xterm pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner --crossbar-venv crossbar-venv -k "not test_docker_with_daemon"
+        pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner --crossbar-venv crossbar-venv -k "not test_docker_with_daemon"
     - name: Build documentation
       run: |
         make -C doc clean


### PR DESCRIPTION
**Description**
ncurses-term and the TERM setting were added for the ColoredStepReporter functionality. This has been removed with the StepLogger introduction. So drop both.

**Checklist**
- [x] PR has been tested