### PR TITLE
remote/client: suggest non-deprecated env var LG_PLACE instead of PLACE

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -410,7 +410,7 @@ class ClientSession(ApplicationSession):
         """Add a place to the coordinator"""
         name = self.args.place
         if not name:
-            raise UserError("missing place name. Set with -p <place> or via env var $PLACE")
+            raise UserError("missing place name. Set with -p <place> or via env var LG_PLACE")
         if name in self.places:
             raise UserError(f"{name} already exists")
         res = await self.call("org.labgrid.coordinator.add_place", name)


### PR DESCRIPTION
**Description**
Since #427 the PLACE environment variable is deprecated in favor of LG_PLACE. So suggest LG_PLACE rather than PLACE.

**Checklist**
- [x] PR has been tested