### PR TITLE
add support for the LCTech LCUS USB

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -480,7 +480,7 @@ HIDRelay
 ++++++++
 An :any:`HIDRelay` resource describes a single output of an HID protocol based
 USB relays.
-It currently supports the widely used *dcttech USBRelay*.
+It currently supports the widely used *dcttech USBRelay* and *lctech LCUS*
 
 .. code-block:: yaml
 

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -671,10 +671,14 @@ class HIDRelay(USBResource):
     index = attr.ib(default=1, validator=attr.validators.instance_of(int))
     invert = attr.ib(default=False, validator=attr.validators.instance_of(bool))
 
-    def __attrs_post_init__(self):
-        self.match['ID_VENDOR_ID'] = '16c0'
-        self.match['ID_MODEL_ID'] = '05df'
-        super().__attrs_post_init__()
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [("16c0", "05df"),  # dcttech USBRelay2
+                         ]:
+            return False
+
+        return super().filter_match(device)
 
 @target_factory.reg_resource
 @attr.s(eq=False)

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -675,6 +675,7 @@ class HIDRelay(USBResource):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
 
         if match not in [("16c0", "05df"),  # dcttech USBRelay2
+                         ("5131", "2007"),  # LC-US8
                          ]:
             return False
 

--- a/labgrid/util/agents/usb_hid_relay.py
+++ b/labgrid/util/agents/usb_hid_relay.py
@@ -60,13 +60,22 @@ class USBHIDRelay:
         usb.util.release_interface(self._dev, 0)
 
 
+_relays = {}
+
+
+def _get_relay(busnum, devnum):
+    if (busnum, devnum) not in _relays:
+        _relays[(busnum, devnum)] = USBHIDRelay(bus=busnum, address=devnum)
+    return _relays[(busnum, devnum)]
+
+
 def handle_set(busnum, devnum, number, status):
-    relay = USBHIDRelay(bus=busnum, address=devnum)
+    relay = _get_relay(busnum, devnum)
     relay.set_output(number, status)
 
 
 def handle_get(busnum, devnum, number):
-    relay = USBHIDRelay(bus=busnum, address=devnum)
+    relay = _get_relay(busnum, devnum)
     return relay.get_output(number)
 
 

--- a/labgrid/util/agents/usb_hid_relay.py
+++ b/labgrid/util/agents/usb_hid_relay.py
@@ -10,6 +10,7 @@ Supported Functionality:
 
 - Turn digital output on and off
 """
+
 import usb.core
 import usb.util
 
@@ -32,9 +33,9 @@ class USBHIDRelay:
         self._dev.ctrl_transfer(
             usb.util.CTRL_TYPE_CLASS | usb.util.CTRL_RECIPIENT_DEVICE | usb.util.ENDPOINT_OUT,
             SET_REPORT,
-            (REPORT_TYPE_FEATURE << 8) | 0, # no report ID
+            (REPORT_TYPE_FEATURE << 8) | 0,  # no report ID
             0,
-            req, # payload
+            req,  # payload
         )
 
     def get_output(self, number):
@@ -42,11 +43,11 @@ class USBHIDRelay:
         resp = self._dev.ctrl_transfer(
             usb.util.CTRL_TYPE_CLASS | usb.util.CTRL_RECIPIENT_DEVICE | usb.util.ENDPOINT_IN,
             GET_REPORT,
-            (REPORT_TYPE_FEATURE << 8) | 0, # no report ID
+            (REPORT_TYPE_FEATURE << 8) | 0,  # no report ID
             0,
-            8, # size
+            8,  # size
         )
-        return bool(resp[7] & (1 << (number-1)))
+        return bool(resp[7] & (1 << (number - 1)))
 
     def __del__(self):
         usb.util.release_interface(self._dev, 0)
@@ -63,6 +64,6 @@ def handle_get(busnum, devnum, number):
 
 
 methods = {
-    'set': handle_set,
-    'get': handle_get,
+    "set": handle_set,
+    "get": handle_get,
 }


### PR DESCRIPTION
**Description**

This USB relay uses a different protocol than the dcttech one, so implement the new protocol and detect which one to use based on the vendor ID.