### PR TITLE
labgrid: pytestplugin: hooks: fix multiple start stop for StepLogger

### DIFF
--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -134,7 +134,7 @@ class SerialLoggingReporter:
 
 
 class StepLogger:
-    _started = False
+    started = False
     _logger = None
     _serial_logger = None
     _length_limit = 100
@@ -151,21 +151,21 @@ class StepLogger:
     @classmethod
     def start(cls, length_limit=None):
         """starts the StepLogger"""
-        assert not cls._started
+        assert not cls.started
         if cls._logger is None:
             cls._logger = logging.getLogger("StepLogger")
         steps.subscribe(cls.notify)
         cls._serial_logger = SerialLoggingReporter()
-        cls._started = True
+        cls.started = True
         if length_limit is not None:
             cls._length_limit = length_limit
 
     @classmethod
     def stop(cls):
         """stops the StepLogger"""
-        assert cls._started
+        assert cls.started
         steps.unsubscribe(cls.notify)
-        cls._started = False
+        cls.started = False
 
     @classmethod
     def get_prefix(cls, event):

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -64,8 +64,9 @@ def configure_pytest_logging(config, plugin):
 
 @pytest.hookimpl(trylast=True)
 def pytest_configure(config):
-    StepLogger.start()
-    config.add_cleanup(StepLogger.stop)
+    if not StepLogger.started:
+        StepLogger.start()
+        config.add_cleanup(StepLogger.stop)
 
     logging_plugin = config.pluginmanager.getplugin('logging-plugin')
     if logging_plugin:


### PR DESCRIPTION


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
pytests pytester can be used to run pytests inside pytest. This results in nested calls of pytest_configure and so multiple starts and stops of the StepLogger.

Only start StepLogger if it is not already active. This solution will run the cleanup hook in the "outer" pytest instance.

fixes #1468 
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
