### PR TITLE
github/workflows/scheduled-unit-tests: drop scheduled docker tests on stable-23.0

### DIFF
--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: ['master', 'stable-23.0']
+        branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests-docker.yml
     with:
       branch: ${{ matrix.branch }}


### PR DESCRIPTION
**Description**
Adding the stable branches here is problematic: GitHub uses the workflow definitions from the default branch (master). The workflow might not match the stable branch. So drop it here.

As a replacement, the current stable branch is tested on a labgrid fork that has the stable branch set as its default branch, so the workflow is maintained in the same branch as the code.