### PR TITLE
chore: add typing hints to pytest components

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ New Features in 25.1
 
 - Guermok HDMI to USB 3.0 capture dongle supported
 
+- The ``pytest``-specific parts of the labgrid framework now have typing hints.
+
 Breaking changes in 25.1
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - The deprecated pytest plugin option ``--env-config`` has been removed. Use

--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -262,7 +262,7 @@ class Config:
 
         return imports
 
-    def get_paths(self):
+    def get_paths(self) -> dict[str, str]:
         """Helper function that returns the subdict of all paths
 
         Returns:
@@ -275,7 +275,7 @@ class Config:
 
         return paths
 
-    def get_images(self):
+    def get_images(self) -> dict[str, str]:
         """Helper function that returns the subdict of all images
 
         Returns:

--- a/labgrid/environment.py
+++ b/labgrid/environment.py
@@ -1,5 +1,7 @@
 import os
+from collections.abc import Callable
 from typing import Optional
+
 import attr
 
 from .target import Target
@@ -9,10 +11,10 @@ from .config import Config
 @attr.s(eq=False)
 class Environment:
     """An environment encapsulates targets."""
-    config_file = attr.ib(
+    config_file: str = attr.ib(
         default="config.yaml", validator=attr.validators.instance_of(str)
     )
-    interact = attr.ib(default=input, repr=False)
+    interact: Callable[[str], str] = attr.ib(default=input, repr=False)
 
     def __attrs_post_init__(self):
         self.targets = {}

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -17,9 +17,9 @@ def basicConfig(**kwargs):
     root.handlers[0].setFormatter(StepFormatter(indent=indent, parent=parent))
 
 
-logging.CONSOLE = logging.INFO - 5
-assert(logging.CONSOLE > logging.DEBUG)
-logging.addLevelName(logging.CONSOLE, "CONSOLE")
+CONSOLE = logging.INFO - 5
+assert(CONSOLE > logging.DEBUG)
+logging.addLevelName(CONSOLE, "CONSOLE")
 
 # Use composition instead of inheritance
 class StepFormatter:
@@ -106,11 +106,11 @@ class SerialLoggingReporter:
 
                 for part in parts:
                     data = self.vt100_replace_cr_nl(part)
-                    logger.log(logging.CONSOLE, self._create_message(event, data), extra=extra)
+                    logger.log(CONSOLE, self._create_message(event, data), extra=extra)
 
             elif state == "start" and step.args and "data" in step.args:
                 data = self.vt100_replace_cr_nl(step.args["data"])
-                logger.log(logging.CONSOLE, self._create_message(event, data), extra=extra)
+                logger.log(CONSOLE, self._create_message(event, data), extra=extra)
 
     def flush(self):
         if self.lastevent is None:
@@ -122,7 +122,7 @@ class SerialLoggingReporter:
         for source, logger in self.loggers.items():
             data = self.vt100_replace_cr_nl(self.bufs[source])
             if data:
-                logger.log(logging.CONSOLE, self._create_message(self.lastevent, data), extra=extra)
+                logger.log(CONSOLE, self._create_message(self.lastevent, data), extra=extra)
             self.bufs[source] = b""
 
 

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -22,7 +22,7 @@ assert(CONSOLE > logging.DEBUG)
 logging.addLevelName(CONSOLE, "CONSOLE")
 
 # Use composition instead of inheritance
-class StepFormatter:
+class StepFormatter(logging.Formatter):
     def __init__(self, *args, indent=True, color=None, parent=None, **kwargs):
         self.formatter = parent or logging.Formatter(*args, **kwargs)
         self.indent = indent

--- a/labgrid/py.typed
+++ b/labgrid/py.typed
@@ -1,0 +1,1 @@
+partial

--- a/labgrid/pytestplugin/__init__.py
+++ b/labgrid/pytestplugin/__init__.py
@@ -1,2 +1,13 @@
 from .fixtures import pytest_addoption, env, target, strategy
 from .hooks import pytest_configure, pytest_collection_modifyitems, pytest_cmdline_main, pytest_runtest_setup
+
+__all__ = [
+    "pytest_addoption",
+    "env",
+    "target",
+    "strategy",
+    "pytest_configure",
+    "pytest_collection_modifyitems",
+    "pytest_cmdline_main",
+    "pytest_runtest_setup",
+]

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -49,8 +49,8 @@ def pytest_cmdline_main(config: pytest.Config) -> None:
 
 
 def configure_pytest_logging(config: pytest.Config, plugin: LoggingPlugin) -> None:
-    if hasattr(plugin.log_cli_handler.formatter, "add_color_level"):
-        plugin.log_cli_handler.formatter.add_color_level(CONSOLE, "blue")
+    if (add_color_level := getattr(plugin.log_cli_handler.formatter, "add_color_level", None)) is not None:
+        add_color_level(CONSOLE, "blue")
     plugin.log_cli_handler.setFormatter(StepFormatter(
         color=config.option.lg_colored_steps,
         parent=plugin.log_cli_handler.formatter,

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -27,15 +27,23 @@ def pytest_cmdline_main(config: pytest.Config) -> None:
         print(f"current_level: {current_level}")
 
         if isinstance(current_level, str):
+            s = current_level.strip()
             try:
-                current_level = int(logging.getLevelName(current_level))
+                current_level_val: Optional[int] = int(s)
             except ValueError:
-                current_level = None
-        assert current_level is None or isinstance(current_level, int), "unexpected type of current log level"
+                v = logging.getLevelName(s.upper())
+                current_level_val = v if isinstance(v, int) else None
+        elif isinstance(current_level, int):
+            current_level_val = current_level
+        else:
+            current_level_val = None
+
+        assert current_level_val is None or isinstance(current_level_val, int), \
+            "unexpected type of current log level"
 
         # If no level was set previously (via ini or cli) or current_level is
         # less verbose than level, set to new level.
-        if current_level is None or level < current_level:
+        if current_level_val is None or level < current_level_val:
             config.option.log_cli_level = str(level)
 
     verbosity = config.getoption("verbose")

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -6,7 +6,7 @@ import pytest
 from .. import Environment
 from ..consoleloggingreporter import ConsoleLoggingReporter
 from ..util.helper import processwrapper
-from ..logging import StepFormatter, StepLogger
+from ..logging import CONSOLE, StepFormatter, StepLogger
 from ..exceptions import NoStrategyFoundError
 
 LABGRID_ENV_KEY = pytest.StashKey[Environment]()
@@ -38,14 +38,14 @@ def pytest_cmdline_main(config):
     if verbosity > 3: # enable with -vvvv
         set_cli_log_level(logging.DEBUG)
     elif verbosity > 2: # enable with -vvv
-        set_cli_log_level(logging.CONSOLE)
+        set_cli_log_level(CONSOLE)
     elif verbosity > 1: # enable with -vv
         set_cli_log_level(logging.INFO)
 
 
 def configure_pytest_logging(config, plugin):
     if hasattr(plugin.log_cli_handler.formatter, "add_color_level"):
-        plugin.log_cli_handler.formatter.add_color_level(logging.CONSOLE, "blue")
+        plugin.log_cli_handler.formatter.add_color_level(CONSOLE, "blue")
     plugin.log_cli_handler.setFormatter(StepFormatter(
         color=config.option.lg_colored_steps,
         parent=plugin.log_cli_handler.formatter,

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -46,7 +46,7 @@ from ..util import diff_dict, flat_dict, dump, atomic_replace, labgrid_version, 
 from ..util.proxy import proxymanager
 from ..util.helper import processwrapper
 from ..driver import Mode, ExecutionError
-from ..logging import basicConfig, StepLogger
+from ..logging import basicConfig, CONSOLE, StepLogger
 
 # This is a workround for the gRPC issue
 # https://github.com/grpc/grpc/issues/38679.
@@ -2105,7 +2105,7 @@ def main():
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)
     if args.verbose > 1:
-        logging.getLogger().setLevel(logging.CONSOLE)
+        logging.getLogger().setLevel(CONSOLE)
     if args.debug or args.verbose > 2:
         logging.getLogger().setLevel(logging.DEBUG)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,6 +13,8 @@ from labgrid.driver.fake import FakeConsoleDriver
 
 psutil = pytest.importorskip("psutil")
 
+pytest_plugins = ["pytester"]
+
 @pytest.fixture(scope="session")
 def curses_init():
     """ curses only reads the terminfo DB once on the first import, so make

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,84 +1,76 @@
 import os
+import pathlib
 
 import pexpect
 import pytest
 
 
 @pytest.fixture
-def short_env(tmpdir):
-    p = tmpdir.join("config.yaml")
-    p.write(
-        """
+def short_env(tmp_path: pathlib.Path) -> pathlib.Path:
+    p = tmp_path / 'config.yaml'
+    p.write_text("""
 targets:
   test1:
     drivers: {}
   test2:
     role: foo
     resources: {}
-"""
-    )
+  main:
+    drivers: {}
+""")
     return p
 
 
 @pytest.fixture
-def short_test(tmpdir):
-    t = tmpdir.join("test.py")
-    t.write(
-        """
+def short_test(tmp_path: pathlib.Path) -> pathlib.Path:
+    t = tmp_path / 'test.py'
+    t.write_text("""
 def test(env):
     assert True
-"""
-    )
+""")
     return t
 
 
-def test_config(short_test):
-    with pexpect.spawn(f"pytest --traceconfig {short_test}") as spawn:
+def test_config(short_test: pathlib.Path) -> None:
+    with pexpect.spawn(f'pytest --traceconfig {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         assert b'labgrid.pytestplugin' in spawn.before
         spawn.close()
         assert spawn.exitstatus == 0
 
 
-def test_env_fixture(short_env, short_test):
-    with pexpect.spawn(f"pytest --lg-env {short_env} {short_test}") as spawn:
+def test_env_fixture(short_env: pathlib.Path, short_test: pathlib.Path) -> None:
+    with pexpect.spawn(f'pytest --lg-env {short_env} {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
 
-def test_env_fixture_no_logging(short_env, short_test):
-    with pexpect.spawn(f"pytest -p no:logging --lg-env {short_env} {short_test}") as spawn:
+def test_env_fixture_no_logging(short_env: pathlib.Path, short_test: pathlib.Path) -> None:
+    with pexpect.spawn(f'pytest -p no:logging --lg-env {short_env} {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before
 
 
-def test_env_old_fixture(short_env, short_test):
-    with pexpect.spawn(f"pytest --env-config {short_env} {short_test}") as spawn:
-        spawn.expect("deprecated option --env-config")
-        spawn.expect(pexpect.EOF)
-        spawn.close()
-        assert spawn.exitstatus == 0
-
-
-def test_env_env_fixture(short_env, short_test):
+def test_env_env_fixture(short_env: pathlib.Path, short_test: pathlib.Path) -> None:
     env = os.environ.copy()
-    env["LG_ENV"] = short_env
-    with pexpect.spawn(f"pytest {short_test}") as spawn:
+    env['LG_ENV'] = str(short_env)
+    with pexpect.spawn(f'pytest {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
 
-def test_env_with_junit(short_env, short_test, tmpdir):
-    x = tmpdir.join("junit.xml")
-    with pexpect.spawn(f"pytest --junitxml={x} --lg-env {short_env} {short_test}") as spawn:
+def test_env_with_junit(short_env: pathlib.Path, short_test: pathlib.Path, tmp_path: pathlib.Path) -> None:
+    x = tmp_path / 'junit.xml'
+    with pexpect.spawn(f'pytest --junitxml={x} --lg-env {short_env} {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
-def test_help(short_test, monkeypatch):
+
+def test_help(short_test: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # argparse in Python >= 3.14 enables colored output by default,
     # disable that to allow argument assertions below
     monkeypatch.setenv("NO_COLOR", "1")
@@ -90,15 +82,15 @@ def test_help(short_test, monkeypatch):
         assert spawn.exitstatus == 0
 
 
-def test_help_coordinator(short_test):
-    with pexpect.spawn(f"pytest --lg-coordinator=127.0.0.1:20408 --help {short_test}") as spawn:
+def test_help_coordinator(short_test: pathlib.Path) -> None:
+    with pexpect.spawn(f'pytest --lg-coordinator=127.0.0.1:20408 --help {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
 
-def test_log_without_capturing(short_env, short_test, tmpdir):
-    with pexpect.spawn(f"pytest -vv -s --lg-env {short_env} {short_test}") as spawn:
+def test_log_without_capturing(short_env: pathlib.Path, short_test: pathlib.Path) -> None:
+    with pexpect.spawn(f'pytest -vv -s --lg-env {short_env} {short_test}') as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         print(spawn.before)

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -1,12 +1,14 @@
 import os
+
 import pexpect
 import pytest
+
 
 @pytest.fixture
 def short_env(tmpdir):
     p = tmpdir.join("config.yaml")
     p.write(
-"""
+        """
 targets:
   test1:
     drivers: {}
@@ -17,47 +19,61 @@ targets:
     )
     return p
 
+
 @pytest.fixture
 def short_test(tmpdir):
     t = tmpdir.join("test.py")
     t.write(
-"""
+        """
 def test(env):
     assert True
 """
     )
     return t
 
+
 def test_config(short_test):
-    with pexpect.spawn(f'pytest --traceconfig {short_test}') as spawn:
+    with pexpect.spawn(f"pytest --traceconfig {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         assert b'labgrid.pytestplugin' in spawn.before
         spawn.close()
         assert spawn.exitstatus == 0
 
+
 def test_env_fixture(short_env, short_test):
-    with pexpect.spawn(f'pytest --lg-env {short_env} {short_test}') as spawn:
+    with pexpect.spawn(f"pytest --lg-env {short_env} {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
+
 def test_env_fixture_no_logging(short_env, short_test):
-    with pexpect.spawn(f'pytest -p no:logging --lg-env {short_env} {short_test}') as spawn:
+    with pexpect.spawn(f"pytest -p no:logging --lg-env {short_env} {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before
 
-def test_env_env_fixture(short_env, short_test):
-    env=os.environ.copy()
-    env['LG_ENV'] = short_env
-    with pexpect.spawn(f'pytest {short_test}') as spawn:
+
+def test_env_old_fixture(short_env, short_test):
+    with pexpect.spawn(f"pytest --env-config {short_env} {short_test}") as spawn:
+        spawn.expect("deprecated option --env-config")
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
+
+def test_env_env_fixture(short_env, short_test):
+    env = os.environ.copy()
+    env["LG_ENV"] = short_env
+    with pexpect.spawn(f"pytest {short_test}") as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0
+
+
 def test_env_with_junit(short_env, short_test, tmpdir):
-    x = tmpdir.join('junit.xml')
-    with pexpect.spawn(f'pytest --junitxml={x} --lg-env {short_env} {short_test}') as spawn:
+    x = tmpdir.join("junit.xml")
+    with pexpect.spawn(f"pytest --junitxml={x} --lg-env {short_env} {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
@@ -67,20 +83,22 @@ def test_help(short_test, monkeypatch):
     # disable that to allow argument assertions below
     monkeypatch.setenv("NO_COLOR", "1")
 
-    with pexpect.spawn(f'pytest --help {short_test}') as spawn:
+    with pexpect.spawn(f"pytest --help {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         assert b'--lg-coordinator=COORDINATOR_ADDRESS' in spawn.before
         spawn.close()
         assert spawn.exitstatus == 0
 
+
 def test_help_coordinator(short_test):
-    with pexpect.spawn(f'pytest --lg-coordinator=127.0.0.1:20408 --help {short_test}') as spawn:
+    with pexpect.spawn(f"pytest --lg-coordinator=127.0.0.1:20408 --help {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         assert spawn.exitstatus == 0
 
+
 def test_log_without_capturing(short_env, short_test, tmpdir):
-    with pexpect.spawn(f'pytest -vv -s --lg-env {short_env} {short_test}') as spawn:
+    with pexpect.spawn(f"pytest -vv -s --lg-env {short_env} {short_test}") as spawn:
         spawn.expect(pexpect.EOF)
         spawn.close()
         print(spawn.before)


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

This PR introduces [Python typing hints](https://docs.python.org/3/library/typing.html) to the `pytest` specific components of the labgrid framework. These additions can be seen as initial steps towards enhancing the overall code navigation experience and improving the effectiveness of static code analysis tools.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested