### PR TITLE
github: enforce ruff format on labgrid.remote

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -51,6 +51,9 @@ jobs:
       run: |
         pylint --list-msgs-enabled
         pylint labgrid
+    - name: Format with ruff
+      run: |
+        ruff format --check --diff labgrid/remote/
     - name: Test with pytest
       run: |
         pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner -k "not test_docker_with_daemon"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,7 @@ dev = [
     "pytest-isort>=2.0.0",
     "pytest-mock>=3.6.1",
     "pylint>=3.0.0",
+    "ruff>=0.5.7",
 
     # GRPC Channelz support
     "grpcio-channelz>=1.64.1, <2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,6 +256,7 @@ exclude = [
   "venv",
   "envs",
   "dist",
+  "labgrid/remote/generated",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
**Description**
The `labgrid.remote` module was formatted with ruff in #1426. The gRPC changes are formatted correctly. Add ruff to the "dev" extra. Then enforce formatting on the module, but exclude generated code.

We can enforce formatting of more modules over time.

**Checklist**
- [x] PR has been tested