### PR TITLE
Add USB loaders for sunxi, tegra, samsung

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -823,6 +823,23 @@ Arguments:
 Used by:
   - `RKUSBDriver`_
 
+SamsungUSBLoader
+~~~~~~~~~~~~~~~~
+A :any:`SamsungUSBLoader` resource describes a USB device in the *Samsung
+loader state*.
+
+.. code-block:: yaml
+
+   SamsungUSBLoader:
+     match:
+       ID_PATH: pci-0000:03:00.2-usb-0:4.2.4
+
+Arguments:
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - `SamsungUSBDriver`_
+
 SunxiUSBLoader
 ~~~~~~~~~~~~~~
 A :any:`SunxiUSBLoader` resource describes a USB device in the *Allwinner
@@ -870,6 +887,11 @@ a remote computer.
 NetworkRKUSBLoader
 ~~~~~~~~~~~~~~~~~~
 A :any:`NetworkRKUSBLoader` describes an `RKUSBLoader`_ resource available on a
+remote computer.
+
+NetworkSamsungUSBLoader
+~~~~~~~~~~~~~~~~~~~~~~~
+A :any:`NetworkSamsungUSBLoader` describes a `SamsungUSBLoader`_ available on a
 remote computer.
 
 NetworkSunxiUSBLoader
@@ -2975,6 +2997,52 @@ Arguments:
 
  Tools:
   - sunxi-fel: Path to the 'sunxi-fel' tool (default is 'sunxi-fel')
+
+SamsungUSBDriver
+~~~~~~~~~~~~~~~~
+A :any:`SamsungUSBDriver` is used to upload an image into a device in the
+*Samsung loader state*. This is useful to bootstrap a bootloader onto a device.
+
+The load happens in three stages: BL1, SPL and U-Boot proper.
+
+Binds to:
+  loader:
+    - `SamsungUSBLoader`_
+    - `NetworkSamsungUSBLoader`_
+
+Implements:
+  - :any:`BootstrapProtocol`
+
+.. code-block:: yaml
+
+   targets:
+     main:
+       drivers:
+         SamsungUSBDriver:
+           bl1_loadaddr: 0x02021400
+           spl_loadaddr: 0x02023400
+           loadaddr: 0x43e00000
+   images:
+     bl1: '/home/dev/exynos/snow/u-boot.bl1.bin'
+   tools:
+     smdk-usbdl: '/home/dev/bin/smdk-usbdl'
+
+Arguments:
+  - bl1_loadaddr (int): Load address of the BL1 file. This depends on the SoC
+    spl_load_addr (int): Load address of SPL. The easiest way to find this value
+    is to check the *CONFIG_SPL_TEXT_BASE* value in U-Boot
+  - loadaddr (int): address to use when loading U-Boot. This depends on the
+    SoC being used. The easiest way to find this value is to check the
+    *CONFIG_TEXT_BASE* value in U-Boot
+  - image (str): optional, reference to the images key for the image to load
+    when no filename is given
+  - bl1_image (str): optional, images key holding the BL1 file (default 'bl1')
+
+ Images:
+  - bl1: the BL1 file which sets up the SoC
+
+ Tools:
+  - smdk-usbdl: Path to the 'smdk-usbdl' tool (default is 'smdk-usbdl')
 
 TegraUSBDriver
 ~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -840,6 +840,23 @@ Arguments:
 Used by:
   - `SunxiUSBDriver`_
 
+TegraUSBLoader
+~~~~~~~~~~~~~~
+A :any:`TegraUSBLoader` resource describes a USB device in the *Tegra
+loader state*.
+
+.. code-block:: yaml
+
+   TegraUSBLoader:
+     match:
+       'ID_PATH': 'pci-0000:03:00.2-usb-0:3.4.1'
+
+Arguments:
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - `TegraUSBDriver`_
+
 NetworkMXSUSBLoader
 ~~~~~~~~~~~~~~~~~~~
 A :any:`NetworkMXSUSBLoader` describes an `MXSUSBLoader`_ resource available on
@@ -858,6 +875,11 @@ remote computer.
 NetworkSunxiUSBLoader
 ~~~~~~~~~~~~~~~~~~~~~
 A :any:`NetworkSunxiUSBLoader` describes a `SunxiUSBLoader`_ available on a
+remote computer.
+
+NetworkTegraUSBLoader
+~~~~~~~~~~~~~~~~~~~~~
+A :any:`NetworkTegraUSBLoader` describes a `TegraUSBLoader`_ available on a
 remote computer.
 
 AndroidUSBFastboot
@@ -2953,6 +2975,49 @@ Arguments:
 
  Tools:
   - sunxi-fel: Path to the 'sunxi-fel' tool (default is 'sunxi-fel')
+
+TegraUSBDriver
+~~~~~~~~~~~~~~
+A :any:`TegraUSBDriver` is used to upload an image into a device in the
+*Nvidia Tegra loader state*. This is useful to bootstrap a bootloader onto a
+device.
+
+The load happens in a single stage, with the bootloader proper (e.g. U-Boot)
+sent along with a *BCT* (Binary Control Tool) configuration file which
+contains memory timings, etc.
+
+Binds to:
+  loader:
+    - `TegraUSBLoader`_
+    - `NetworkTegraUSBLoader`_
+
+Implements:
+  - :any:`BootstrapProtocol`
+
+.. code-block:: yaml
+
+   targets:
+     main:
+       drivers:
+         TegraUSBDriver:
+           loadaddr: 0x80108000
+   images:
+     bct: '/home/dev/tegra124/nvidia/norrin/PM370_Hynix_2GB_H5TC4G63AFR_PBA_924MHz_01212014.bct'
+   tools:
+     tegrarcm: '/home/dev/bin/tegrarcm'
+
+Arguments:
+  - loadaddr (int): address to use when loading U-Boot. This depends on the
+    SoC being used. The easiest way to find this value is to check the
+    *CONFIG_TEXT_BASE* value in U-Boot
+  - image (str): optional, reference to the images key for the image to load
+    when no filename is given
+
+ Images:
+  - bct: reference to the images key for the BCT (configuration file)
+
+ Tools:
+  - tegrarcm: Path to the 'tegrarcm' tool (default is 'tegrarcm')
 
 UUUDriver
 ~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -823,6 +823,23 @@ Arguments:
 Used by:
   - `RKUSBDriver`_
 
+SunxiUSBLoader
+~~~~~~~~~~~~~~
+A :any:`SunxiUSBLoader` resource describes a USB device in the *Allwinner
+loader state*.
+
+.. code-block:: yaml
+
+   SunxiUSBLoader:
+     match:
+       'ID_PATH': 'pci-0000:00:14.0-usb-0:10.4.4:1.0'
+
+Arguments:
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - `SunxiUSBDriver`_
+
 NetworkMXSUSBLoader
 ~~~~~~~~~~~~~~~~~~~
 A :any:`NetworkMXSUSBLoader` describes an `MXSUSBLoader`_ resource available on
@@ -836,6 +853,11 @@ a remote computer.
 NetworkRKUSBLoader
 ~~~~~~~~~~~~~~~~~~
 A :any:`NetworkRKUSBLoader` describes an `RKUSBLoader`_ resource available on a
+remote computer.
+
+NetworkSunxiUSBLoader
+~~~~~~~~~~~~~~~~~~~~~
+A :any:`NetworkSunxiUSBLoader` describes a `SunxiUSBLoader`_ available on a
 remote computer.
 
 AndroidUSBFastboot
@@ -2892,6 +2914,45 @@ Arguments:
     of an image to bootstrap onto the target
   - usb_loader (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
     of a first-stage bootloader image to write
+
+SunxiUSBDriver
+~~~~~~~~~~~~~~
+A :any:`SunxiUSBDriver` is used to upload an image into a device in the
+*Allwinner loader state*. This is useful to bootstrap a bootloader onto a
+device.
+
+Note that sunxi is the common name for Allwinner SoCs, since they have product
+codes like sun50i, sun7i, etc.
+
+The load happens in two stages, first SPL and then U-Boot proper.
+
+Binds to:
+  loader:
+    - `SunxiUSBLoader`_
+    - `NetworkSunxiUSBLoader`_
+
+Implements:
+  - :any:`BootstrapProtocol`
+
+.. code-block:: yaml
+
+   targets:
+     main:
+       drivers:
+         SunxiUSBDriver:
+           loadaddr: 0x4a000000
+   tools:
+     sunxi-fel: '/home/dev/bin/sunxi-fel'
+
+Arguments:
+  - loadaddr (int): address to use when loading U-Boot. This depends on the
+    SoC being used. The easiest way to find this value is to check the
+    *CONFIG_TEXT_BASE* value in U-Boot
+  - image (str): optional, reference to the images key for the image to load
+    when no filename is given
+
+ Tools:
+  - sunxi-fel: Path to the 'sunxi-fel' tool (default is 'sunxi-fel')
 
 UUUDriver
 ~~~~~~~~~

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -16,7 +16,8 @@ from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
                          DigitalOutputPowerDriver, YKUSHPowerDriver, \
                          USBPowerDriver, SiSPMPowerDriver, NetworkPowerDriver, \
                          PDUDaemonDriver
-from .usbloader import MXSUSBDriver, IMXUSBDriver, BDIMXUSBDriver, RKUSBDriver, UUUDriver
+from .usbloader import MXSUSBDriver, IMXUSBDriver, BDIMXUSBDriver, \
+                       RKUSBDriver, SunxiUSBDriver, UUUDriver
 from .usbsdmuxdriver import USBSDMuxDriver
 from .usbsdwiredriver import USBSDWireDriver
 from .usbsdwire3driver import USBSDWire3Driver

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -348,4 +348,65 @@ class TegraUSBDriver(Driver, BootstrapProtocol):
     @Driver.check_active
     @step()
     def execute(self):
+        """Nothing to do: the boot ROM runs each piece as it arrives"""
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class SamsungUSBDriver(Driver, BootstrapProtocol):
+    bindings = {
+        'loader': {'SamsungUSBLoader', 'NetworkSamsungUSBLoader'},
+    }
+
+    bl1_loadaddr = attr.ib(validator=attr.validators.instance_of(int))
+    spl_loadaddr = attr.ib(validator=attr.validators.instance_of(int))
+    loadaddr = attr.ib(validator=attr.validators.instance_of(int))
+    image = attr.ib(default=None)
+    bl1_image = attr.ib(default='bl1',
+                        validator=attr.validators.instance_of(str))
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        # FIXME make sure we always have an environment or config
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('smdk-usbdl')
+        else:
+            self.tool = 'smdk-usbdl'
+
+    def on_activate(self):
         pass
+
+    def on_deactivate(self):
+        pass
+
+    @Driver.check_active
+    @step(args=['filename'])
+    def load(self, filename=None, phase=None):
+        if filename is None and phase == 'bl1':
+            filename = self.target.env.config.get_image_path(self.bl1_image)
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        mf = ManagedFile(filename, self.loader)
+        mf.sync_to_resource()
+
+        if phase == 'bl1':
+            addr = self.bl1_loadaddr
+        elif phase == 'spl':
+            addr = self.spl_loadaddr
+        elif phase in (None, 'u-boot'):
+            addr = self.loadaddr
+        else:
+            raise ValueError(f"Unknown phase '{phase}'")
+        pathname = mf.get_remote_path()
+
+        args = [self.tool, '-a', f'{addr:x}',
+                '-b', f'{self.loader.busnum:03d}',
+                '-d', f'{self.loader.devnum:03d}',
+                '-f', pathname]
+
+        processwrapper.check_output(self.loader.command_prefix + args)
+
+    @Driver.check_active
+    @step()
+    def execute(self):
+        """Nothing to do: the boot ROM runs each piece as it arrives"""

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -297,3 +297,55 @@ class SunxiUSBDriver(Driver, BootstrapProtocol):
     def execute(self):
         """Start executing the loaded image at the load address"""
         self._run_tool('exe', '%#x' % self.loadaddr)
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class TegraUSBDriver(Driver, BootstrapProtocol):
+    bindings = {
+        'loader': {'TegraUSBLoader', 'NetworkTegraUSBLoader'},
+    }
+
+    loadaddr = attr.ib(validator=attr.validators.instance_of(int))
+    image = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        # FIXME make sure we always have an environment or config
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('tegrarcm')
+        else:
+            self.tool = 'tegrarcm'
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    @Driver.check_active
+    @step(args=['filename'])
+    def load(self, filename=None, phase=None):
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        mf = ManagedFile(filename, self.loader)
+        mf.sync_to_resource()
+
+        pathname = mf.get_remote_path()
+        bct = ManagedFile(self.target.env.config.get_image_path('bct'),
+                          self.loader)
+        bct.sync_to_resource()
+        args = [self.tool, '--bct=' + bct.get_remote_path(),
+               f'--bootloader={pathname}',
+               f'--loadaddr={self.loadaddr:#08x}',
+               '--usb-port-path', self.loader.path]
+
+        processwrapper.check_output(
+            self.loader.command_prefix + args,
+            print_on_silent_log=True
+        )
+
+    @Driver.check_active
+    @step()
+    def execute(self):
+        pass

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -238,3 +238,62 @@ class BDIMXUSBDriver(Driver, BootstrapProtocol):
             ],
             print_on_silent_log=True
         )
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class SunxiUSBDriver(Driver, BootstrapProtocol):
+    bindings = {
+        "loader": {"SunxiUSBLoader", "NetworkSunxiUSBLoader"},
+    }
+
+    loadaddr = attr.ib(validator=attr.validators.instance_of(int))
+    image = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        # FIXME make sure we always have an environment or config
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('sunxi-fel')
+        else:
+            self.tool = 'sunxi-fel'
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    def _run_tool(self, *part):
+        """Run sunxi-fel against the loader's USB device
+
+        Args:
+            part: Arguments to pass to the tool
+        """
+        args = ['-d', '%s:%s' % (self.loader.busnum, self.loader.devnum)]
+        cmd = ['sunxi-fel'] + args + list(part)
+
+        processwrapper.check_output(
+            self.loader.command_prefix + cmd,
+            print_on_silent_log=True
+        )
+
+    @Driver.check_active
+    @step(args=['filename', 'phase'])
+    def load(self, filename=None, phase=None):
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        mf = ManagedFile(filename, self.loader)
+        mf.sync_to_resource()
+
+        pathname = mf.get_remote_path()
+        if phase == 'spl':
+            self._run_tool('spl', pathname)
+        else:
+            self._run_tool('write', '%#x' % self.loadaddr, pathname)
+
+    @Driver.check_active
+    @step()
+    def execute(self):
+        """Start executing the loaded image at the load address"""
+        self._run_tool('exe', '%#x' % self.loadaddr)

--- a/labgrid/protocol/bootstrapprotocol.py
+++ b/labgrid/protocol/bootstrapprotocol.py
@@ -3,5 +3,11 @@ import abc
 
 class BootstrapProtocol(abc.ABC):
     @abc.abstractmethod
-    def load(self, filename: str):
+    def load(self, filename: str, phase=None):
+        """Load a file into the DUT
+
+        Args:
+            filename (str): Filename to load
+            phase (str): Loading phase, e.g. 'bl1'
+        """
         raise NotImplementedError

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1175,6 +1175,7 @@ class ClientSession:
             NetworkMXSUSBLoader,
             NetworkIMXUSBLoader,
             NetworkRKUSBLoader,
+            NetworkSunxiUSBLoader,
             NetworkAlteraUSBBlaster,
         )
         from ..driver import OpenOCDDriver
@@ -1201,6 +1202,9 @@ class ClientSession:
                     drv.interface.timeout = self.args.wait
                 elif isinstance(resource, NetworkRKUSBLoader):
                     drv = self._get_driver_or_new(target, "RKUSBDriver", activate=False, name=name)
+                    drv.loader.timeout = self.args.wait
+                elif isinstance(resource, NetworkSunxiUSBLoader):
+                    drv = self._get_driver_or_new(target, "SunxiUSBDriver", activate=False, name=name)
                     drv.loader.timeout = self.args.wait
                 if drv:
                     break

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -575,6 +575,7 @@ exports["DFUDevice"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
 exports["MXSUSBLoader"] = USBGenericExport
 exports["RKUSBLoader"] = USBGenericExport
+exports["SunxiUSBLoader"] = USBGenericExport
 exports["AlteraUSBBlaster"] = USBGenericExport
 exports["SigrokUSBDevice"] = USBSigrokExport
 exports["SigrokUSBSerialDevice"] = USBSigrokExport

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -576,6 +576,7 @@ exports["IMXUSBLoader"] = USBGenericExport
 exports["MXSUSBLoader"] = USBGenericExport
 exports["RKUSBLoader"] = USBGenericExport
 exports["SunxiUSBLoader"] = USBGenericExport
+exports["TegraUSBLoader"] = USBGenericExport
 exports["AlteraUSBBlaster"] = USBGenericExport
 exports["SigrokUSBDevice"] = USBSigrokExport
 exports["SigrokUSBSerialDevice"] = USBSigrokExport

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -575,6 +575,7 @@ exports["DFUDevice"] = USBGenericExport
 exports["IMXUSBLoader"] = USBGenericExport
 exports["MXSUSBLoader"] = USBGenericExport
 exports["RKUSBLoader"] = USBGenericExport
+exports["SamsungUSBLoader"] = USBGenericExport
 exports["SunxiUSBLoader"] = USBGenericExport
 exports["TegraUSBLoader"] = USBGenericExport
 exports["AlteraUSBBlaster"] = USBGenericExport

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -18,6 +18,7 @@ from .udev import (
     MatchedSysfsGPIO,
     MXSUSBLoader,
     RKUSBLoader,
+    SamsungUSBLoader,
     SunxiUSBLoader,
     TegraUSBLoader,
     SiSPMPowerPort,

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -18,6 +18,7 @@ from .udev import (
     MatchedSysfsGPIO,
     MXSUSBLoader,
     RKUSBLoader,
+    SunxiUSBLoader,
     SiSPMPowerPort,
     SigrokUSBDevice,
     SigrokUSBSerialDevice,

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -19,6 +19,7 @@ from .udev import (
     MXSUSBLoader,
     RKUSBLoader,
     SunxiUSBLoader,
+    TegraUSBLoader,
     SiSPMPowerPort,
     SigrokUSBDevice,
     SigrokUSBSerialDevice,

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -176,6 +176,14 @@ class NetworkSunxiUSBLoader(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkTegraUSBLoader(RemoteUSBResource):
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkAlteraUSBBlaster(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -168,6 +168,14 @@ class NetworkRKUSBLoader(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkSamsungUSBLoader(RemoteUSBResource):
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkSunxiUSBLoader(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -168,6 +168,14 @@ class NetworkRKUSBLoader(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkSunxiUSBLoader(RemoteUSBResource):
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkAlteraUSBBlaster(RemoteUSBResource):
     def __attrs_post_init__(self):
         self.timeout = 10.0

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -17,6 +17,7 @@ from .udev import (
     USBSDWire3Device,
     AlteraUSBBlaster,
     RKUSBLoader,
+    SunxiUSBLoader,
     USBNetworkInterface,
     SiSPMPowerPort,
     USBAudioInput,
@@ -52,6 +53,7 @@ class Suggester:
         self.resources.append(USBSDWire3Device(**args))
         self.resources.append(AlteraUSBBlaster(**args))
         self.resources.append(RKUSBLoader(**args))
+        self.resources.append(SunxiUSBLoader(**args))
         self.resources.append(USBNetworkInterface(**args))
         self.resources.append(SiSPMPowerPort(**args))
         self.resources.append(USBAudioInput(**args))

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -18,6 +18,7 @@ from .udev import (
     AlteraUSBBlaster,
     RKUSBLoader,
     SunxiUSBLoader,
+    TegraUSBLoader,
     USBNetworkInterface,
     SiSPMPowerPort,
     USBAudioInput,
@@ -54,6 +55,7 @@ class Suggester:
         self.resources.append(AlteraUSBBlaster(**args))
         self.resources.append(RKUSBLoader(**args))
         self.resources.append(SunxiUSBLoader(**args))
+        self.resources.append(TegraUSBLoader(**args))
         self.resources.append(USBNetworkInterface(**args))
         self.resources.append(SiSPMPowerPort(**args))
         self.resources.append(USBAudioInput(**args))

--- a/labgrid/resource/suggest.py
+++ b/labgrid/resource/suggest.py
@@ -17,6 +17,7 @@ from .udev import (
     USBSDWire3Device,
     AlteraUSBBlaster,
     RKUSBLoader,
+    SamsungUSBLoader,
     SunxiUSBLoader,
     TegraUSBLoader,
     USBNetworkInterface,
@@ -54,6 +55,7 @@ class Suggester:
         self.resources.append(USBSDWire3Device(**args))
         self.resources.append(AlteraUSBBlaster(**args))
         self.resources.append(RKUSBLoader(**args))
+        self.resources.append(SamsungUSBLoader(**args))
         self.resources.append(SunxiUSBLoader(**args))
         self.resources.append(TegraUSBLoader(**args))
         self.resources.append(USBNetworkInterface(**args))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -360,6 +360,17 @@ class MXSUSBLoader(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class SunxiUSBLoader(USBResource):
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [("1f3a", "efe8")]:
+            return False
+
+        return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class AndroidUSBFastboot(USBResource):
     usb_vendor_id = attr.ib(default='1d6b', validator=attr.validators.instance_of(str))
     usb_product_id = attr.ib(default='0104', validator=attr.validators.instance_of(str))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -360,6 +360,17 @@ class MXSUSBLoader(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class SamsungUSBLoader(USBResource):
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [("04e8", "1234")]:
+            return False
+
+        return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class SunxiUSBLoader(USBResource):
     def filter_match(self, device):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -371,6 +371,18 @@ class SunxiUSBLoader(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class TegraUSBLoader(USBResource):
+    def filter_match(self, device):
+        match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
+
+        if match not in [("0955", "7340"), ("0955", "7140"),
+                         ("0955", "7740")]:
+            return False
+
+        return super().filter_match(device)
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class AndroidUSBFastboot(USBResource):
     usb_vendor_id = attr.ib(default='1d6b', validator=attr.validators.instance_of(str))
     usb_product_id = attr.ib(default='0104', validator=attr.validators.instance_of(str))

--- a/tests/test_usbloader.py
+++ b/tests/test_usbloader.py
@@ -1,0 +1,67 @@
+import pytest
+
+from labgrid.resource.udev import SunxiUSBLoader
+from labgrid.resource.remote import NetworkSunxiUSBLoader
+from labgrid.driver.usbloader import SunxiUSBDriver
+
+
+class FakeDevice:
+    """Fake USB device to use for testing"""
+    subsystem = 'usb'
+    device_type = 'usb_device'
+    properties= {'BUSNUM': 1, 'DEVNUM': 2}
+
+
+def test_sunxiusb_network_create(target):
+    r = NetworkSunxiUSBLoader(target, busnum=1, devnum=2, path='a/path',
+                                vendor_id=1234, model_id=5678, name=None,
+                                host='localhost')
+    assert isinstance(r, NetworkSunxiUSBLoader)
+    assert r.busnum == 1
+    assert r.devnum == 2
+    assert r.path == 'a/path'
+    assert r.vendor_id == 1234
+    assert r.model_id == 5678
+    assert r.name is None
+    d = SunxiUSBDriver(target, loadaddr=0x100, name=None)
+    assert isinstance(d, SunxiUSBDriver)
+    assert d.loadaddr == 0x100
+    assert d.name is None
+
+
+def test_sunxiusb_driver_create(target):
+    r = SunxiUSBLoader(target, name=None)
+    assert isinstance(r, SunxiUSBLoader)
+
+    d = SunxiUSBDriver(target, loadaddr=0x100, name=None)
+    assert isinstance(d, SunxiUSBDriver)
+
+
+def test_sunxiusb_driver_load(target, mocker, tmpdir):
+    r = SunxiUSBLoader(target, name=None)
+    assert isinstance(r, SunxiUSBLoader)
+
+    d = SunxiUSBDriver(target, loadaddr=0x100, name=None)
+    r.avail = True
+    dev = FakeDevice()
+    r.device = dev
+    target.activate(d)
+
+    spl = tmpdir.join('spl').strpath
+    with open(spl, 'wb') as outf:
+        outf.write(b'spl image')
+
+    main = tmpdir.join('spl').strpath
+    with open(spl, 'wb') as outf:
+        outf.write(b'main image')
+
+    pwrap = mocker.patch('labgrid.driver.usbloader.processwrapper')
+
+    d.load(spl, phase='spl')
+    pwrap.check_output.assert_called_once_with(
+        ['sunxi-fel', '-d', '1:2', 'spl', spl], print_on_silent_log=True)
+
+    pwrap.reset_mock()
+    d.load(main)
+    pwrap.check_output.assert_called_once_with(
+        ['sunxi-fel', '-d', '1:2', 'write', '0x100', main], print_on_silent_log=True)

--- a/tests/test_usbloader.py
+++ b/tests/test_usbloader.py
@@ -1,8 +1,8 @@
 import pytest
 
-from labgrid.resource.udev import SunxiUSBLoader
-from labgrid.resource.remote import NetworkSunxiUSBLoader
-from labgrid.driver.usbloader import SunxiUSBDriver
+from labgrid.resource.udev import SunxiUSBLoader, TegraUSBLoader
+from labgrid.resource.remote import NetworkSunxiUSBLoader, NetworkTegraUSBLoader
+from labgrid.driver.usbloader import SunxiUSBDriver, TegraUSBDriver
 
 
 class FakeDevice:
@@ -10,6 +10,7 @@ class FakeDevice:
     subsystem = 'usb'
     device_type = 'usb_device'
     properties= {'BUSNUM': 1, 'DEVNUM': 2}
+    sys_name = '3/4'
 
 
 def test_sunxiusb_network_create(target):
@@ -65,3 +66,61 @@ def test_sunxiusb_driver_load(target, mocker, tmpdir):
     d.load(main)
     pwrap.check_output.assert_called_once_with(
         ['sunxi-fel', '-d', '1:2', 'write', '0x100', main], print_on_silent_log=True)
+
+
+def test_tegrausb_network_create(target):
+    r = NetworkTegraUSBLoader(target, busnum=1, devnum=2, path='a/path',
+                                vendor_id=1234, model_id=5678, name=None,
+                                host='localhost')
+    assert isinstance(r, NetworkTegraUSBLoader)
+    assert r.busnum == 1
+    assert r.devnum == 2
+    assert r.path == 'a/path'
+    assert r.vendor_id == 1234
+    assert r.model_id == 5678
+    assert r.name is None
+    d = TegraUSBDriver(target, loadaddr=0x100, name=None)
+    assert isinstance(d, TegraUSBDriver)
+    assert d.loadaddr == 0x100
+    assert d.name is None
+
+
+def test_tegrausb_driver_create(target):
+    r = TegraUSBLoader(target, name=None)
+    assert isinstance(r, TegraUSBLoader)
+
+    d = TegraUSBDriver(target, loadaddr=0x100, name=None)
+    assert isinstance(d, TegraUSBDriver)
+
+
+def test_tegrausb_driver_load(target, mocker, tmpdir):
+    r = TegraUSBLoader(target, name=None)
+    assert isinstance(r, TegraUSBLoader)
+
+    d = TegraUSBDriver(target, loadaddr=0x100, name=None)
+    r.avail = True
+    dev = FakeDevice()
+    r.device = dev
+    target.activate(d)
+
+    main = tmpdir.join('boot').strpath
+    with open(main, 'wb') as outf:
+        outf.write(b'main image')
+
+    # The BCT filename comes from the env's 'images:' section, not a driver
+    # arg. It is a real file here since it is pushed with ManagedFile
+    bct = tmpdir.join('the.bct').strpath
+    with open(bct, 'wb') as outf:
+        outf.write(b'bct data')
+    target.env = mocker.MagicMock()
+    target.env.config.get_image_path.return_value = bct
+
+    pwrap = mocker.patch('labgrid.driver.usbloader.processwrapper')
+
+    pwrap.reset_mock()
+    d.load(main)
+    target.env.config.get_image_path.assert_called_once_with('bct')
+    pwrap.check_output.assert_called_once_with(
+        ['tegrarcm', f'--bct={bct}', f'--bootloader={main}',
+         '--loadaddr=0x000100', '--usb-port-path', '3/4'],
+        print_on_silent_log=True)

--- a/tests/test_usbloader.py
+++ b/tests/test_usbloader.py
@@ -1,8 +1,12 @@
 import pytest
 
-from labgrid.resource.udev import SunxiUSBLoader, TegraUSBLoader
-from labgrid.resource.remote import NetworkSunxiUSBLoader, NetworkTegraUSBLoader
-from labgrid.driver.usbloader import SunxiUSBDriver, TegraUSBDriver
+from labgrid.resource.udev import SamsungUSBLoader, SunxiUSBLoader
+from labgrid.resource.udev import TegraUSBLoader
+from labgrid.resource.remote import NetworkSamsungUSBLoader
+from labgrid.resource.remote import NetworkSunxiUSBLoader
+from labgrid.resource.remote import NetworkTegraUSBLoader
+from labgrid.driver.usbloader import SamsungUSBDriver, SunxiUSBDriver
+from labgrid.driver.usbloader import TegraUSBDriver
 
 
 class FakeDevice:
@@ -124,3 +128,59 @@ def test_tegrausb_driver_load(target, mocker, tmpdir):
         ['tegrarcm', f'--bct={bct}', f'--bootloader={main}',
          '--loadaddr=0x000100', '--usb-port-path', '3/4'],
         print_on_silent_log=True)
+
+
+def test_samsungusb_network_create(target):
+    r = NetworkSamsungUSBLoader(target, busnum=1, devnum=2, path='a/path',
+                                vendor_id=1234, model_id=5678, name=None,
+                                host='localhost')
+    assert isinstance(r, NetworkSamsungUSBLoader)
+    assert r.busnum == 1
+    assert r.devnum == 2
+    assert r.path == 'a/path'
+    assert r.vendor_id == 1234
+    assert r.model_id == 5678
+    assert r.name is None
+    d = SamsungUSBDriver(target, bl1_loadaddr=0x100,
+                         spl_loadaddr=0x200, loadaddr=0x300, name=None)
+    assert isinstance(d, SamsungUSBDriver)
+    assert d.bl1_loadaddr == 0x100
+    assert d.spl_loadaddr == 0x200
+    assert d.loadaddr == 0x300
+    assert d.name is None
+
+
+def test_samsungusb_driver_create(target):
+    r = SamsungUSBLoader(target, name=None)
+    assert isinstance(r, SamsungUSBLoader)
+
+    d = SamsungUSBDriver(target, bl1_loadaddr=0x100,
+                         spl_loadaddr=0x200, loadaddr=0x300, name=None)
+    assert isinstance(d, SamsungUSBDriver)
+
+
+def test_samsungusb_driver_load(target, mocker, tmpdir):
+    r = SamsungUSBLoader(target, name=None)
+    assert isinstance(r, SamsungUSBLoader)
+
+    bl1 = tmpdir.join('bl1').strpath
+    d = SamsungUSBDriver(target, bl1_loadaddr=0x100,
+                         spl_loadaddr=0x200, loadaddr=0x300, name=None)
+    r.avail = True
+    dev = FakeDevice()
+    r.device = dev
+    target.activate(d)
+
+    with open(bl1, 'wb') as outf:
+        outf.write(b'blah')
+
+    # The BL1 filename comes from the env's 'images:' section, not a driver arg
+    target.env = mocker.MagicMock()
+    target.env.config.get_image_path.return_value = bl1
+
+    pwrap = mocker.patch('labgrid.driver.usbloader.processwrapper')
+
+    d.load(phase='bl1')
+    target.env.config.get_image_path.assert_called_once_with('bl1')
+    pwrap.check_output.assert_called_once_with(
+        ['smdk-usbdl', '-a', '100', '-b', '001', '-d', '002', '-f', bl1])


### PR DESCRIPTION
This adds USB loaders for three different SoCs. The Tegra loader is fairly straightfoward and similar to iMX, so it can use the same protocol.

For Allwinner (sunxi) and Samsung, the loading happens in 2-3 phases, so a new 'phase' parameter is added to the protocol. This allows USB loading to work correctly on these boards, sending an initial BL1 image (in the case of Samsung), then U-Boot SPL and U-Boot proper.

This has been tested on:
- snow (exynos5250)
- Linksprite_pcDuino3 (sunxi)
- nyan-big (Tegra124-based Chromebook)


- [X] Documentation for the feature
- [ ] Tests for the feature 
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested
