### PR TITLE
driver: Add driver for Dediprog SPI-flash emulator

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1333,6 +1333,34 @@ NetworkDediprogFlasher
 A :any:`NetworkDediprogFlasher` describes a `DediprogFlasher`_ resource
 available on a remote computer.
 
+SFEmulator
+~~~~~~~~~~
+A :any:`SFEmulator` resource is used to configure the parameters for a
+SPI-flash emulator. This allows a DUT's SPI flash to be replaced or
+overridden with a USB-connected emulator, which is much faster to load than
+reprogramming the DUT's actual SPI flash.
+
+So far only the Dediprog EM100-PRO is supported, so there is no 'model' property
+defined.
+
+Arguments:
+  - serial (str): Serial number of the device
+  - chip (str): SPI-flash chip to emulate
+
+.. code-block:: yaml
+
+  SFEmulator:
+    serial: DP025143
+    chip: W25Q64CV
+
+Used by:
+  - `SFEmulatorDriver`_
+
+NetworkSFEmulator
+~~~~~~~~~~~~~~~~~
+A :any:`NetworkSFEmulator` describes a `SFEmulator`_ available on a
+remote computer.
+
 XenaManager
 ~~~~~~~~~~~
 A :any:`XenaManager` resource describes a *Xena Manager* instance which is the
@@ -3489,6 +3517,15 @@ The DediprogFlashDriver allows using DediprogFlasher dpcmd to flash or erase SPI
 devices. It is assumed that the device flashing is an exporter wired, via a
 *Dediprog SF100 SPI NOR Flash Programmer* for instance, to the device being
 flashed.
+
+SFEmulatorDriver
+~~~~~~~~~~~~~~~~
+The :any:`SFEmulatorDriver` is used to emulate a SPI-flash device on the DUT.
+
+Binds to:
+  flasher:
+    - `SFEmulator`_
+    - `NetworkSFEmulator`_
 
 XenaDriver
 ~~~~~~~~~~

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -54,3 +54,4 @@ from .laadriver import LAASerialDriver, LAAPowerDriver, \
                        LAAUSBGadgetMassStorageDriver, LAAUSBDriver, \
                        LAAButtonDriver, LAALedDriver, LAATempDriver, LAAWattDriver, \
                        LAAProviderDriver
+from .sfemulatordriver import SFEmulatorDriver

--- a/labgrid/driver/sfemulatordriver.py
+++ b/labgrid/driver/sfemulatordriver.py
@@ -1,0 +1,50 @@
+import attr
+from .common import Driver
+from ..factory import target_factory
+from ..step import step
+from ..util.helper import processwrapper
+from ..util.managedfile import ManagedFile
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class SFEmulatorDriver(Driver):
+    """Provides access to em100 features
+
+    Args:
+        bindings (dict): driver to use with
+    """
+    bindings = {
+        'emul': {'SFEmulator', 'NetworkSFEmulator'},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        if self.target.env:
+            self.tool = self.target.env.config.get_tool('em100')
+        else:
+            self.tool = 'em100'
+
+    @Driver.check_active
+    @step(title='write_image', args=['filename'])
+    def write_image(self, filename):
+        '''Write an image to the SPI-flash emulator
+
+        Args:
+            filename (str): Filename to write
+        '''
+        mf = ManagedFile(filename, self.emul)
+        mf.sync_to_resource()
+        cmd = self.emul.command_prefix + [
+            self.tool,
+            '-x', str(self.emul.serial),
+            '-s',
+            '-p', 'LOW',
+            '-c', self.emul.chip,
+            '-d', mf.get_remote_path(),
+            '-r',
+        ]
+
+        processwrapper.check_output(cmd)
+
+    def __str__(self):
+        return f'SFEmulatorDriver({self.emul.serial})'

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -808,6 +808,26 @@ class YKUSHPowerPortExport(ResourceExport):
 exports["YKUSHPowerPort"] = YKUSHPowerPortExport
 
 
+@attr.s(eq=False)
+class SFEmulatorExport(ResourceExport):
+    """ResourceExport for SFEmulator devices"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        local_cls_name = self.cls
+        self.data["cls"] = f"Network{local_cls_name}"
+        from ..resource import sfemulator
+
+        local_cls = getattr(sfemulator, local_cls_name)
+        self.local = local_cls(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        return {"host": self.host, **self.local_params}
+
+
+exports["SFEmulator"] = SFEmulatorExport
+
+
 class Exporter:
     def __init__(self, config) -> None:
         """Set up internal datastructures on successful connection:

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -52,3 +52,4 @@ from .eth008 import Eth008DigitalOutput
 from .laa import LAASerialPort, LAAPowerPort, LAAUSBGadgetMassStorage, \
                  LAAUSBPort, LAAButtonPort, \
                  LAALed, LAATempSensor, LAAWattMeter, LAAProvider
+from .sfemulator import SFEmulator, NetworkSFEmulator

--- a/labgrid/resource/sfemulator.py
+++ b/labgrid/resource/sfemulator.py
@@ -1,0 +1,32 @@
+import attr
+
+from ..factory import target_factory
+from .common import NetworkResource, Resource
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class SFEmulator(Resource):
+    """"This resource describes a Dediprog em100 SPI-Flash Emulator
+
+    This provides serial consoles along with reset control
+
+    Args:
+        serial (str): serial number of the em100 device, e.g. DP025143
+        chip (str): SPI-flash chip to emulate, e.g. W25Q64CV
+    """
+    serial = attr.ib(validator=attr.validators.instance_of(str))
+    chip = attr.ib(validator=attr.validators.instance_of(str))
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkSFEmulator(NetworkResource):
+    """"This resource describes a remote Dediprog em100 SPI-Flash Emulator
+
+    This provides serial consoles along with reset control
+
+    Args:
+        serial (str): serial number of the em100 device, e.g. DP025143
+        chip (str): SPI-flash chip to emulate, e.g. W25Q64CV
+    """
+    serial = attr.ib(validator=attr.validators.instance_of(str))
+    chip = attr.ib(validator=attr.validators.instance_of(str))

--- a/tests/test_sfemulator.py
+++ b/tests/test_sfemulator.py
@@ -1,0 +1,39 @@
+from labgrid.resource.sfemulator import SFEmulator, NetworkSFEmulator
+from labgrid.driver.sfemulatordriver import SFEmulatorDriver
+
+
+def test_sfemulator_network_create(target):
+    r = NetworkSFEmulator(target, name=None, serial='DP025143',
+                          chip='W25Q64CV', host='localhost')
+    assert isinstance(r, NetworkSFEmulator)
+    assert r.serial == 'DP025143'
+    assert r.chip == 'W25Q64CV'
+
+    d = SFEmulatorDriver(target, name=None)
+    assert isinstance(d, SFEmulatorDriver)
+
+
+def test_sfemulator_driver_create(target):
+    r = SFEmulator(target, name=None, serial='DP025143', chip='W25Q64CV')
+    assert isinstance(r, SFEmulator)
+
+    d = SFEmulatorDriver(target, name=None)
+    assert isinstance(d, SFEmulatorDriver)
+
+
+def test_sfemulator_driver_write(target, mocker, tmpdir):
+    r = SFEmulator(target, name=None, serial='DP025143', chip='W25Q64CV')
+    d = SFEmulatorDriver(target, name=None)
+    r.avail = True
+    target.activate(d)
+
+    image = tmpdir.join('image.bin').strpath
+    with open(image, 'wb') as outf:
+        outf.write(b'image data')
+
+    pwrap = mocker.patch('labgrid.driver.sfemulatordriver.processwrapper')
+
+    d.write_image(image)
+    pwrap.check_output.assert_called_once_with(
+        ['em100', '-x', 'DP025143', '-s', '-p', 'LOW', '-c', 'W25Q64CV',
+         '-d', image, '-r'])


### PR DESCRIPTION
The EM100-pro is a SPI-flash emulator which supports a variety of chips. It can be used to provide an image to a booting system.

Add a driver which allows images to be loaded ready for use. Provide a trace facility for use when the board does not boot.

This emulator is widely used on x86 machines since they boot using SPI flash. It is prohibitively expensive (in terms of time) to re-flash the SPI chip on test run, whereas the Dediprog emulator updates in about 5 seconds.

This has been tested on several x86 Chromebooks, including coral.

- [X] Documentation for the feature
- [ ] Tests for the feature 
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested
