### PR TITLE
Make QEMU machine and cpu optional

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3142,9 +3142,9 @@ Implements:
 
 Arguments:
   - qemu_bin (str): reference to the tools key for the QEMU binary
-  - machine (str): QEMU machine type
-  - cpu (str): QEMU cpu type
   - memory (str): QEMU memory size (ends with M or G)
+  - machine (str): optional, QEMU machine type (defaults to default machine of ``qemu_bin``)
+  - cpu (str): optional, QEMU cpu type (defaults to default cpu type of ``qemu_bin``)
   - extra_args (str): optional, extra QEMU arguments, they are passed directly to the QEMU binary
   - boot_args (str): optional, additional kernel boot argument
   - kernel (str): optional, reference to the images key for the kernel

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -33,9 +33,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
 
     Args:
         qemu_bin (str): reference to the tools key for the QEMU binary
-        machine (str): QEMU machine type
-        cpu (str): QEMU cpu type
         memory (str): QEMU memory size (ends with M or G)
+        cpu (str): optional, QEMU cpu type
+        machine (str): optional, QEMU machine type
         extra_args (str): optional, extra QEMU arguments passed directly to the QEMU binary
         boot_args (str): optional, additional kernel boot argument
         kernel (str): optional, reference to the images key for the kernel
@@ -53,9 +53,13 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         nic (str): optional, configuration string to pass to QEMU to create a network interface
     """
     qemu_bin = attr.ib(validator=attr.validators.instance_of(str))
-    machine = attr.ib(validator=attr.validators.instance_of(str))
-    cpu = attr.ib(validator=attr.validators.instance_of(str))
     memory = attr.ib(validator=attr.validators.instance_of(str))
+    cpu = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str)))
+    machine = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str)))
     extra_args = attr.ib(
         default='',
         validator=attr.validators.optional(attr.validators.instance_of(str)))
@@ -153,7 +157,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 cmd.append(
                     f"if=sd,format={disk_format},file={disk_path},id=mmc0{disk_opts}")
                 boot_args.append("root=/dev/mmcblk0p1 rootfstype=ext4 rootwait")
-            elif self.machine in ["pc", "q35", "virt"]:
+            elif self.machine in ["pc", "q35", "virt", None]:
                 cmd.append("-drive")
                 cmd.append(
                     f"if=virtio,format={disk_format},file={disk_path}{disk_opts}")
@@ -181,15 +185,15 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             cmd.append("-bios")
             cmd.append(
                 self.target.env.config.get_image_path(self.bios))
-
         if "-append" in shlex.split(self.extra_args):
             raise ExecutionError("-append in extra_args not allowed, use boot_args instead")
-
         cmd.extend(shlex.split(self.extra_args))
-        cmd.append("-machine")
-        cmd.append(self.machine)
-        cmd.append("-cpu")
-        cmd.append(self.cpu)
+        if self.machine:
+            cmd.append("-machine")
+            cmd.append(self.machine)
+        if self.cpu:
+            cmd.append("-cpu")
+            cmd.append(self.cpu)
         cmd.append("-m")
         cmd.append(self.memory)
         if self.display == "none":

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -3,6 +3,7 @@ import subprocess
 import pytest
 
 from labgrid.driver import QEMUDriver
+from labgrid.driver.exception import ExecutionError
 from labgrid import Environment
 
 @pytest.fixture
@@ -78,6 +79,48 @@ def qemu_qmp_mock(mocker):
 
 def test_qemu_instance(qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
+
+def test_qemu_base_args_optional(qemu_target, qemu_mock):
+    q = QEMUDriver(
+        qemu_target,
+        "qemu_opt",
+        qemu_bin="qemu",
+        machine="pc",
+        cpu="cortex-a15",
+        memory="512M",
+        extra_args="-d guest_errors",
+        kernel="kernel",
+        rootfs="rootfs")
+    args = q.get_qemu_base_args()
+
+    assert args[args.index("-machine") + 1] == "pc"
+    assert args[args.index("-cpu") + 1] == "cortex-a15"
+    assert args[args.index("-d") + 1] == "guest_errors"
+
+def test_qemu_base_args_defaults(qemu_target, qemu_mock):
+    q = QEMUDriver(
+        qemu_target,
+        "qemu_default",
+        qemu_bin="qemu",
+        memory="512M",
+        kernel="kernel",
+        rootfs="rootfs")
+    args = q.get_qemu_base_args()
+
+    assert "-machine" not in args
+    assert "-cpu" not in args
+
+def test_qemu_extra_args_append_rejected(qemu_target, qemu_mock):
+    q = QEMUDriver(
+        qemu_target,
+        "qemu_append",
+        qemu_bin="qemu",
+        memory="512M",
+        extra_args="-append root=/dev/foo",
+        kernel="kernel",
+        rootfs="rootfs")
+    with pytest.raises(ExecutionError):
+        q.get_qemu_base_args()
 
 def test_qemu_activate_deactivate(qemu_target, qemu_driver, qemu_qmp_mock):
     qemu_target.activate(qemu_driver)


### PR DESCRIPTION
This makes the QEMU driver's machine, cpu and extra_args parameters optional, since on x86 these are typically not specified. It allows a simpler configuration for x86 targets.

- [X] Documentation for the feature
- [X] Tests for the feature 
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested
