### PR TITLE
fix: match interface regex in ShellDriver

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -567,7 +567,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         regex = r"""default\s+via # leading strings
                 \s+\S+ # IP address
-                \s+dev\s+(\w+) # interface"""
+                \s+dev\s+([\w\.-]+) # interface"""
 
         default_route = self._run_check(f"ip -{version} route list default")
         matches = re.findall(regex, "\n".join(default_route), re.X)

--- a/tests/test_shelldriver.py
+++ b/tests/test_shelldriver.py
@@ -48,6 +48,18 @@ class TestShellDriver:
         res = d.run("test")
         assert res == (['success'], [], 0)
 
+    def test_default_interface_device_name(self, target_with_fakeconsole, mocker):
+        fake_default_route_show = "default via 10.0.2.2 dev br-lan  src 10.0.2.15"
+
+        t = target_with_fakeconsole
+        d = ShellDriver(t, "shell", prompt="dummy", login_prompt="dummy", username="dummy")
+        d.on_activate = mocker.MagicMock()
+        d = t.get_driver("ShellDriver")
+        d._run = mocker.MagicMock(return_value=([fake_default_route_show], [], 0))
+
+        res = d.get_default_interface_device_name()
+        assert res == "br-lan"
+
     def test_get_ip_addresses(self, target_with_fakeconsole, mocker):
         fake_ip_addr_show = r"""
 18: br-lan.42    inet 192.168.42.1/24 brd 192.168.42.255 scope global br-lan.42\       valid_lft forever preferred_lft forever
@@ -61,4 +73,27 @@ class TestShellDriver:
         d._run = mocker.MagicMock(return_value=([fake_ip_addr_show], [], 0))
 
         res = d.get_ip_addresses("br-lan.42")
+        assert res[0] == IPv4Interface("192.168.42.1/24")
+
+    def test_get_ip_addresses_default(self, target_with_fakeconsole, mocker):
+        t = target_with_fakeconsole
+        d = ShellDriver(t, "shell", prompt="dummy", login_prompt="dummy", username="dummy")
+        d.on_activate = mocker.MagicMock()
+        d = t.get_driver("ShellDriver")
+        d._run = mocker.MagicMock()
+        d._run.side_effect = [
+            (["default via 192.168.42.255 dev br-lan.42  src 192.168.42.1"], [], 0),
+            (
+                [
+                    r"""
+18: br-lan.42    inet 192.168.42.1/24 brd 192.168.42.255 scope global br-lan.42\       valid_lft forever preferred_lft forever
+18: br-lan.42    inet6 fe80::9683:c4ff:fea6:fb6b/64 scope link \       valid_lft forever preferred_lft forever
+"""
+                ],
+                [],
+                0,
+            ),
+        ]
+
+        res = d.get_ip_addresses()
         assert res[0] == IPv4Interface("192.168.42.1/24")


### PR DESCRIPTION
**Description**

This PR fixes the regex that matches the default interface device name. This bug was discovered when working with OpenWrt in the context of labgrid.

**Checklist**

- [x] Tests for the feature
- [x] PR has been tested
