### PR TITLE
remote/coordinator: Fix typo to allow for reservations matching multiple tags

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -922,7 +922,7 @@ class Coordinator(labgrid_coordinator_pb2_grpc.CoordinatorServicer):
                     await context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"Key {k} is invalid")
                 if not TAG_VAL.match(v):
                     await context.abort(grpc.StatusCode.INVALID_ARGUMENT, f"Value {v} is invalid")
-            fltr[k] = v
+                fltr[k] = v
 
         owner = self.clients[peer].name
         res = Reservation(owner=owner, prio=request.prio, filters=fltrs)


### PR DESCRIPTION
**Description**

The code which is creating Reservation objects in the coordinator contains what looks to be a typo. This typo creates a bug where reservations that match more than one tag are not correctly handled.

The places needed to reproduce this problem can be created in the following way:
```
labgrid-client -p place1 create
labgrid-client -p place1 set-tags env=prod
labgrid-client -p place1 set-tags board_model=foo

labgrid-client -p place2 create
labgrid-client -p place2 set-tags env=ci
labgrid-client -p place2 set-tags board_model=foo
```

Before fix:

```
$ labgrid-client reserve --wait env=ci board_model=foo
Reservation '45JJKBHK1X':
  owner: localhost/m.grela
  token: 45JJKBHK1X
  state: allocated
  filters:
    main: board_model=foo
  allocations:
    main: place1
  created: 2024-09-03 12:46:15.928365
  timeout: 2024-09-03 12:47:15.928397
Waiting for allocation...
```

place1 is incorrectly allocated where place2 should have been selected. Also the reservation record is clearly missing the env=ci tag.

After fix:

```
$ labgrid-client reserve --wait env=ci board_model=foo
Reservation 'L9WKOT71I7':
  owner: localhost/m.grela
  token: L9WKOT71I7
  state: allocated
  filters:
    main: env=ci board_model=foo
  allocations:
    main: place2
  created: 2024-09-03 12:57:31.191642
  timeout: 2024-09-03 12:58:31.191690
Waiting for allocation...
```

**Checklist**
- [X] PR has been tested
