### PR TITLE
driver/usbvideodriver: reduce latency of GStreamer pipeline

### DIFF
--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -131,7 +131,7 @@ class USBVideoDriver(Driver, VideoProtocol):
         tx_cmd = self.video.command_prefix + ["gst-launch-1.0", "-q"]
         tx_cmd += pipeline.split()
         rx_cmd = ["gst-launch-1.0"]
-        rx_cmd += "playbin3 uri=fd://0".split()
+        rx_cmd += "playbin3 buffer-duration=0 uri=fd://0".split()
 
         tx = subprocess.Popen(
             tx_cmd,


### PR DESCRIPTION
The playbin3 uses a urisourcebin to open and read the uri. The urisourcebin detects the fd as a stream uri and internally crates a multiqueue with a default buffer duration of 5 s and a high watermark of 0.60 to buffer the stream. This adds 3 s latency to the video stream.

If the source signals that is it a live source, the urisourcebin would avoid buffering of the stream. Unfortunately, the fdsrc doesn't signal that the data is live, and doesn't have a property to change this.

Use buffer-duration to set the size of the queue for buffering to 0 to avoid this additional latency.

The queue could be completely removed by setting "buffering" in the flags property of playbin3 to 0, which would be equal to the behavior of a live source, but the changed flags are more difficult to understand than the buffer duration.

- [x] PR has been tested

Tested by running `labgrid-client video` on a place with a USB camera as resource, moving in front of the camera, and looking the delay of the movement on the screen.