### PR TITLE
resource: Add generic USB port

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -641,6 +641,23 @@ device available on a remote computer.
 The NetworkUSBMassStorage can be used in test cases by calling the
 ``write_files()``, ``write_image()``, and ``get_size()`` functions.
 
+GenericUSBPort
+~~~~~~~~~~~~~~
+A :any:`GenericUSBPort` resource describes a generic USB device, that has no
+specific driver yet. Useful if your DUT creates its own USB endpoint, that you
+want to test.
+
+.. code-block:: yaml
+
+  GenericUSBPort:
+    match:
+      ID_PATH: pci-0000:3c:00.0-usb-0:1.2:1.0
+
+NetworkGenericUSBPort
+~~~~~~~~~~~~~~~~~~~
+A :any:`NetworkGenericUSBPort` describes a `GenericUSBPort`_ available on a remote
+computer.
+
 SigrokDevice
 ~~~~~~~~~~~~
 A :any:`SigrokDevice` resource describes a *Sigrok* device. To select a

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -550,6 +550,7 @@ exports["USBSDMuxDevice"] = USBSDMuxExport
 exports["USBSDWireDevice"] = USBSDWireExport
 exports["USBDebugger"] = USBGenericExport
 
+exports["GenericUSBPort"] = USBGenericExport
 exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport
 exports["USBAudioInput"] = USBAudioInputExport

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -12,6 +12,7 @@ from .udev import (
     AndroidUSBFastboot,
     DFUDevice,
     DeditecRelais8,
+    GenericUSBPort,
     HIDRelay,
     IMXUSBLoader,
     LXAUSBMux,

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -296,6 +296,15 @@ class NetworkUSBTMC(RemoteUSBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class NetworkGenericUSBPort(RemoteUSBResource):
+    """The NetworkGenericUSBPort describes a remotely accessible USB device"""
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class NetworkUSBDebugger(RemoteUSBResource):
     """The NetworkUSBDebugger describes a remotely accessible USB JTAG/Debugger device"""
     def __attrs_post_init__(self):

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -230,6 +230,12 @@ class USBResource(ManagedResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class GenericUSBPort(USBResource):
+    pass
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class USBSerialPort(USBResource, SerialPort):
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'tty'


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

This is useful, if the DUT is a USB device, where you are not yet sure, what exactly it is. This allows the test to use the wrapper to communicate with the device, even if it is on the network.

Might also be useful, if you don't yet have a driver for a USB controlled device and want to test it out before upstreaming it.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

Not sure about the description in usage and development, but I'm currently using it in my labgrid to communicate with a USB device, that has not yet a driver in Labgrid and where I have not yet come around to upstream the driver, because it is a lot of work to make it work reliable.

Have not written any tests, because I think the USB-Port is already tested enough.