### PR TITLE
target: store features and options

### DIFF
--- a/labgrid/config.py
+++ b/labgrid/config.py
@@ -199,6 +199,12 @@ class Config:
                 configuration, or if the target can not be found in the
                 configuration.
         """
+        warn(
+            "get_target_option is deprecated, access the options on the target directly.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
         if target not in self.data['targets']:
             raise KeyError(f"No target '{target}' found in configuration")
 
@@ -224,6 +230,11 @@ class Config:
             KeyError: if the requested target can not be found in the
                 configuration
         """
+        warn(
+            "set_target_option is deprecated, use the YAML configuration instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         assert isinstance(target, str)
         assert isinstance(name, str)
 

--- a/labgrid/environment.py
+++ b/labgrid/environment.py
@@ -55,6 +55,14 @@ class Environment:
         return self.config.get_features()
 
     def get_target_features(self):
+        warn(
+            "use get_all_features instead. For target features, use target.features instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return get_all_features()
+
+    def get_all_features(self):
         flags = set()
         for value in self.config.get_targets().values():
             flags = flags | set(value.get('features', {}))

--- a/labgrid/factory.py
+++ b/labgrid/factory.py
@@ -144,7 +144,9 @@ class TargetFactory:
     def make_target(self, name, config, *, env=None):
         from .target import Target
 
-        target = Target(name, env=env)
+        target = Target(name, env=env,
+                        features=frozenset(config.get('features', [])),
+                        options=frozenset(config.get('options', [])))
         for item in TargetFactory._convert_to_named_list(config.get('resources', {})):
             resource = item.pop('cls')
             name = item.pop('name', None)

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -105,7 +105,7 @@ def pytest_collection_modifyitems(config, items):
     if not env:
         return
 
-    have_feature = env.get_features() | env.get_target_features()
+    have_feature = env.get_features() | env.get_all_features()
 
     for item in items:
         want_feature = set()

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -19,6 +19,8 @@ from .factory import target_factory
 class Target:
     name = attr.ib(validator=attr.validators.instance_of(str))
     env = attr.ib(default=None)
+    features = attr.ib(default=set())
+    options = attr.ib(default=set())
 
     def __attrs_post_init__(self):
         self.log = logging.getLogger(f"target({self.name})")


### PR DESCRIPTION
**Description**
Instead of always having to revert to the configuration for options and features, store both directly in the target object. Also deprecate the setters and getters for both in the configuration object.

Reasoning is that setters are not required for this, the YAML configuration should be changed instead. The getters are not required if the options and features are bound to the target which is more intuitive anyway.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 

Closes #704