### PR TITLE
update codecov/codecov-action v3 -> v4

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -67,4 +67,4 @@ jobs:
         # check README.rst separately
         pip install rstcheck
         rstcheck --ignore-languages=bash --report-level=WARNING README.rst
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@v4


### PR DESCRIPTION
**Description**

GitHub emits warnings like:

> The following actions use a deprecated Node.js version and will be forced to run on node20: codecov/codecov-action@v3. For more info:
> https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

The codecov upload hasn't worked reliably in a while. This should fix it.