### PR TITLE
github: bump ubuntu runner images to 24.04

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
     - name: Install system dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,9 +21,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install system dependencies
       run: |
-        sudo apt install -yq python3-pip
-        pip install --upgrade setuptools
-        pip install setuptools_scm
+        sudo apt install -yq python3-pip python3-setuptools-scm
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
       with:

--- a/.github/workflows/reusable-unit-tests-docker.yml
+++ b/.github/workflows/reusable-unit-tests-docker.yml
@@ -16,9 +16,7 @@ jobs:
         ref: ${{ inputs.branch }}
     - name: Install system dependencies
       run: |
-        sudo apt install -yq python3-pip
-        pip install --upgrade setuptools
-        pip install setuptools_scm
+        sudo apt install -yq python3-pip python3-setuptools-scm
     - name: Build docker images
       run: |
         ./dockerfiles/build.sh

--- a/.github/workflows/reusable-unit-tests-docker.yml
+++ b/.github/workflows/reusable-unit-tests-docker.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: false
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
**Description**
Installing setuptools_scm via pip system-wide is deprecated. With ubuntu 24.04 this becomes an error. labgrid does not rely on a special version of setuptools_scm anyway, so simply install the corresponding Ubuntu package.

Bump the Ubuntu runner images to 24.04. Pinning the runner images to a release prevents unexpected breakages
when a new LTS is released. We follow the releases, so let's keep this a manual step.

**Checklist**
- [x] PR has been tested (CI, succeeded when combined with #1497)
