### PR TITLE
Test/Advertise Python 3.13 Support

### DIFF
--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     uses: ./.github/workflows/reusable-unit-tests.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -58,7 +58,7 @@ jobs:
         ruff format --check --diff labgrid/remote/
     - name: Test with pytest
       run: |
-        pytest --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner -k "not test_docker_with_daemon"
+        pytest -r a --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner -k "not test_docker_with_daemon"
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v4
       with:

--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests.yml
     secrets:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -180,7 +180,8 @@ autodoc_default_options = {
 }
 autodoc_mock_imports = ['onewire',
                         'gi',
-                        'gi.repository',]
+                        'gi.repository',
+                        'vxi11']
 
 # -- Options for autosection ----------------------------------------------
 autosectionlabel_prefix_document = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
 ]
 dependencies = [
@@ -187,7 +188,7 @@ signature-mutators = ["labgrid.step.step"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py39, py310, py311, py312
+envlist = py39, py310, py311, py312, py313
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
**Description**
Add tests for Python 3.13 ([expected on 2024-10-07](https://peps.python.org/pep-0719/#schedule)) and advertise support.

Note that the siglent power backend is incompatible with Python 3.13, see #1509. I think this shouldn't stop us from testing/advertising support, right?

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested (CI only)