### PR TITLE
udev: Adds model id for stlink-v2 and v3

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -710,7 +710,9 @@ class USBDebugger(USBResource):
 
         if match not in [("0403", "6010"),  # FT2232C/D/H Dual UART/FIFO IC
                          ("0403", "6014"),  # FT232HL/Q
+                         ("0483", "3748"),  # STLINK-V2
                          ("0483", "374b"),  # STLINK-V3
+                         ("0483", "374e"),  # STLINK-V3
                          ("0483", "374f"),  # STLINK-V3
                          ("15ba", "0003"),  # Olimex ARM-USB-OCD
                          ("15ba", "002b"),  # Olimex ARM-USB-OCD-H


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Update list of USBDebugger to match stlink v2 and more stlink v3

Tested with `labgrid-suggest`, which properly reports stlink v2 and v3 with the added model id. Also tested with OpenOCDDriver to load fw on an stm32 mcu (see https://github.com/labgrid-project/labgrid/discussions/1517 for original discussion)

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
