### PR TITLE
Drop Support for Python 3.8

### DIFF
--- a/.github/workflows/push-pr-unit-tests.yml
+++ b/.github/workflows/push-pr-unit-tests.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:
       python-version: ${{ matrix.python-version }}

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -47,7 +47,6 @@ jobs:
       run: |
         pip install -e ".[dev]"
     - name: Lint with pylint
-      if: inputs.python-version != '3.8'
       run: |
         pylint --list-msgs-enabled
         pylint labgrid

--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         branch: ['master']
     uses: ./.github/workflows/reusable-unit-tests.yml
     with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,7 +42,7 @@ Due to the migration, 24.1 includes the following breaking changes:
 
 Other breaking changes include:
 
-FIXME
+- Support for Python 3.8 was dropped.
 
 Known issues in 24.1
 ~~~~~~~~~~~~~~~~~~~~

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ authors = [
 description = "embedded systems control library for development, testing and installation"
 readme = "README.rst"
 license = { file="LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 classifiers = [
     "Intended Audience :: Developers",
     "Development Status :: 5 - Production/Stable",
@@ -24,7 +24,6 @@ classifiers = [
     "Topic :: Software Development :: Testing",
     "Framework :: Pytest",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -228,7 +227,7 @@ signature-mutators = ["labgrid.step.step"]
 [tool.tox]
 legacy_tox_ini = """
 [tox]
-envlist = py38, py39, py310, py311, py312
+envlist = py39, py310, py311, py312
 isolated_build = true
 
 [testenv]


### PR DESCRIPTION
**Description**
Python 3.8 received its [final security release on 2024-09-06 (3.8.20) and is now EOL](https://peps.python.org/pep-0569/). Since #1519 makes our Python 3.8 CI job fail, let's remove support now.