### PR TITLE
treewide: drop pylint disable=no-self-use comments

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -92,10 +92,10 @@ class ResourceExport(ResourceEntry):
         self.data["acquired"] = "<broken>"
         self.logger.error("marked as broken: %s", reason)
 
-    def _get_start_params(self):  # pylint: disable=no-self-use
+    def _get_start_params(self):
         return {}
 
-    def _get_params(self):  # pylint: disable=no-self-use
+    def _get_params(self):
         return {}
 
     def _start(self, start_params):

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -60,7 +60,7 @@ class USBResource(ManagedResource):
         self.match.setdefault('SUBSYSTEM', 'usb')
         super().__attrs_post_init__()
 
-    def filter_match(self, device):  # pylint: disable=unused-argument,no-self-use
+    def filter_match(self, device):  # pylint: disable=unused-argument
         return True
 
     def suggest_match(self, device):


### PR DESCRIPTION
**Description**
pylint's 'no-self-use' check was moved to an optional extension, see [1].

[1] https://pylint.readthedocs.io/en/latest/whatsnew/2/2.14/summary.html#removed-checkers.

**Checklist**
- [x] PR has been tested

Note: This is also part of (otherwise unrelated) #1497. Since that PR is still in discussion, let's merge this first as a first step towards happy CI.