### PR TITLE
pyproject.toml: limit pysnmp's pyasn1 dependency to <0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ pyvisa = [
     "pyvisa>=1.11.3",
     "PyVISA-py>=0.5.2",
 ]
-snmp = ["pysnmp-lextudio>=4.4.12, <6"]
+snmp = [
+    "pysnmp>=4.4.12, <6",
+    "pyasn1<0.6.1",
+]
 vxi11 = ["python-vxi11>=0.9"]
 xena = ["xenavalkyrie>=3.0.1"]
 deb = [
@@ -80,7 +83,8 @@ deb = [
     "onewire>=0.2",
 
     # labgrid[snmp]
-    "pysnmp-lextudio>=4.4.12, <6",
+    "pysnmp>=4.4.12, <6",
+    "pyasn1<0.6.1",
 ]
 dev = [
     # references to other optional dependency groups
@@ -114,7 +118,8 @@ dev = [
     "PyVISA-py>=0.5.2",
 
     # labgrid[snmp]
-    "pysnmp-lextudio>=4.4.12, <6",
+    "pysnmp>=4.4.12, <6",
+    "pyasn1<0.6.1",
 
     # labgrid[vxi11]
     "python-vxi11>=0.9",


### PR DESCRIPTION
**Description**
pysnmp depends on pyasn1. `pyasn1.compat.octets` was removed in pyasn1 0.6.1 [1] leading to ModuleNotFoundErrors in labgrid's "eaton" and "poe_mib" power backends:
```
  _______________ TestNetworkPowerDriver.test_import_backend_eaton _______________

  self = <test_powerdriver.TestNetworkPowerDriver object at 0x7f84794bfdd0>

      def test_import_backend_eaton(self):
          pytest.importorskip("pysnmp")
  >       import labgrid.driver.power.eaton

  tests/test_powerdriver.py:295:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  labgrid/driver/power/eaton.py:2: in <module>
      from ...util.snmp import SimpleSNMP
  labgrid/util/snmp.py:1: in <module>
      from pysnmp import hlapi
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/hlapi/__init__.py:7: in <module>
      from pysnmp.proto.rfc1902 import *
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/proto/rfc1902.py:8: in <module>
      from pysnmp.proto import rfc1155, error
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/proto/rfc1155.py:10: in <module>
      from pysnmp.proto import error
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/proto/error.py:9: in <module>
      from pysnmp import debug
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

      #
      # This file is part of pysnmp software.
      #
      # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
      # License: https://www.pysnmp.com/pysnmp/license.html
      #
      import logging
  >   from pyasn1.compat.octets import octs2ints
  E   ModuleNotFoundError: No module named 'pyasn1.compat.octets'

  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/debug.py:8: ModuleNotFoundError
  ______________ TestNetworkPowerDriver.test_import_backend_poe_mib ______________

  self = <test_powerdriver.TestNetworkPowerDriver object at 0x7f84794bd910>

      def test_import_backend_poe_mib(self):
          pytest.importorskip("pysnmp")
  >       import labgrid.driver.power.poe_mib

  tests/test_powerdriver.py:307:
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
  labgrid/driver/power/poe_mib.py:4: in <module>
      from ...util.snmp import SimpleSNMP
  labgrid/util/snmp.py:1: in <module>
      from pysnmp import hlapi
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/hlapi/__init__.py:7: in <module>
      from pysnmp.proto.rfc1902 import *
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/proto/rfc1902.py:8: in <module>
      from pysnmp.proto import rfc1155, error
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/proto/rfc1155.py:10: in <module>
      from pysnmp.proto import error
  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/proto/error.py:9: in <module>
      from pysnmp import debug
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

      #
      # This file is part of pysnmp software.
      #
      # Copyright (c) 2005-2019, Ilya Etingof <etingof@gmail.com>
      # License: https://www.pysnmp.com/pysnmp/license.html
      #
      import logging
  >   from pyasn1.compat.octets import octs2ints
  E   ModuleNotFoundError: No module named 'pyasn1.compat.octets'

  /opt/hostedtoolcache/Python/3.12.5/x64/lib/python3.12/site-packages/pysnmp/debug.py:8: ModuleNotFoundError
```

The issue is documented upstream [2]. [3] limited the pysnmp version to <6. pysnmp 6.1.4, 6.2.6, and 7.1.0 are not affected.

Limit compatible pyasn1 versions to <0.6.1 until [5] switches labgrid to pysnmp's asyncio API, thereby dropping the upper bound introduced by [3].

While at it, switch from "pysnmp-lextudio" to "pysnmp". The original author of pysnmp passed away and the lextudio folks took over maintenanc. While the request to take over the pysnmp PyPi project was pending, the maintained fork was called pysnmp-lextudio (see #1186, aa2549c). Now that the migration is complete, let's move back to the original package name.

See: [6]

[1] https://github.com/pyasn1/pyasn1/releases/tag/v0.6.1
[2] https://github.com/pyasn1/pyasn1/issues/76
[3] https://github.com/labgrid-project/labgrid/pull/1332
[4] https://github.com/lextudio/pysnmp/issues/113#issuecomment-2342699222
[5] https://github.com/labgrid-project/labgrid/pull/1497
[6] https://github.com/etingof/pysnmp/issues/429

**Checklist**
- [x] PR has been tested

Closes #1456
