### PR TITLE
ruff: maintain configuration, format examples and labgrid.protocols

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -55,7 +55,7 @@ jobs:
         pylint labgrid
     - name: Format with ruff
       run: |
-        ruff format --check --diff labgrid/remote/
+        ruff format --check --diff
     - name: Test with pytest
       run: |
         pytest -r a --cov-config .coveragerc --cov=labgrid --local-sshmanager --ssh-username runner -k "not test_docker_with_daemon"

--- a/examples/barebox/conftest.py
+++ b/examples/barebox/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def command(target):
-    barebox = target.get_driver('CommandProtocol')
+    barebox = target.get_driver("CommandProtocol")
     target.activate(barebox)
     return barebox

--- a/examples/barebox/test_barebox.py
+++ b/examples/barebox/test_barebox.py
@@ -1,11 +1,11 @@
 def test_barebox(command):
-    stdout, stderr, returncode = command.run('version')
+    stdout, stderr, returncode = command.run("version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'barebox' in '\n'.join(stdout)
+    assert "barebox" in "\n".join(stdout)
 
-    stdout, stderr, returncode = command.run('false')
+    stdout, stderr, returncode = command.run("false")
     assert returncode == 1
     assert not stdout
     assert not stderr

--- a/examples/barebox/test_bootchooser.py
+++ b/examples/barebox/test_bootchooser.py
@@ -2,10 +2,10 @@ import pytest
 
 
 def test_bootchooser(command):
-    stdout, stderr, returncode = command.run('bootchooser -i')
+    stdout, stderr, returncode = command.run("bootchooser -i")
     if returncode == 127:
         pytest.skip("bootchooser command not available")
     assert returncode == 0
     assert not stderr
-    assert stdout[0].startswith('Good targets')
-    assert stdout[1] != 'none'
+    assert stdout[0].startswith("Good targets")
+    assert stdout[1] != "none"

--- a/examples/barebox/test_sleep.py
+++ b/examples/barebox/test_sleep.py
@@ -6,14 +6,14 @@ from pytest import approx
 def test_sleep(command):
     # measure the round-trip-time
     timestamp = monotonic()
-    stdout, stderr, returncode = command.run('true')
+    stdout, stderr, returncode = command.run("true")
     elapsed_true = monotonic() - timestamp
     assert returncode == 0
     assert not stdout
     assert not stderr
 
     timestamp = monotonic()
-    stdout, stderr, returncode = command.run('sleep 1')
+    stdout, stderr, returncode = command.run("sleep 1")
     elapsed_sleep = monotonic() - timestamp
     assert returncode == 0
     assert not stdout

--- a/examples/barebox/test_state.py
+++ b/examples/barebox/test_state.py
@@ -2,10 +2,10 @@ import pytest
 
 
 def test_state(command):
-    stdout, stderr, returncode = command.run('state')
+    stdout, stderr, returncode = command.run("state")
     if returncode == 127:
         pytest.skip("state command not available")
     assert returncode == 0
     assert not stderr
-    assert stdout[0] == 'registered state instances:'
+    assert stdout[0] == "registered state instances:"
     assert len(stdout) > 1

--- a/examples/barebox/test_watchdog.py
+++ b/examples/barebox/test_watchdog.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def test_watchdog(command):
-    stdout, stderr, returncode = command.run('wd 1')
+    stdout, stderr, returncode = command.run("wd 1")
     if returncode == 127:
         pytest.skip("wd command not available")
     assert returncode == 0
@@ -11,6 +11,6 @@ def test_watchdog(command):
 
     command._await_prompt()
 
-    stdout = command.run_check('echo ${global.system.reset}')
+    stdout = command.run_check("echo ${global.system.reset}")
     assert len(stdout) == 1
-    assert stdout[0] == 'WDG'
+    assert stdout[0] == "WDG"

--- a/examples/deditec-relais8/deditec.py
+++ b/examples/deditec-relais8/deditec.py
@@ -12,7 +12,7 @@ basicConfig(level=logging.INFO)
 # log labgrid steps
 StepLogger.start()
 
-t = Target('main')
+t = Target("main")
 r = DeditecRelais8(t, name=None, index=1)
 d = DeditecRelaisDriver(t, name=None)
 

--- a/examples/deditec-relais8/deditec_remote.py
+++ b/examples/deditec-relais8/deditec_remote.py
@@ -10,7 +10,7 @@ basicConfig(level=logging.INFO)
 # show labgrid steps on the console
 StepLogger.start()
 
-e = Environment('import-dedicontrol.yaml')
+e = Environment("import-dedicontrol.yaml")
 t = e.get_target()
 
 p = t.get_driver("DigitalOutputProtocol")

--- a/examples/docker/conftest.py
+++ b/examples/docker/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 
-@pytest.fixture(scope='session')
-def command(target):
-    strategy = target.get_driver('DockerStrategy')
-    strategy.transition("accessible")
-    shell = target.get_driver('CommandProtocol')
-    return shell
 
+@pytest.fixture(scope="session")
+def command(target):
+    strategy = target.get_driver("DockerStrategy")
+    strategy.transition("accessible")
+    shell = target.get_driver("CommandProtocol")
+    return shell

--- a/examples/docker/test_shell.py
+++ b/examples/docker/test_shell.py
@@ -1,11 +1,11 @@
 def test_shell(command):
-    stdout, stderr, returncode = command.run('cat /proc/version')
+    stdout, stderr, returncode = command.run("cat /proc/version")
     assert returncode == 0
     assert len(stdout) > 0
     assert len(stderr) == 0
-    assert 'Linux' in stdout[0]
+    assert "Linux" in stdout[0]
 
-    stdout, stderr, returncode = command.run('false')
+    stdout, stderr, returncode = command.run("false")
     assert returncode != 0
     assert len(stdout) == 0
     assert len(stderr) == 0

--- a/examples/library/test.py
+++ b/examples/library/test.py
@@ -15,15 +15,17 @@ basicConfig(level=logging.INFO)
 # log labgrid steps
 StepLogger.start()
 
+
 def run_once(target):
-    s = target.get_driver('BareboxStrategy')
+    s = target.get_driver("BareboxStrategy")
     s.status = Status.unknown  # force a power-cycle
-    s.transition('barebox')
-    cmd = target['CommandProtocol']
-    cmd.run_check('test -e /dev/nand0')
+    s.transition("barebox")
+    cmd = target["CommandProtocol"]
+    cmd.run_check("test -e /dev/nand0")
     target.deactivate(cmd)
 
+
 env = Environment(sys.argv[1])
-target = env.get_target('main')
+target = env.get_target("main")
 while True:
     run_once(target)

--- a/examples/modbusrtu/conftest.py
+++ b/examples/modbusrtu/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def instrument(target):
-    _modbus = target.get_driver('ModbusRTUDriver')
+    _modbus = target.get_driver("ModbusRTUDriver")
     return _modbus

--- a/examples/network-test/pkg-replay-record.py
+++ b/examples/network-test/pkg-replay-record.py
@@ -11,6 +11,7 @@ from scapy.all import Ether, Raw, rdpcap, wrpcap, conf
 from labgrid import Environment
 from labgrid.logging import basicConfig, StepLogger
 
+
 def generate_frame():
     frame = Ether(dst="11:22:33:44:55:66", src="66:55:44:33:22:11", type=0x9000)
     padding = "\x00" * (conf.min_pkt_size - len(frame))

--- a/examples/networkmanager/nm.py
+++ b/examples/networkmanager/nm.py
@@ -12,72 +12,71 @@ basicConfig(level=logging.DEBUG)
 StepLogger.start()
 
 
-e = Environment('nm.env')
+e = Environment("nm.env")
 t = e.get_target()
-d = t.get_driver('NetworkInterfaceDriver')
+d = t.get_driver("NetworkInterfaceDriver")
 
 # based on https://developer.gnome.org/NetworkManager/stable/ch01.html, but adapted to python dicts
 s_client = {
-    'connection': {
-        'type': "802-11-wireless",
+    "connection": {
+        "type": "802-11-wireless",
     },
-    '802-11-wireless': {
-        'mode': "infrastructure",
-        'ssid': "local-rpi",
+    "802-11-wireless": {
+        "mode": "infrastructure",
+        "ssid": "local-rpi",
     },
-    '802-11-wireless-security': {
-        'key-mgmt': "wpa-psk",
-        'psk': "obMinwyurArc5",
+    "802-11-wireless-security": {
+        "key-mgmt": "wpa-psk",
+        "psk": "obMinwyurArc5",
     },
-    'ipv4': {
-        'method': "auto",
-        'ignore-auto-dns': True,
-        'ignore-auto-routes': True,
-        'never-default': True,
+    "ipv4": {
+        "method": "auto",
+        "ignore-auto-dns": True,
+        "ignore-auto-routes": True,
+        "never-default": True,
     },
-    'ipv6': {
-        'method': "link-local",
+    "ipv6": {
+        "method": "link-local",
     },
 }
 s_ap = {
-    'connection': {
-        'type': "802-11-wireless",
+    "connection": {
+        "type": "802-11-wireless",
     },
-    '802-11-wireless': {
-        'mode': "ap",
-        'ssid': "local-rpi",
+    "802-11-wireless": {
+        "mode": "ap",
+        "ssid": "local-rpi",
     },
-    '802-11-wireless-security': {
-        'key-mgmt': "wpa-psk",
-        'psk': "obMinwyurArc5",
+    "802-11-wireless-security": {
+        "key-mgmt": "wpa-psk",
+        "psk": "obMinwyurArc5",
     },
-    'ipv4': {
+    "ipv4": {
         #'method': "auto",
         #'method': "link-local",
-        'method': "shared",
-        'addresses': ["172.16.0.2/29"],
+        "method": "shared",
+        "addresses": ["172.16.0.2/29"],
     },
-    'ipv6': {
-        'method': "link-local",
+    "ipv6": {
+        "method": "link-local",
     },
 }
 
 d.disable()
-d.wait_state('disconnected')
+d.wait_state("disconnected")
 print("access points after scan")
 pprint(d.get_access_points())
 
 d.configure(s_ap)
-d.wait_state('activated')
+d.wait_state("activated")
 print("settings in AP mode")
 pprint(d.get_settings())
 print("state in AP mode")
 pprint(d.get_state())
 
-#d.configure(s_client)
-#d.wait_state('activated')
-#print("settings in client mode")
-#pprint(d.get_settings())
-#print("state in client mode")
-#pprint(d.get_state())
-
+# d.configure(s_client)
+# d.wait_state('activated')
+# print("settings in client mode")
+# pprint(d.get_settings())
+# print("state in client mode")
+# pprint(d.get_state())

--- a/examples/power/power_example.py
+++ b/examples/power/power_example.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture()
 def pdu(target):
-    return target.get_driver('NetworkPowerDriver')
+    return target.get_driver("NetworkPowerDriver")
 
 
 def test_something(pdu):

--- a/examples/pyvisa/pyvisa_example.py
+++ b/examples/pyvisa/pyvisa_example.py
@@ -3,13 +3,13 @@ import pytest
 
 @pytest.fixture()
 def signal_generator(target):
-    return target.get_driver('PyVISADriver').get_session()
+    return target.get_driver("PyVISADriver").get_session()
 
 
 def test_with_signal_generator_example(signal_generator):
-    signal_generator.write('*RST')
+    signal_generator.write("*RST")
 
     # Setup channel 1
-    signal_generator.write('C1:BSWV WVTP,SQUARE,HLEV,5,LLEV,0,DUTY,50')
+    signal_generator.write("C1:BSWV WVTP,SQUARE,HLEV,5,LLEV,0,DUTY,50")
     # Switch on channel 1
-    signal_generator.write('C1:OUTP ON,LOAD,HZ,PLRT,NOR')
+    signal_generator.write("C1:OUTP ON,LOAD,HZ,PLRT,NOR")

--- a/examples/qemu-networking/test_qemu_networking.py
+++ b/examples/qemu-networking/test_qemu_networking.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def test_shell(shell_command):
     shell_command.run("true")
 

--- a/examples/remote/test_barebox.py
+++ b/examples/remote/test_barebox.py
@@ -1,14 +1,14 @@
 def test_target(target):
-    barebox = target.get_driver('CommandProtocol')
+    barebox = target.get_driver("CommandProtocol")
     target.activate(barebox)
 
-    stdout, stderr, returncode = barebox.run('version')
+    stdout, stderr, returncode = barebox.run("version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'barebox' in '\n'.join(stdout)
+    assert "barebox" in "\n".join(stdout)
 
-    stdout, stderr, returncode = barebox.run('false')
+    stdout, stderr, returncode = barebox.run("false")
     assert returncode == 1
     assert not stdout
     assert not stderr

--- a/examples/shell/conftest.py
+++ b/examples/shell/conftest.py
@@ -1,8 +1,8 @@
 import pytest
 
 
-@pytest.fixture(scope='session')
+@pytest.fixture(scope="session")
 def command(target):
-    shell = target.get_driver('CommandProtocol')
+    shell = target.get_driver("CommandProtocol")
     target.activate(shell)
     return shell

--- a/examples/shell/test_hwclock.py
+++ b/examples/shell/test_hwclock.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 def test_hwclock_rate(command):
     """Test that the hardware clock rate is not too inaccurate."""
-    result = command.run_check('hwclock -c | head -n 3')
+    result = command.run_check("hwclock -c | head -n 3")
     hw_time, sys_time, freq_offset_ppm, tick = result[-1].strip().split()
     assert abs(int(freq_offset_ppm)) < 1000
 
@@ -15,11 +15,11 @@ def test_hwclock_value(command):
     """
 
     def get_time():
-        result = command.run_check('hwclock --utc --show')[0].strip()
-        return datetime.strptime(result, '%Y-%m-%d %H:%M:%S.%f+0:00')
+        result = command.run_check("hwclock --utc --show")[0].strip()
+        return datetime.strptime(result, "%Y-%m-%d %H:%M:%S.%f+0:00")
 
     def set_time(time):
-        time = time.strftime('%Y-%m-%d %H:%M:%S.%f+0:00')
+        time = time.strftime("%Y-%m-%d %H:%M:%S.%f+0:00")
         command.run_check(f'hwclock --utc --set --date "{time}"')
 
     offset = abs((get_time() - datetime.utcnow()).total_seconds())

--- a/examples/shell/test_memory.py
+++ b/examples/shell/test_memory.py
@@ -8,26 +8,26 @@ from labgrid.driver import ExecutionError
 def test_memory_mbw(command):
     """Test memcopy bandwidth"""
     try:
-        command.run_check('which mbw')
+        command.run_check("which mbw")
     except ExecutionError:
         pytest.skip("mbw missing")
 
-    result = command.run_check('mbw -qt0 8M')
+    result = command.run_check("mbw -qt0 8M")
     result = result[-1].strip()
 
     pattern = r"AVG\s+.*Copy:\s+(?P<bw>\S+)\s+MiB/s"
-    bw, = map(float, re.fullmatch(pattern, result).groups())
+    (bw,) = map(float, re.fullmatch(pattern, result).groups())
     assert bw > 40  # > 40 MiB/second
 
 
 def test_memory_memtester_short(command):
     """Test RAM for errors"""
     try:
-        command.run_check('which memtester')
+        command.run_check("which memtester")
     except ExecutionError:
         pytest.skip("memtester missing")
 
-    result = command.run_check('memtester 128k 1 | tail -n 1')
+    result = command.run_check("memtester 128k 1 | tail -n 1")
     result = result[-1].strip()
 
     assert result == "Done."

--- a/examples/shell/test_rt.py
+++ b/examples/shell/test_rt.py
@@ -8,11 +8,11 @@ from labgrid.driver import ExecutionError
 def test_rt_cyclictest_short(command):
     """Test a basic cyclictest run"""
     try:
-        command.run_check('which cyclictest')
+        command.run_check("which cyclictest")
     except ExecutionError:
         pytest.skip("cyclictest missing")
 
-    result = command.run_check('cyclictest -SN -D 5 -q')
+    result = command.run_check("cyclictest -SN -D 5 -q")
     result = result[-1].strip()
 
     pattern = r"Min:\s+(?P<min>\w+)\s+Act:\s+\w+\s+Avg:\s+(?P<avg>\w+)\s+Max:\s+(?P<max>\w+)"
@@ -25,13 +25,13 @@ def test_rt_cyclictest_short(command):
 def test_rt_hackbench_short(command):
     """Test a basic hackbench run"""
     try:
-        command.run_check('which hackbench')
+        command.run_check("which hackbench")
     except ExecutionError:
         pytest.skip("hackbench missing")
 
-    result = command.run_check('hackbench -f 10')
+    result = command.run_check("hackbench -f 10")
     result = result[-1].strip()
 
     pattern = r"Time:\s+(?P<time>\w+)"
-    time, = map(int, re.search(pattern, result).groups())
+    (time,) = map(int, re.search(pattern, result).groups())
     assert time < 20  # max 20 seconds

--- a/examples/shell/test_shell.py
+++ b/examples/shell/test_shell.py
@@ -1,11 +1,11 @@
 def test_shell(command):
-    stdout, stderr, returncode = command.run('cat /proc/version')
+    stdout, stderr, returncode = command.run("cat /proc/version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'Linux' in stdout[0]
+    assert "Linux" in stdout[0]
 
-    stdout, stderr, returncode = command.run('false')
+    stdout, stderr, returncode = command.run("false")
     assert returncode != 0
     assert not stdout
     assert not stderr

--- a/examples/sigrok/main.py
+++ b/examples/sigrok/main.py
@@ -12,7 +12,7 @@ from labgrid.logging import basicConfig
 basicConfig(level=logging.INFO)
 
 env = Environment(sys.argv[1])
-target = env.get_target('main')
+target = env.get_target("main")
 
 sigrok = target.get_driver("SigrokDriver")
 sigrok.capture("test.cap")

--- a/examples/strategy/bareboxrebootstrategy.py
+++ b/examples/strategy/bareboxrebootstrategy.py
@@ -58,7 +58,7 @@ class BareboxRebootStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
-    @step(args=['new_status'])
+    @step(args=["new_status"])
     def transition(self, new_status, *, step):
         if not isinstance(new_status, Status):
             new_status = Status[new_status]
@@ -95,8 +95,6 @@ class BareboxRebootStrategy(Strategy):
             self.target.activate(self.barebox)
 
         else:
-            raise StrategyError(
-                f"no transition found from {self.status} to {new_status}"
-            )
+            raise StrategyError(f"no transition found from {self.status} to {new_status}")
 
         self.status = new_status

--- a/examples/strategy/quartusstrategy.py
+++ b/examples/strategy/quartusstrategy.py
@@ -23,6 +23,7 @@ class Status(enum.Enum):
 @attr.s(eq=False)
 class QuartusHPSStrategy(Strategy):
     """QuartusHPSStrategy - Strategy to flash QSPI via 'Quartus Prime Programmer and Tools'"""
+
     bindings = {
         "power": PowerProtocol,
         "quartushps": QuartusHPSDriver,
@@ -36,7 +37,7 @@ class QuartusHPSStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
-    @step(args=['status'])
+    @step(args=["status"])
     def transition(self, status, *, step):
         if not isinstance(status, Status):
             status = Status[status]
@@ -59,7 +60,5 @@ class QuartusHPSStrategy(Strategy):
             # activate serial in order to make 'labgrid-client -s $STATE con' work
             self.target.activate(self.serial)
         else:
-            raise StrategyError(
-                f"no transition found from {self.status} to {status}"
-            )
+            raise StrategyError(f"no transition found from {self.status} to {status}")
         self.status = status

--- a/examples/strategy/test_barebox_strategy.py
+++ b/examples/strategy/test_barebox_strategy.py
@@ -14,28 +14,28 @@ def in_shell(strategy, capsys):
 
 
 def test_barebox(target, in_bootloader):
-    #command = target['CommandProtocol']
-    command = target['BareboxDriver']
+    # command = target['CommandProtocol']
+    command = target["BareboxDriver"]
 
-    stdout, stderr, returncode = command.run('version')
+    stdout, stderr, returncode = command.run("version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'barebox' in '\n'.join(stdout)
+    assert "barebox" in "\n".join(stdout)
 
 
 def test_shell(target, in_shell):
-    #command = target['CommandProtocol']
-    command = target['ShellDriver']
-    stdout, stderr, returncode = command.run('cat /proc/version')
+    # command = target['CommandProtocol']
+    command = target["ShellDriver"]
+    stdout, stderr, returncode = command.run("cat /proc/version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'Linux' in stdout[0]
+    assert "Linux" in stdout[0]
 
 
 def test_barebox_2(target, in_bootloader):
-    #command = target['CommandProtocol']
-    command = target['BareboxDriver']
+    # command = target['CommandProtocol']
+    command = target["BareboxDriver"]
 
-    command.run_check('true')
+    command.run_check("true")

--- a/examples/strategy/test_uboot_strategy.py
+++ b/examples/strategy/test_uboot_strategy.py
@@ -14,31 +14,31 @@ def in_shell(strategy, capsys):
 
 
 def test_uboot(target, in_bootloader):
-    #command = target.get_driver(CommandProtocol)
-    command = target.get_driver('UBootDriver')
+    # command = target.get_driver(CommandProtocol)
+    command = target.get_driver("UBootDriver")
 
-    stdout, stderr, returncode = command.run('version')
+    stdout, stderr, returncode = command.run("version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'U-Boot' in '\n'.join(stdout)
+    assert "U-Boot" in "\n".join(stdout)
 
 
 def test_shell(target, in_shell):
-    #command = target.get_driver(CommandProtocol)
-    command = target.get_driver('ShellDriver')
-    stdout, stderr, returncode = command.run('cat /proc/version')
+    # command = target.get_driver(CommandProtocol)
+    command = target.get_driver("ShellDriver")
+    stdout, stderr, returncode = command.run("cat /proc/version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'Linux' in stdout[0]
+    assert "Linux" in stdout[0]
 
 
 def test_uboot_2(target, in_bootloader):
-    command = target.get_driver('UBootDriver')
+    command = target.get_driver("UBootDriver")
 
-    stdout, stderr, returncode = command.run('version')
+    stdout, stderr, returncode = command.run("version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'U-Boot' in '\n'.join(stdout)
+    assert "U-Boot" in "\n".join(stdout)

--- a/examples/sysfsgpio/sysfsgpio.py
+++ b/examples/sysfsgpio/sysfsgpio.py
@@ -12,7 +12,7 @@ basicConfig(level=logging.INFO)
 # show labgrid steps on the console
 StepLogger.start()
 
-t = Target('main')
+t = Target("main")
 r = SysfsGPIO(t, name=None, index=60)
 d = GpioDigitalOutputDriver(t, name=None)
 

--- a/examples/sysfsgpio/sysfsgpio_remote.py
+++ b/examples/sysfsgpio/sysfsgpio_remote.py
@@ -10,7 +10,7 @@ basicConfig(level=logging.INFO)
 # show labgrid steps on the console
 StepLogger.start()
 
-e = Environment('import-gpio.yaml')
+e = Environment("import-gpio.yaml")
 t = e.get_target()
 
 p = t.get_driver("DigitalOutputProtocol")

--- a/examples/usb/test_usb_mxs.py
+++ b/examples/usb/test_usb_mxs.py
@@ -1,8 +1,9 @@
 def test_usb(target):
-    r = target.get_resource('MXSUSBLoader')
+    r = target.get_resource("MXSUSBLoader")
     assert r.devnum is not None
     assert r.busnum is not None
 
+
 def test_mxs_load(target):
-    bp = target.get_driver('BootstrapProtocol')
+    bp = target.get_driver("BootstrapProtocol")
     bp.load()

--- a/examples/usb/test_usb_storage.py
+++ b/examples/usb/test_usb_storage.py
@@ -1,7 +1,8 @@
 def test_usb_storage(target):
-    r = target.get_resource('USBMassStorage')
+    r = target.get_resource("USBMassStorage")
     assert r.path is not None
 
+
 def test_usb_storage_size(target):
-    d = target.get_driver('USBStorageDriver')
+    d = target.get_driver("USBStorageDriver")
     assert d.get_size() > 0

--- a/examples/usbpower/cycle.py
+++ b/examples/usbpower/cycle.py
@@ -3,9 +3,8 @@ from labgrid.resource import USBPowerPort
 from labgrid.driver import USBPowerDriver
 
 
-t = Target(name='main')
-upp = USBPowerPort(t, name=None,
-                   match={'ID_PATH': 'pci-0000:00:14.0-usb-0:2:1.0'}, index=1)
+t = Target(name="main")
+upp = USBPowerPort(t, name=None, match={"ID_PATH": "pci-0000:00:14.0-usb-0:2:1.0"}, index=1)
 upd = USBPowerDriver(t, name=None)
 
 t.activate(upd)

--- a/examples/usbpower/examplestrategy.py
+++ b/examples/usbpower/examplestrategy.py
@@ -23,6 +23,7 @@ class Status(enum.Enum):
 @attr.s(eq=False)
 class ExampleStrategy(Strategy):
     """ExampleStrategy - Strategy to for the usbpower labgrid example"""
+
     bindings = {
         "power": PowerProtocol,
         "sdmux": USBSDMuxDriver,
@@ -35,7 +36,7 @@ class ExampleStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
-    @step(args=['status'])
+    @step(args=["status"])
     def transition(self, status, *, step):
         if not isinstance(status, Status):
             status = Status[status]
@@ -50,7 +51,7 @@ class ExampleStrategy(Strategy):
             # power off
             self.power.off()
             # configure sd-mux
-            self.sdmux.set_mode('dut')
+            self.sdmux.set_mode("dut")
             # cycle power
             self.power.on()
             # interrupt barebox
@@ -62,7 +63,5 @@ class ExampleStrategy(Strategy):
             self.barebox.await_boot()
             self.target.activate(self.shell)
         else:
-            raise StrategyError(
-                f"no transition found from {self.status} to {status}"
-            )
+            raise StrategyError(f"no transition found from {self.status} to {status}")
         self.status = status

--- a/examples/usbpower/test_example.py
+++ b/examples/usbpower/test_example.py
@@ -5,31 +5,31 @@ import pytest
 def bootloader(target, strategy, capsys):
     with capsys.disabled():
         strategy.transition("barebox")
-    return target['CommandProtocol'] # this will return the BareboxDriver
+    return target["CommandProtocol"]  # this will return the BareboxDriver
 
 
 @pytest.fixture(scope="function")
 def shell(target, strategy, capsys):
     with capsys.disabled():
         strategy.transition("shell")
-    return target['CommandProtocol'] # this will return the ShellDriver
+    return target["CommandProtocol"]  # this will return the ShellDriver
 
 
 def test_barebox(bootloader):
-    stdout, stderr, returncode = bootloader.run('version')
+    stdout, stderr, returncode = bootloader.run("version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'barebox' in '\n'.join(stdout)
+    assert "barebox" in "\n".join(stdout)
 
 
 def test_shell(shell):
-    stdout, stderr, returncode = shell.run('cat /proc/version')
+    stdout, stderr, returncode = shell.run("cat /proc/version")
     assert returncode == 0
     assert stdout
     assert not stderr
-    assert 'Linux' in stdout[0]
+    assert "Linux" in stdout[0]
 
 
 def test_barebox_2(bootloader):
-    bootloader.run_check('true')
+    bootloader.run_check("true")

--- a/examples/usbsdmux/test_sdmux.py
+++ b/examples/usbsdmux/test_sdmux.py
@@ -1,4 +1,4 @@
 def test_stick_plugin(target):
-    sdmux = target.get_driver('USBSDMuxDriver')
-    sdmux.set_mode('dut')
-    sdmux.set_mode('host')
+    sdmux = target.get_driver("USBSDMuxDriver")
+    sdmux.set_mode("dut")
+    sdmux.set_mode("host")

--- a/labgrid/protocol/infoprotocol.py
+++ b/labgrid/protocol/infoprotocol.py
@@ -5,7 +5,7 @@ class InfoProtocol(abc.ABC):
     """Abstract class providing the InfoProtocol interface"""
 
     @abc.abstractmethod
-    def get_ip(self, interface: str = 'eth0'):
+    def get_ip(self, interface: str = "eth0"):
         """Implementations should return the IP address for the supplied
         interface."""
         raise NotImplementedError

--- a/labgrid/protocol/resetprotocol.py
+++ b/labgrid/protocol/resetprotocol.py
@@ -1,5 +1,6 @@
 import abc
 
+
 class ResetProtocol(abc.ABC):
     @abc.abstractmethod
     def reset(self):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,10 @@ extend-exclude = [
   "envs",
   "labgrid/remote/generated",
 ]
+include = [
+  "**/pyproject.toml",
+  "labgrid/remote/**/*.py",
+]
 
 [tool.ruff.lint]
 select = ["B", "E", "F", "I", "SIM", "UP"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,16 +206,11 @@ commands = pylint -f colorized labgrid
 
 [tool.ruff]
 line-length = 119
-exclude = [
-  "__pycache__",
-  "labgrid.egg-info",
+extend-exclude = [
   ".pybuild",
-  "build",
   "debian",
   "env",
-  "venv",
   "envs",
-  "dist",
   "labgrid/remote/generated",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,7 +215,15 @@ extend-exclude = [
 ]
 include = [
   "**/pyproject.toml",
+  "examples/**/*.py",
   "labgrid/remote/**/*.py",
+  "labgrid/driver/httpvideodriver.py",
+  "labgrid/driver/manualswitchdriver.py",
+  "labgrid/protocol/**/*.py",
+  "labgrid/resource/httpvideostream.py",
+  "labgrid/resource/provider.py",
+  "labgrid/util/agents/usb_hid_relay.py",
+  "labgrid/util/exceptions.py",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
**Description**
Thinking and arguing about formatting is usually tedious work. To move a step closer to enforced formatting, maintain ruff's configuration centrally, run `ruff format` on `examples/` and `labgrid/protocols/` (these shouldn't cause too much friction) and enforce formatting on more code ruff is already happy about.

**Checklist**
- [x] PR has been tested