### PR TITLE
pyproject.toml: use recursive dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,54 +74,9 @@ snmp = [
 ]
 vxi11 = ["python-vxi11>=0.9"]
 xena = ["xenavalkyrie>=3.0.1"]
-deb = [
-    # labgrid[modbus]
-    "pyModbusTCP>=0.1.10",
-
-    # labgrid[onewire]
-    "onewire>=0.2",
-
-    # labgrid[snmp]
-    "pysnmp>=4.4.12, <6",
-    "pyasn1<0.6.1",
-]
+deb = ["labgrid[modbus,onewire,snmp]"]
 dev = [
-    # references to other optional dependency groups
-    # labgrid[doc]
-    "sphinx_rtd_theme>=1.0.0",
-    "Sphinx>=2.0.0",
-
-    # labgrid[docker]
-    "docker>=5.0.2",
-
-    # labgrid[graph]
-    "graphviz>=0.17.0",
-
-    # labgrid[kasa]
-    "python-kasa>=0.4.0",
-
-    # labgrid[modbus]
-    "pyModbusTCP>=0.1.10",
-
-    # labgrid[modbusrtu]
-    "minimalmodbus>=1.0.2",
-
-    # labgrid[mqtt]
-    "paho-mqtt>=2.0.0",
-
-    # labgrid[onewire]
-    "onewire>=0.2",
-
-    # labgrid[pyvisa]
-    "pyvisa>=1.11.3",
-    "PyVISA-py>=0.5.2",
-
-    # labgrid[snmp]
-    "pysnmp>=4.4.12, <6",
-    "pyasn1<0.6.1",
-
-    # labgrid[vxi11]
-    "python-vxi11>=0.9",
+    "labgrid[doc,docker,graph,kasa,modbus,modbusrtu,mqtt,onewire,pyvisa,snmp,vxi11]",
 
     # additional dev dependencies
     "psutil>=5.8.0",


### PR DESCRIPTION
**Description**
Instead of repeating the dependencies in the "deb" and "dev" extras, switch to recursively referencing the relevant extras.

This has worked in pip for a while.

**Checklist**
- [x] PR has been tested