### PR TITLE
github/workflows: set the python version as a codecov flag

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -63,6 +63,7 @@ jobs:
       uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        flags: ${{ inputs.python-version }}
     - name: Build documentation
       run: |
         make -C doc clean


### PR DESCRIPTION
This allows codecov to show the coverage sepeately for each tested python version.