### PR TITLE
ruff: enforce on more files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,10 +216,10 @@ extend-exclude = [
 include = [
   "**/pyproject.toml",
   "examples/**/*.py",
-  "labgrid/remote/**/*.py",
   "labgrid/driver/httpvideodriver.py",
   "labgrid/driver/manualswitchdriver.py",
   "labgrid/protocol/**/*.py",
+  "labgrid/remote/**/*.py",
   "labgrid/resource/httpvideostream.py",
   "labgrid/resource/provider.py",
   "labgrid/util/agents/usb_hid_relay.py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,8 @@ include = [
   "examples/**/*.py",
   "labgrid/driver/httpvideodriver.py",
   "labgrid/driver/manualswitchdriver.py",
+  "labgrid/driver/power/gude8031.py",
+  "labgrid/driver/rawnetworkinterfacedriver.py",
   "labgrid/protocol/**/*.py",
   "labgrid/remote/**/*.py",
   "labgrid/resource/httpvideostream.py",


### PR DESCRIPTION
**Description**
Ideally we add files once we ran `ruff format` initially. We've missed that in #1320 and #1534, so do it now.