### PR TITLE
driver/sigrokdriver: add channel group parameter

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -655,8 +655,10 @@ specific device from all connected supported devices use the
 
 Arguments:
   - driver (str): name of the sigrok driver to use
-  - channels (str): optional, channel mapping as described in the sigrok-cli
-    man page
+  - channels (str): optional, channel mapping as described in the
+    ``sigrok-cli`` man page
+  - channel_group (str): optional, channel group as described in the
+    ``sigrok-cli`` man page
 
 Used by:
   - `SigrokDriver`_
@@ -896,8 +898,10 @@ A :any:`SigrokUSBDevice` resource describes a *Sigrok* USB device.
 
 Arguments:
   - driver (str): name of the sigrok driver to use
-  - channels (str): optional, channel mapping as described in the sigrok-cli
-    man page
+  - channels (str): optional, channel mapping as described in the
+    ``sigrok-cli`` man page
+  - channel_group (str): optional, channel group as described in the
+    ``sigrok-cli`` man page
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 
 Used by:
@@ -925,6 +929,8 @@ communicates over a USB serial port instead of being a USB device itself (see
 Arguments:
   - driver (str): name of the sigrok driver to use
   - channels (str): optional, channel mapping as described in the
+    ``sigrok-cli`` man page
+  - channel_group (str): optional, channel group as described in the
     ``sigrok-cli`` man page
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
 

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -89,6 +89,8 @@ class SigrokCommon(Driver):
             prefix += ["-d", self.sigrok.driver]
         if self.sigrok.channels:
             prefix += ["-C", self.sigrok.channels]
+        if self.sigrok.channel_group:
+            prefix += ["-g", self.sigrok.channel_group]
         return self.sigrok.command_prefix + prefix
 
     @Driver.check_active
@@ -109,6 +111,8 @@ class SigrokCommon(Driver):
         combined = self.sigrok.command_prefix + [self.tool]
         if self.sigrok.channels:
             combined += ["-C", self.sigrok.channels]
+        if self.sigrok.channel_group:
+            combined += ["-g", self.sigrok.channel_group]
         combined += list(args)
         self.logger.debug("Combined command: %s", combined)
         self._process = subprocess.Popen(

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -373,6 +373,7 @@ class USBSigrokExport(USBGenericExport):
             "model_id": self.local.model_id,
             "driver": self.local.driver,
             "channels": self.local.channels,
+            "channel_group": self.local.channel_group,
         }
 
 

--- a/labgrid/resource/sigrok.py
+++ b/labgrid/resource/sigrok.py
@@ -6,15 +6,20 @@ from .common import Resource
 @target_factory.reg_resource
 @attr.s(eq=False)
 class SigrokDevice(Resource):
-    """The SigrokDevice describes an attached sigrok device with driver and
-    channel mapping
+    """The SigrokDevice describes an attached sigrok device with driver,
+    channel mapping and channel group
 
     Args:
         driver (str): driver to use with sigrok
         channels (str): a sigrok channel mapping as described in the sigrok-cli man page
+        channel_group (str): a sigrok channel group as described in the sigrok-cli man page
     """
     driver = attr.ib(default="demo")
     channels = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    channel_group = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -396,12 +396,18 @@ class SigrokUSBDevice(USBResource):
     Args:
         driver (str): driver to use with sigrok
         channels (str): a sigrok channel mapping as described in the sigrok-cli man page
+        channel_group (str): a sigrok channel group as described in the sigrok-cli man page
     """
     driver = attr.ib(
         default=None,
         validator=attr.validators.instance_of(str)
     )
     channels = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+
+    channel_group = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
@@ -421,12 +427,17 @@ class SigrokUSBSerialDevice(USBResource):
     Args:
         driver (str): driver to use with sigrok
         channels (str): a sigrok channel mapping as described in the sigrok-cli man page
+        channel_group (str): a sigrok channel group as described in the sigrok-cli man page
     """
     driver = attr.ib(
         default=None,
         validator=attr.validators.instance_of(str)
     )
     channels = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    channel_group = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )


### PR DESCRIPTION
Add channel group parameter to sigrok devices

**Description**

Trying to interface Labgrid with a power supply using `sigrok`, I need to specify the channel group to be used (in my case: `-g 1`).

**Checklist**
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested with a scpi-pps power supply
