### PR TITLE
doc/configuration: fix dead wiki.tizen.org links by using archive.org's

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -980,7 +980,7 @@ remote computer.
 USBSDWireDevice
 ~~~~~~~~~~~~~~~
 A :any:`USBSDWireDevice` resource describes a Tizen
-`SD Wire device <https://wiki.tizen.org/SDWire>`_.
+`SD Wire device <https://web.archive.org/web/20240121081917/https://wiki.tizen.org/SDWire>`_.
 
 .. code-block:: yaml
 
@@ -2822,7 +2822,7 @@ Not all combinations can be configured at the same time.
 USBSDWireDriver
 ~~~~~~~~~~~~~~~
 The :any:`USBSDWireDriver` uses a `USBSDWireDevice`_ resource to control a
-USB-SD-Wire device via `sd-mux-ctrl <https://wiki.tizen.org/SD_MUX#Software>`_
+USB-SD-Wire device via `sd-mux-ctrl <https://web.archive.org/web/20220812002642/https://wiki.tizen.org/SD_MUX#Software>`_
 tool.
 
 Binds to:


### PR DESCRIPTION
**Description**

I wasn't able to reach the Wiki in the last few days, I guess since the Tizen project is stopped, they stopped serving the wiki?

Let's use links from archive.org instead.

```sh
cd doc/
python3 -m venv venv
source venv/bin/activate
python3 -m pip install sphinx sphinx_rtd_theme setuptools
make html
python3 -m http.server -d .build/html
# Click on links, it works.
```

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [X] PR has been tested
