### PR TITLE
util/agents/network_interface: handle wifis without SSID

### DIFF
--- a/labgrid/util/agents/network_interface.py
+++ b/labgrid/util/agents/network_interface.py
@@ -192,7 +192,8 @@ class NMDev:
         res["wpa-flags"] = self._flags_to_str(ap.get_wpa_flags())
         res["rsn-flags"] = self._flags_to_str(ap.get_rsn_flags())
         res["bssid"] = ap.get_bssid()
-        res["ssid"] = ap.get_ssid().get_data().decode(errors="surrogateescape")
+        if ap.get_ssid():
+            res["ssid"] = ap.get_ssid().get_data().decode(errors="surrogateescape")
         res["frequency"] = ap.get_frequency()
         res["mode"] = self._flags_to_str(ap.get_mode())
         res["max-bitrate"] = ap.get_max_bitrate()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ include = [
   "labgrid/remote/**/*.py",
   "labgrid/resource/httpvideostream.py",
   "labgrid/resource/provider.py",
+  "labgrid/util/agents/network_interface.py",
   "labgrid/util/agents/usb_hid_relay.py",
   "labgrid/util/exceptions.py",
 ]


### PR DESCRIPTION
**Description**
Hidden wifis do not send an SSID. If a hidden wifi is in reach, the following error can be observed:
```
Traceback (most recent call last):
  File "/path/to/labgrid/examples/networkmanager/nm.py", line 68, in <module>
    pprint(d.get_access_points())
           ^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/binding.py", line 102, in wrapper
    return func(self, *_args, **_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/step.py", line 215, in wrapper
    _result = func(*_args, **_kwargs)
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/driver/networkinterfacedriver.py", line 126, in get_access_points
    return self.proxy.get_access_points(self.iface.ifname, scan)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/util/agentwrapper.py", line 29, in __call__
    return self.wrapper.call(self.name, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/path/to/labgrid/labgrid/util/agentwrapper.py", line 106, in call
    raise AgentException(e)
labgrid.util.agentwrapper.AgentException: AttributeError("'NoneType' object has no attribute 'get_data'")
```

Fix that by retrieving the SSID only if it was received. The AP dict will not contain the "ssid" key if no SSID was received.

While at it, run ruff format.

**Checklist**
- [x] PR has been tested (in an environment with wifi networks with hidden SSIDs)

Fixes #741