### PR TITLE
add USBHub resource and export

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1222,6 +1222,27 @@ Arguments:
 Used by:
   - `HTTPVideoDriver`_
 
+USBHub
+~~~~~~
+
+A :any:`USBHub` resource describes an USB hub.
+There is no corresponding driver, as this resource is only useful to monitor
+whether the expected USB hubs are detected by an exporter.
+To control individual ports, use `USBPowerPort`_.
+
+.. code-block:: yaml
+
+   USBHub:
+     match:
+       ID_PATH: 'pci-0000:02:00.0-usb-0:4:1.0'
+
+
+Arguments:
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+Used by:
+  - none
+
 Providers
 ~~~~~~~~~
 Providers describe directories that are accessible by the target over a

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -549,7 +549,7 @@ exports["SigrokUSBSerialDevice"] = USBSigrokExport
 exports["USBSDMuxDevice"] = USBSDMuxExport
 exports["USBSDWireDevice"] = USBSDWireExport
 exports["USBDebugger"] = USBGenericExport
-
+exports["USBHub"] = USBGenericRemoteExport
 exports["USBMassStorage"] = USBGenericExport
 exports["USBVideo"] = USBGenericExport
 exports["USBAudioInput"] = USBAudioInputExport

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -542,6 +542,20 @@ class USBSDMuxDevice(USBResource):
     def path(self):
         return self.disk_path
 
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class USBHub(USBResource):
+    """The USBHub describes a USB hub.
+
+    This is mainly useful to monitor if all expected hubs are detected.
+    """
+    def __attrs_post_init__(self):
+        self.match['DEVTYPE'] = 'usb_interface'
+        self.match['DRIVER'] = 'hub'
+        super().__attrs_post_init__()
+
+
 @target_factory.reg_resource
 @attr.s(eq=False)
 class USBPowerPort(USBResource):


### PR DESCRIPTION
This resource is a bit unusual, as there is no corresponding driver, as it is only useful to monitor whether the expected USB hubs are detected by an exporter.

In larger labs, there are often USB hubs that are considered part of the infrastructure. When these fail (either temporarily or permanently), the connected devices aren't detected any more. For users of individual places, this leads to unavailable resources without a clear cause.

By configuring USBHub resources for the infrastructure hubs in the exporters, we can start monitoring hub availability centrally via the coordinator.