### PR TITLE
util/ssh: Enable StrictHostKeyChecking SSH option

### DIFF
--- a/labgrid/util/ssh.py
+++ b/labgrid/util/ssh.py
@@ -18,6 +18,8 @@ __all__ = ['sshmanager', 'SSHConnection', 'ForwardError']
 def get_ssh_connect_timeout():
     return int(os.environ.get("LG_SSH_CONNECT_TIMEOUT", 30))
 
+def get_ssh_strict_host_key():
+    return os.environ.get("LG_SSH_STRICT_HOST_KEY_CHECKING", "yes").lower()
 
 @attr.s
 class SSHConnectionManager:
@@ -427,9 +429,8 @@ class SSHConnection:
     def _start_own_master(self):
         """Starts a controlmaster connection in a temporary directory."""
         control = os.path.join(self._tmpdir, f'control-{self.host}')
-
         connect_timeout = get_ssh_connect_timeout()
-
+        strict_host_key = get_ssh_strict_host_key()
         self._logger.debug("ControlSocket: %s", control)
         args = ["ssh"] + SSHConnection._get_ssh_base_args()
         args += [
@@ -439,7 +440,7 @@ class SSHConnection:
             "-o", "ControlMaster=yes",
             "-o", f"ControlPath={control}",
             # We don't want to ask the user to confirm host keys here.
-            "-o", "StrictHostKeyChecking=yes",
+            "-o", f"StrictHostKeyChecking={strict_host_key}",
             self.host,
         ]
 

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-CLIENT" "1" "2017-04-15" "0.0.1" "embedded testing"
+.TH "LABGRID-CLIENT" 1 "2017-04-15" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-client \- labgrid-client interface to control boards
 .SH SYNOPSIS
@@ -124,6 +124,10 @@ CI pipelines where the username may not be consistent between pipeline stages.
 .sp
 Set the connection timeout when using SSH (The \fBConnectTimeout\fP option). If
 unspecified, defaults to 30 seconds.
+.SS LG_SSH_STRICT_HOST_KEY_CHECKING
+.sp
+Set strict host key checking status for SSH client. (The \fBStrictHostKeyChecking\fP option). If
+unspecified, defaults to \fByes\fP
 .SH MATCHES
 .sp
 Match patterns are used to assign a resource to a specific place. The format is:
@@ -247,9 +251,11 @@ To retrieve a list of places run:
 .INDENT 0.0
 .INDENT 3.5
 .sp
-.EX
+.nf
+.ft C
 $ labgrid\-client places
-.EE
+.ft P
+.fi
 .UNINDENT
 .UNINDENT
 .sp
@@ -258,9 +264,11 @@ the \fBacquire command\fP and passing the placename as a \-p parameter:
 .INDENT 0.0
 .INDENT 3.5
 .sp
-.EX
+.nf
+.ft C
 $ labgrid\-client \-p <placename> acquire
-.EE
+.ft P
+.fi
 .UNINDENT
 .UNINDENT
 .sp
@@ -268,9 +276,11 @@ Open a console to the acquired place:
 .INDENT 0.0
 .INDENT 3.5
 .sp
-.EX
+.nf
+.ft C
 $ labgrid\-client \-p <placename> console
-.EE
+.ft P
+.fi
 .UNINDENT
 .UNINDENT
 .sp
@@ -278,9 +288,11 @@ Add all resources with the group \(dqexample\-group\(dq to the place example\-pl
 .INDENT 0.0
 .INDENT 3.5
 .sp
-.EX
+.nf
+.ft C
 $ labgrid\-client \-p example\-place add\-match */example\-group/*/*
-.EE
+.ft P
+.fi
 .UNINDENT
 .UNINDENT
 .SH SEE ALSO

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -117,6 +117,11 @@ LG_SSH_CONNECT_TIMEOUT
 Set the connection timeout when using SSH (The ``ConnectTimeout`` option). If
 unspecified, defaults to 30 seconds.
 
+LG_SSH_STRICT_HOST_KEY_CHECKING
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Set strict host key checking status for SSH client. (The ``StrictHostKeyChecking`` option). If
+unspecified, defaults to ``yes``
+
 MATCHES
 -------
 Match patterns are used to assign a resource to a specific place. The format is:


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Enables setting StrictHostKeyChecking option for SSH client by introducing LG_SSH_STRICT_HOST_KEY_CHECKING environment variable.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
