### PR TITLE
[RFC] pytestplugin: make "target" a parametrized fixture

### DIFF
--- a/labgrid/pytestplugin/__init__.py
+++ b/labgrid/pytestplugin/__init__.py
@@ -1,2 +1,2 @@
-from .fixtures import pytest_addoption, env, target, strategy
+from .fixtures import pytest_addoption, env, pytest_generate_tests, strategy
 from .hooks import pytest_configure, pytest_collection_modifyitems, pytest_cmdline_main


### PR DESCRIPTION
**Description**

This allows users to run their pytest test scripts with an `LG_ENV`/`--lg-env` that has multiple targets instead of forcing the user to define one named "main" in order to run the tests.

One of the downsides of this implementation is that autogenerated doc wouldn't define the "target" fixture anymore as it is entirely programmatically defined.

I'm investigating using labgrid for validating U-Boot with multiple pytest tests inside a single file, for multiple targets. Not sure it's the best practice but I intuitively went for that.

Essentially:

```yaml
---
targets:
    px30-ringneck-1:
        features:
            - something
        options:
            emmc_path: '/mmc@ff370000'
    [...]
    rk3399-puma-1:
        features:
            - bootablespi
            - somethingelse
        options:
            emmc_path: '/mmc@ff390000'
    [...]
```

```py

# bootloader_command fixture depends on target fixture

def test_uboot_initial(bootloader_flash, bootloader_command):
    stdout = bootloader_command.run_check('version')
    assert 'U-Boot' in '\n'.join(stdout)


@pytest.mark.lg_feature('bootablespi')
def test_uboot_properfromspi(bootloader_flash, bootloader_command, env, target):
    [...]
```

I believe this would allow users to have one big YAML file for all their targets, or merge YAML files for the same target into one YAML file so with one call to pytest, multiple targets can be checked. It would also allow to have one big pytest file with all tests to run on all targets, with parametrizing their arguments via target:options/target:features.

I checked the output of `pytest --lg-env local.yaml --collect-only test.py` and the tests are listed twice, once for each target in the YAML file. I then ran the tests and because I don't have enough HW for the infra for two boards, it complained for the second board that it was lacking resources, but the first board ran the tests just fine.

**Checklist**
- [ ] Documentation for the feature (N/A?)
- [ ] Tests for the feature (N/A?)
- [ ] PR has been tested (somewhat; I don't have enough HW for the setup of two boards but the second board complains about lacking resources when I run pytest)

RFC because maybe there was a reason for only allowing a "main"-named target to run the pytest tests and also because I wasn't really able to make sure the second target was used for the second test run (though there are good hints it is).

Also I believe this may be a bit too enthusiastic, we probably want to add a selection mechanism instead of simply adding all targets from the file? e.g. maybe add an ``--lg-target`` option which can be repeated to collect which targets to include.

Also not entirely sure which part of the documentation we would need to update for that.