### PR TITLE
labgrid/driver/power: Add Tapo(Kasa) smart plug support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -239,6 +239,13 @@ Currently available are:
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
   for details.
 
+``tapoplug``
+  Controls *Tapo Smart Plugs* via `python-kasa
+  <https://github.com/python-kasa/python-kasa>`_.
+  Requires *KASA_USERNAME* and *KASA_USERNAME* environment variables to be set.
+  Tested on *Tapo P100* smart plug.
+  See the `list of supported TAPO devices <https://python-kasa.readthedocs.io/en/stable/SUPPORTED.html#tapo-devices>`_.
+
 ``tplink``
   Controls *TP-Link power strips* via `python-kasa
   <https://github.com/python-kasa/python-kasa>`_.

--- a/labgrid/driver/power/tapoplug.py
+++ b/labgrid/driver/power/tapoplug.py
@@ -1,0 +1,77 @@
+"""Tested with TAPO P100, and should be compatible with any TAPO smart plug supported by kasa
+
+There is a list of supported devices in python-kasa package official documentation.
+https://python-kasa.readthedocs.io/en/stable/SUPPORTED.html#tapo-devices
+
+"""
+
+import asyncio
+import os
+
+from kasa import (
+    Credentials,
+    DeviceConfig,
+    DeviceConnectionParameters,
+    DeviceEncryptionType,
+    DeviceFamily,
+    SmartProtocol,
+    smart,
+    transports,
+)
+
+connection_type = DeviceConnectionParameters(
+    device_family=DeviceFamily.SmartTapoPlug, encryption_type=DeviceEncryptionType.Klap, login_version=2
+)
+
+
+def get_credentials():
+    username = os.environ.get("KASA_USERNAME")
+    password = os.environ.get("KASA_PASSWORD")
+    if username is None or password is None:
+        raise ValueError(
+            "Username and password cannot be None.Set KASA_USERNAME and KASA_PASSWORD environment variables"
+        )
+    return Credentials(username=username, password=password)
+
+
+async def _power_set(host, port, index, value):
+    assert port is None
+    config = DeviceConfig(host=host, credentials=get_credentials(), connection_type=connection_type)
+    protocol = SmartProtocol(transport=transports.KlapTransportV2(config=config))
+
+    device = smart.SmartDevice(host=host, config=config, protocol=protocol)
+
+    try:
+        await device.update()
+
+        if value:
+            await device.turn_on()
+        else:
+            await device.turn_off()
+    except Exception as e:
+        print(f"An error occurred while setting power: {e}")
+    finally:
+        await device.disconnect()
+
+
+def power_set(host, port, index, value):
+    asyncio.run(_power_set(host, port, index, value))
+
+
+async def _power_get(host, port, index):
+    assert port is None
+    config = DeviceConfig(host=host, credentials=get_credentials(), connection_type=connection_type)
+    protocol = SmartProtocol(transport=transports.KlapTransportV2(config=config))
+
+    device = smart.SmartDevice(host=host, config=config, protocol=protocol)
+    try:
+        await device.update()
+        return device.is_on
+    except Exception as e:
+        print(f"An error occurred while getting power: {e}")
+    finally:
+        await device.disconnect()
+
+
+def power_get(host, port, index):
+    return asyncio.run(_power_get(host, port, index))

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -16,7 +16,7 @@ class NetworkPowerPort(Resource):
     """
     model = attr.ib(validator=attr.validators.instance_of(str))
     host = attr.ib(validator=attr.validators.instance_of(str))
-    index = attr.ib(validator=attr.validators.instance_of(str),
+    index = attr.ib(default='0',validator=attr.validators.instance_of(str),
                     converter=lambda x: str(int(x)))
 
 

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -299,6 +299,10 @@ class TestNetworkPowerDriver:
         pytest.importorskip("kasa")
         import labgrid.driver.power.tplink
 
+    def test_import_backend_tapoplug(self):
+        pytest.importorskip("kasa")
+        import labgrid.driver.power.tapoplug
+
     def test_import_backend_siglent(self):
         pytest.importorskip("vxi11")
         import labgrid.driver.power.siglent


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Adds power driver integration for Tapo Smart plugs with Klap authentication. 
python-kasa requires KASA_USERNAME and KASA_PASSWORD environment variables to be set to handle the authentication.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
