### PR TITLE
docker: fix nw_service not available error

### DIFF
--- a/labgrid/resource/docker.py
+++ b/labgrid/resource/docker.py
@@ -108,6 +108,7 @@ class DockerDaemon(ManagedResource):
             nw_service = target_factory.make_resource(
                 self.target, "NetworkService",
                 service_name, network_service)
+            nw_service.parent = self
             if client.container_name not in self._nw_services:
                 self._nw_services[client.container_name] = list()
             self._nw_services[client.container_name].append(nw_service)


### PR DESCRIPTION
There is race condition between container start and ssh-server service ready in container, which may possible make `nw_service` not available.

Make `nw_service` for docker not static allows `target` to wait for the available of `nw_service`, rather than raise an exception.

**Description**

Run the command `pytest -s --lg-env env.yaml test_shell.py`, there is a low probability next:
 
```
test_shell.py E

======================================== ERRORS =========================================
_____________________________ ERROR at setup of test_shell ______________________________

target = Target(name='main', env=Environment(config_file='env.yaml'))

    @pytest.fixture(scope="session")
    def command(target):
        strategy = target.get_driver("DockerStrategy")
        strategy.transition("accessible")
>       shell = target.get_driver("CommandProtocol")

conftest.py:8:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../../labgrid-venv/lib/python3.8/site-packages/labgrid/target.py:234: in get_driver
    return self._get_driver(cls, name=name, resource=resource, activate=activate)
../../../labgrid-venv/lib/python3.8/site-packages/labgrid/target.py:208: in _get_driver
    self.activate(found[0])
../../../labgrid-venv/lib/python3.8/site-packages/labgrid/target.py:462: in activate
    self.await_resources(resources)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = Target(name='main', env=Environment(config_file='env.yaml'))
resources = [NetworkService(target=Target(name='main', env=Environment(config_file='env.yaml')), name='NetworkService', state=<BindingState.bound: 1>, avail=False, address='172.17.0.2', username='root', password='root', port=22)]
timeout = None, avail = True

    def await_resources(self, resources, timeout=None, avail=True):
        """
        Poll the given resources and wait until they are (un-)available.

        Args:
            resources (List): the resources to poll
            timeout (float): optional timeout
            avail (bool): optionally wait until the resources are unavailable with avail=False
        """
        self.update_resources()

        waiting = set(r for r in resources if r.avail != avail)
        static = set(r for r in waiting if r.get_managed_parent() is None)
        if static:
>           raise NoResourceFoundError(
                f"Static resources are not {'available' if avail else 'unavailable'}: {static}"
            )
E           labgrid.exceptions.NoResourceFoundError: Static resources are not available: {NetworkService(target=Target(name='main', env=Environment(config_file='env.yaml')), name='NetworkService', state=<BindingState.bound: 1>, avail=False, address='172.17.0.2', username='root', password='root', port=22)}

../../../labgrid-venv/lib/python3.8/site-packages/labgrid/target.py:79: NoResourceFoundError
================================ short test summary info ================================
ERROR test_shell.py::test_shell - labgrid.exceptions.NoResourceFoundError: Static resources are not available: {Networ...
=================================== 1 error in 6.98s ====================================
```

This is because when container start, the ssh-server maybe not ready very quickly, which makes `_socket_connect` failure, then `nw_service.avail = False`.

This PR assigned a parent to `nw_service` which makes it no longer static, then `target` wait until they are available.

- [√] PR has been tested

After this patch, and if explicitly print exception, it will show next:

```
(labgrid-venv) pie@pie:~/labgrid/examples/docker$ pytest -s --lg-env env.yaml test_shell.py
========================================================================= test session starts ==========================================================================
platform linux -- Python 3.8.10, pytest-8.3.3, pluggy-1.5.0
rootdir: /home/pie/labgrid/examples
configfile: pytest.ini
plugins: labgrid-24.1.dev130
collected 1 item

test_shell.py Traceback (most recent call last):
  File "/home/pie/labgrid-venv/lib/python3.8/site-packages/labgrid/resource/docker.py", line 154, in _socket_connect
    s = socket.create_connection((address, port))
  File "/usr/lib/python3.8/socket.py", line 808, in create_connection
    raise err
  File "/usr/lib/python3.8/socket.py", line 796, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
Traceback (most recent call last):
  File "/home/pie/labgrid-venv/lib/python3.8/site-packages/labgrid/resource/docker.py", line 154, in _socket_connect
    s = socket.create_connection((address, port))
  File "/usr/lib/python3.8/socket.py", line 808, in create_connection
    raise err
  File "/usr/lib/python3.8/socket.py", line 796, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
Traceback (most recent call last):
  File "/home/pie/labgrid-venv/lib/python3.8/site-packages/labgrid/resource/docker.py", line 154, in _socket_connect
    s = socket.create_connection((address, port))
  File "/usr/lib/python3.8/socket.py", line 808, in create_connection
    raise err
  File "/usr/lib/python3.8/socket.py", line 796, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused
.

========================================================================== 1 passed in 3.42s ===========================================================================
(labgrid-venv) pie@pie:~/labgrid/examples/docker$
```
You can see even `Connection refused`, finally after ssh-server ready, the test pass.

