### PR TITLE
driver/sshdriver: read from tools

### DIFF
--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -132,6 +132,14 @@ See:  <https://www.intel.com/content/www/us/en/docs/programmable/683039/22\-3/hp
 Path to the rk\-usb\-loader binary, used by the RKUSBDriver.
 See:  <https://git.pengutronix.de/cgit/barebox/tree/scripts/rk\-usb\-loader.c> 
 .TP
+.B \fBrsync\fP
+Path to the rsync binary, used by the SSHDriver.
+See:  <https://github.com/rsyncproject/rsync> 
+.TP
+.B \fBscp\fP
+Path to the scp binary, used by the SSHDriver.
+See:  <https://github.com/openssh/openssh\-portable> 
+.TP
 .B \fBsd\-mux\-ctrl\fP
 Path to the sd\-mux\-ctrl binary, used by the USBSDWireDriver.
 See:  <https://git.tizen.org/cgit/tools/testlab/sd\-mux/> 
@@ -139,6 +147,14 @@ See:  <https://git.tizen.org/cgit/tools/testlab/sd\-mux/>
 .B \fBsispmctl\fP
 Path to the sispmctl binary, used by the SiSPMPowerDriver.
 See:  <https://sispmctl.sourceforge.net/> 
+.TP
+.B \fBssh\fP
+Path to the ssh binary, used by the SSHDriver.
+See:  <https://github.com/openssh/openssh\-portable> 
+.TP
+.B \fBsshfs\fP
+Path to the sshfs binary, used by the SSHDriver.
+See:  <https://github.com/libfuse/sshfs> 
 .TP
 .B \fBuhubctl\fP
 Path to the uhubctl binary, used by the USBPowerDriver.

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -131,6 +131,14 @@ TOOLS KEYS
     Path to the rk-usb-loader binary, used by the RKUSBDriver.
     See: https://git.pengutronix.de/cgit/barebox/tree/scripts/rk-usb-loader.c
 
+``rsync``
+    Path to the rsync binary, used by the SSHDriver.
+    See: https://github.com/rsyncproject/rsync
+
+``scp``
+    Path to the scp binary, used by the SSHDriver.
+    See: https://github.com/openssh/openssh-portable
+
 ``sd-mux-ctrl``
     Path to the sd-mux-ctrl binary, used by the USBSDWireDriver.
     See: https://git.tizen.org/cgit/tools/testlab/sd-mux/
@@ -138,6 +146,14 @@ TOOLS KEYS
 ``sispmctl``
     Path to the sispmctl binary, used by the SiSPMPowerDriver.
     See: https://sispmctl.sourceforge.net/
+
+``ssh``
+    Path to the ssh binary, used by the SSHDriver.
+    See: https://github.com/openssh/openssh-portable
+
+``sshfs``
+    Path to the sshfs binary, used by the SSHDriver.
+    See: https://github.com/libfuse/sshfs
 
 ``uhubctl``
     Path to the uhubctl binary, used by the USBPowerDriver.


### PR DESCRIPTION
**Description**
`SSHDriver` now supports the `tools` key in the config to customize the path to `ssh`, `scp`, `sshfs` and `rsync`. It falls back to loading them from the `PATH`, so there's no change in behaviour if the tools aren't specified.

This is useful when running Labgrid on hosts which don't have these tools installed. It also allows running Labgrid workflows hermetically.

**Testing**
Manual tests have been done, using `SSHDriver` to transfer files and execute commands. 

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested
- [x] Man pages have been regenerated

Fixes #1553
