### PR TITLE
doc: hostname can have a '-' character

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1687,7 +1687,7 @@ Implements:
 .. code-block:: yaml
 
    ShellDriver:
-     prompt: 'root@\w+:[^ ]+ '
+     prompt: 'root@[\w-]+:[^ ]+ '
      login_prompt: ' login: '
      username: 'root'
 
@@ -3300,7 +3300,7 @@ Here is an example environment config:
          SerialDriver: {}
          BareboxDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
          BareboxStrategy: {}
@@ -3347,7 +3347,7 @@ Here is an example environment config:
          ManualPowerDriver: {}
          SerialDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
          ShellStrategy: {}
@@ -3395,7 +3395,7 @@ Here is an example environment config:
          SerialDriver: {}
          UBootDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
          UBootStrategy: {}

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -126,7 +126,7 @@ and ``password`` of the ShellDriver driver in ``local.yaml``:
             name: "example"
           SerialDriver: {}
           ShellDriver:
-            prompt: 'root@\w+:[^ ]+ '
+            prompt: 'root@[\w-]+:[^ ]+ '
             login_prompt: ' login: '
             username: 'root'
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -494,7 +494,7 @@ access this board:
       drivers:
         SerialDriver: {}
         ShellDriver:
-          prompt: 'root@\w+:[^ ]+ '
+          prompt: 'root@[\w-]+:[^ ]+ '
           login_prompt: ' login: '
           username: 'root'
 
@@ -665,7 +665,7 @@ setup:
         BareboxDriver:
           prompt: 'barebox@[^:]+:[^ ]+ '
         ShellDriver:
-          prompt: 'root@\w+:[^ ]+ '
+          prompt: 'root@[\w-]+:[^ ]+ '
           login_prompt: ' login: '
           username: 'root'
         BareboxStrategy: {}

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -203,7 +203,7 @@ A sample configuration with one `main` target, accessible via SerialPort
        drivers:
          SerialDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
 
@@ -221,7 +221,7 @@ in the loaded local python file:
        drivers:
          SerialDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
 	 IMXUSBDriver: {}


### PR DESCRIPTION
rfc952 specifies:

  A "name" (Net, Host, Gateway, or Domain name) is a text string up
     to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus
     sign (-), and period (.).  Note that periods are only allowed when
     they serve to delimit components of "domain style names".

