### PR TITLE
Qemu enhancements for extra_args

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ more performant and the import times are shorter.
 New Features in 24.1
 ~~~~~~~~~~~~~~~~~~~~
 - All components can be installed into the same virtualenv again.
+- The `QEMUDriver` now supports setting the ``display`` option to
+  ``qemu-default``, which will neither set the QEMU ``-display`` option
+  or pass along ``-nographic``.
 
 Bug fixes in 24.1
 ~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2726,6 +2726,7 @@ Arguments:
     - none: Do not create a display device
     - fb-headless: Create a headless framebuffer device
     - egl-headless: Create a headless GPU-backed graphics card. Requires host support
+    - qemu-default: Don't override QEMU default settings
 
   - nic (str): optional, configuration string to pass to QEMU to create a network interface
 

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2712,7 +2712,7 @@ Arguments:
   - machine (str): QEMU machine type
   - cpu (str): QEMU cpu type
   - memory (str): QEMU memory size (ends with M or G)
-  - extra_args (str): extra QEMU arguments, they are passed directly to the QEMU binary
+  - extra_args (str): optional, extra QEMU arguments, they are passed directly to the QEMU binary
   - boot_args (str): optional, additional kernel boot argument
   - kernel (str): optional, reference to the images key for the kernel
   - disk (str): optional, reference to the images key for the disk image

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -48,6 +48,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             none: Do not create a display device
             fb-headless: Create a headless framebuffer device
             egl-headless: Create a headless GPU-backed graphics card. Requires host support
+            qemu-default: Don't override QEMU default settings
         nic (str): optional, configuration string to pass to QEMU to create a network interface
     """
     qemu_bin = attr.ib(validator=attr.validators.instance_of(str))
@@ -85,7 +86,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         default="none",
         validator=attr.validators.optional(attr.validators.and_(
             attr.validators.instance_of(str),
-            attr.validators.in_(["none", "fb-headless", "egl-headless"]),
+            attr.validators.in_(
+                ["none", "fb-headless", "egl-headless", "qemu-default"]
+            ),
         ))
     )
     nic = attr.ib(
@@ -211,7 +214,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 cmd.append("virtio")
             cmd.append("-display")
             cmd.append("egl-headless")
-        else:
+        elif self.display != "qemu-default":
             raise ExecutionError(f"Unknown display '{self.display}'")
 
         if self.nic:

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -35,7 +35,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         machine (str): QEMU machine type
         cpu (str): QEMU cpu type
         memory (str): QEMU memory size (ends with M or G)
-        extra_args (str): extra QEMU arguments, they are passed directly to the QEMU binary
+        extra_args (str): optional, extra QEMU arguments passed directly to the QEMU binary
         boot_args (str): optional, additional kernel boot argument
         kernel (str): optional, reference to the images key for the kernel
         disk (str): optional, reference to the images key for the disk image
@@ -54,7 +54,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
     machine = attr.ib(validator=attr.validators.instance_of(str))
     cpu = attr.ib(validator=attr.validators.instance_of(str))
     memory = attr.ib(validator=attr.validators.instance_of(str))
-    extra_args = attr.ib(validator=attr.validators.instance_of(str))
+    extra_args = attr.ib(
+        default='',
+        validator=attr.validators.optional(attr.validators.instance_of(str)))
     boot_args = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str)))

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -273,9 +273,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             self.qmp = QMPMonitor(self._child.stdout, self._child.stdin)
         except QMPError as exc:
             if self._child.poll() is not None:
-                self._child.communicate()
+                _, err = self._child.communicate()
                 raise IOError(
-                    f"QEMU process terminated with exit code {self._child.returncode}"
+                    f"QEMU error: {err} (exitcode={self._child.returncode})"
                 ) from exc
             raise
 


### PR DESCRIPTION
**Description**

- what do you use the feature for?

The barebox test suite uses Labgrid in CI for QEMU and these are some quality of life improvements around `QEMUDriver` `extra_args`:

  - Allow `extra_args` to be empty
  - Show QEMU stderr for malformed `extra_args`
  - Allow `extra_args` to list display devices and have them shown if requested

- how did you verify the feature works?

Manually by editing the YAML and running Labgrid with QEMUDriver:
   - by removing `extra_args`
   - adding an unknown option in `extra_args` 
   - adding `-device ramfb` in `extra_args` and setting `display` to `qemu-default`

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x ] PR has been tested
