### PR TITLE
labgrid/resource/remote: add missing sigrok channel_group parameter

### DIFF
--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -186,6 +186,10 @@ class NetworkSigrokUSBDevice(RemoteUSBResource):
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
+    channel_group = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()
@@ -200,6 +204,10 @@ class NetworkSigrokUSBSerialDevice(RemoteUSBResource):
         validator=attr.validators.instance_of(str)
     )
     channels = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str))
+    )
+    channel_group = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Add the missing sigrok channel_group parameter to the Network variants of the sigrok resources.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->

Fixes: #1536 