### PR TITLE
remote/exporter: apply ruff format fixes for 2025 style guide

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -249,7 +249,7 @@ class SerialPortExport(ResourceExport):
                 "-Y",
                 f"connection: &con01#  accepter: telnet(rfc2217,mode=server),tcp,{self.port}",
                 "-Y",
-                f'  connector: serialdev(nouucplock=true),{start_params["path"]},{self.local.speed}n81,local',  # pylint: disable=line-too-long
+                f"  connector: serialdev(nouucplock=true),{start_params['path']},{self.local.speed}n81,local",  # pylint: disable=line-too-long
                 "-Y",
                 "  options:",
                 "-Y",
@@ -262,7 +262,7 @@ class SerialPortExport(ResourceExport):
                 "-n",
                 "-u",
                 "-C",
-                f'{self.port}:telnet:0:{start_params["path"]}:{self.local.speed} NONE 8DATABITS 1STOPBIT LOCAL',  # pylint: disable=line-too-long
+                f"{self.port}:telnet:0:{start_params['path']}:{self.local.speed} NONE 8DATABITS 1STOPBIT LOCAL",  # pylint: disable=line-too-long
             ]
         self.logger.info("Starting ser2net with: %s", " ".join(cmd))
         self.child = subprocess.Popen(cmd)


### PR DESCRIPTION
**Description**
This change is caused by updating ruff 0.8.6 -> 0.9.0. The changelog reads:

> Ruff now formats your code according to the 2025 style guide. As a result, your code might now get formatted differently. See the formatter section for a detailed list of changes.

From: https://github.com/astral-sh/ruff/blob/main/CHANGELOG.md

Fixes the scheduled CI errors: https://github.com/labgrid-project/labgrid/actions/runs/12705943303/job/35417915127

**Checklist**
- [x] PR has been tested