### PR TITLE
readthedocs: set explicit sphinx configuration and bump Ubuntu/Python

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+sphinx:
+  configuration: doc/conf.py
+
 python:
   install:
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,6 +11,6 @@ python:
         - doc
 
 build:
-  os: "ubuntu-22.04"
+  os: "ubuntu-24.04"
   tools:
-    python: "3.11"
+    python: "3.13"


### PR DESCRIPTION
**Description**
Not specifying a configuration is now deprecated and results in permanent errors soon [1].

Temporary build errors were already observed, see the deprecation timeline in: https://app.readthedocs.org/projects/labgrid/builds/

While at it, bump RTD's Ubuntu/Python versions.

[1] https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/

**Checklist**
- [x] PR has been tested