### PR TITLE
add support for KMTronic usb relay controller

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -589,6 +589,25 @@ Arguments:
 Used by:
   - `GpioDigitalOutputDriver`_
 
+KMTronicRelay
++++++++++++++
+A :any:`KMTronicRelay` resource describes a single output of an USB Relay Controller from KMTronic.
+
+.. code-block:: yaml
+
+   KMTronicRelay:
+     index: 2
+     match:
+       ID_SERIAL_SHORT: 'AB0LBF2U'
+
+Arguments:
+  - index (int): number of the relay to use.
+  - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+NetworkKMTronicRelay
+++++++++++++++++++++
+A :any:`NetworkKMTronicRelay` describes an `KMTronicRelay`_ exported over the network.
+
 NetworkService
 ~~~~~~~~~~~~~~
 A :any:`NetworkService` describes a remote SSH connection.
@@ -2353,6 +2372,30 @@ Implements:
 
 Arguments:
   - None
+
+KMTronicRelayDriver
+~~~~~~~~~~~~~~~~~~~
+A :any:`KMTronicRelayDriver` controls an `KMTronicRelay`_ or `NetworkKMTronicRelay`_ resource.
+It can set and get the current state of the resource.
+
+Binds to:
+  relay:
+    - `KMTronicRelay`_
+    - `NetworkKMTronicRelay`_
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   KMTronicRelayDriver: {}
+
+Arguments:
+  - None
+
+.. note::
+  In order to be able to use this driver pyserial need to be installed on
+  the system the relay is connected to.
 
 ManualSwitchDriver
 ~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -597,12 +597,20 @@ A :any:`KMTronicRelay` resource describes a single output of an USB Relay Contro
 
    KMTronicRelay:
      index: 2
+     ports: 8
      match:
        ID_SERIAL_SHORT: 'AB0LBF2U'
 
 Arguments:
-  - index (int): number of the relay to use.
+  - index (int, default=1): number on the relay to use.
+  - ports: (int, default=1): number of ports on the relay.
   - match (dict): key and value pairs for a udev match, see `udev Matching`_
+
+.. note::
+   IMPORTANT
+   Set ports=8 if you are using a 8 relay controller. if not the default=1 is fine.
+   The reason for this is the 8 relay controller does not read the state of relays the same
+   way as the other controllers.
 
 NetworkKMTronicRelay
 ++++++++++++++++++++

--- a/examples/kmtronic/kmtronic-exporter.yaml
+++ b/examples/kmtronic/kmtronic-exporter.yaml
@@ -2,5 +2,6 @@ main:
   location: Work Desk
   KMTronicRelay:
     index: 3
+    ports: 8
     match:
       ID_SERIAL_SHORT: 'AB0LBF2U'

--- a/examples/kmtronic/kmtronic-exporter.yaml
+++ b/examples/kmtronic/kmtronic-exporter.yaml
@@ -1,0 +1,6 @@
+main:
+  location: Work Desk
+  KMTronicRelay:
+    index: 3
+    match:
+      ID_SERIAL_SHORT: 'AB0LBF2U'

--- a/examples/kmtronic/kmtronic.yaml
+++ b/examples/kmtronic/kmtronic.yaml
@@ -1,0 +1,10 @@
+targets:
+  main:
+    resources:
+      KMTronicRelay:
+        index: 3
+
+    drivers:
+      KMTronicRelayDriver: {}
+      DigitalOutputPowerDriver:
+        delay: 2.0

--- a/examples/kmtronic/kmtronic.yaml
+++ b/examples/kmtronic/kmtronic.yaml
@@ -2,7 +2,7 @@ targets:
   main:
     resources:
       KMTronicRelay:
-        index: 3
+        index: 2
 
     drivers:
       KMTronicRelayDriver: {}

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -48,3 +48,4 @@ from .usbtmcdriver import USBTMCDriver
 from .deditecrelaisdriver import DeditecRelaisDriver
 from .dediprogflashdriver import DediprogFlashDriver
 from .httpdigitaloutput import HttpDigitalOutputDriver
+from .kmtronicrelay import KMTronicRelayDriver

--- a/labgrid/driver/kmtronicrelay.py
+++ b/labgrid/driver/kmtronicrelay.py
@@ -1,0 +1,44 @@
+import attr
+
+from .common import Driver
+from ..factory import target_factory
+from ..step import step
+from ..protocol import DigitalOutputProtocol
+from ..util.agentwrapper import AgentWrapper
+from ..resource.remote import NetworkKMTronicRelay
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class KMTronicRelayDriver(Driver, DigitalOutputProtocol):
+    bindings = {
+        "relay": {"KMTronicRelay", "NetworkKMTronicRelay"},
+    }
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.wrapper = None
+
+    def on_activate(self):
+        if isinstance(self.relay, NetworkKMTronicRelay):
+            host = self.relay.host
+        else:
+            host = None
+        self.wrapper = AgentWrapper(host)
+        self.proxy = self.wrapper.load('kmtronic_relay')
+
+    def on_deactivate(self):
+        self.wrapper.close()
+        self.wrapper = None
+        self.proxy = None
+
+    @Driver.check_active
+    @step(args=['status'])
+    def set(self, status):
+        self.proxy.set(self.relay.path, self.relay.index, status)
+
+    @Driver.check_active
+    @step(result=True)
+    def get(self):
+        status = self.proxy.get(self.relay.path, self.relay.index)
+        return status

--- a/labgrid/driver/kmtronicrelay.py
+++ b/labgrid/driver/kmtronicrelay.py
@@ -40,5 +40,5 @@ class KMTronicRelayDriver(Driver, DigitalOutputProtocol):
     @Driver.check_active
     @step(result=True)
     def get(self):
-        status = self.proxy.get(self.relay.path, self.relay.index)
+        status = self.proxy.get(self.relay.path, self.relay.index, self.relay.ports)
         return status

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -898,8 +898,7 @@ class ClientSession:
         name = self.args.name
         target = self._get_target(place)
         from ..resource import ModbusTCPCoil, OneWirePIO, HttpDigitalOutput
-        from ..resource.remote import NetworkDeditecRelais8, NetworkSysfsGPIO, NetworkLXAIOBusPIO, NetworkHIDRelay
-
+        from ..resource.remote import NetworkDeditecRelais8, NetworkSysfsGPIO, NetworkLXAIOBusPIO, NetworkHIDRelay, NetworkKMTronicRelay
         drv = None
         try:
             drv = target.get_driver("DigitalOutputProtocol", name=name)
@@ -919,6 +918,8 @@ class ClientSession:
                     drv = self._get_driver_or_new(target, "LXAIOBusPIODriver", name=name)
                 elif isinstance(resource, NetworkHIDRelay):
                     drv = self._get_driver_or_new(target, "HIDRelayDriver", name=name)
+                elif isinstance(resource, NetworkKMTronicRelay):
+                    drv = self._get_driver_or_new(target, "KMTronicRelayDriver", name=name)
                 if drv:
                     break
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -525,6 +525,24 @@ class USBHIDRelayExport(USBGenericExport):
             "index": self.local.index,
         }
 
+@attr.s(eq=False)
+class KMTronicRelayExport(USBGenericExport):
+    """ResourceExport for outputs on KMTronic relays"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_params(self):
+        """Helper function to return parameters"""
+        return {
+            "host": self.host,
+            "busnum": self.local.busnum,
+            "devnum": self.local.devnum,
+            "path": self.local.path,
+            "vendor_id": self.local.vendor_id,
+            "model_id": self.local.model_id,
+            "index": self.local.index,
+        }
 
 @attr.s(eq=False)
 class USBFlashableExport(USBGenericExport):
@@ -567,6 +585,7 @@ exports["SiSPMPowerPort"] = SiSPMPowerPortExport
 exports["USBPowerPort"] = USBPowerPortExport
 exports["DeditecRelais8"] = USBDeditecRelaisExport
 exports["HIDRelay"] = USBHIDRelayExport
+exports["KMTronicRelay"] = KMTronicRelayExport
 exports["USBFlashableDevice"] = USBFlashableExport
 exports["LXAUSBMux"] = USBGenericExport
 

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -542,6 +542,7 @@ class KMTronicRelayExport(USBGenericExport):
             "vendor_id": self.local.vendor_id,
             "model_id": self.local.model_id,
             "index": self.local.index,
+            "ports": self.local.ports,
         }
 
 @attr.s(eq=False)

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -32,6 +32,7 @@ from .udev import (
     USBSerialPort,
     USBTMC,
     USBVideo,
+    KMTronicRelay,
 )
 from .common import Resource, ResourceManager, ManagedResource
 from .ykushpowerport import YKUSHPowerPort, NetworkYKUSHPowerPort

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -332,6 +332,14 @@ class NetworkHIDRelay(RemoteUSBResource):
         self.timeout = 10.0
         super().__attrs_post_init__()
 
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkKMTronicRelay(RemoteUSBResource):
+    """The NetworkKMTronicRelay describes a remotely accessible USB relay port"""
+    index = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
 
 @target_factory.reg_resource
 @attr.s(eq=False)

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -337,6 +337,8 @@ class NetworkHIDRelay(RemoteUSBResource):
 class NetworkKMTronicRelay(RemoteUSBResource):
     """The NetworkKMTronicRelay describes a remotely accessible USB relay port"""
     index = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    ports = attr.ib(default=1, validator=attr.validators.instance_of(int))
+
     def __attrs_post_init__(self):
         self.timeout = 10.0
         super().__attrs_post_init__()

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -708,6 +708,22 @@ class HIDRelay(USBResource):
 
 @target_factory.reg_resource
 @attr.s(eq=False)
+class KMTronicRelay(USBResource):
+    index = attr.ib(default=1, validator=attr.validators.instance_of(int))
+
+    def __attrs_post_init__(self):
+        self.match['SUBSYSTEM'] = 'tty'
+        super().__attrs_post_init__()
+
+    @property
+    def path(self):
+        if self.device is not None:
+            return self.device.device_node
+
+        return None
+
+@target_factory.reg_resource
+@attr.s(eq=False)
 class USBFlashableDevice(USBResource):
     @property
     def devnode(self):

--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -710,6 +710,7 @@ class HIDRelay(USBResource):
 @attr.s(eq=False)
 class KMTronicRelay(USBResource):
     index = attr.ib(default=1, validator=attr.validators.instance_of(int))
+    ports = attr.ib(default=1, validator=attr.validators.instance_of(int))
 
     def __attrs_post_init__(self):
         self.match['SUBSYSTEM'] = 'tty'

--- a/labgrid/util/agents/kmtronic_relay.py
+++ b/labgrid/util/agents/kmtronic_relay.py
@@ -1,0 +1,38 @@
+import serial
+
+class USBKMTronicRelay:
+    def set_output(self, path, index, status):
+        # second and third is index and status on/off
+        # \xFF\x01\x00 = turn relay 1 off
+        # \xFF\x01\x01 = turn relay 1 on
+        cmd = bytes([255, index, int(status == True)])
+        with serial.Serial(path, 9600) as ser:
+            ser.write(cmd)
+
+    def get_output(self, path, index):
+        # \xFF\x01\x03 will read relay 1 status
+        cmd = bytes([255, index, 3])
+        with serial.Serial(path, 9600) as ser:
+            ser.write(cmd)
+            data = ser.read(3)
+        return data[2]
+
+_relays = {}
+
+def _get_relay(path):
+    if (path) not in _relays:
+        _relays[(path)] = USBKMTronicRelay()
+    return _relays[(path)]
+
+def handle_set(path, index, status):
+    relay = _get_relay(path)
+    relay.set_output(path, index, status)
+
+def handle_get(path, index):
+    relay = _get_relay(path)
+    return relay.get_output(path, index)
+
+methods = {
+    "set": handle_set,
+    "get": handle_get,
+}

--- a/labgrid/util/agents/kmtronic_relay.py
+++ b/labgrid/util/agents/kmtronic_relay.py
@@ -9,13 +9,29 @@ class USBKMTronicRelay:
         with serial.Serial(path, 9600) as ser:
             ser.write(cmd)
 
-    def get_output(self, path, index):
+    def get_output(self, path, index, ports):
         # \xFF\x01\x03 will read relay 1 status
+        # \xFF\x09\x00 will read from all relays, only works on 4 and 8 relay controller
         cmd = bytes([255, index, 3])
-        with serial.Serial(path, 9600) as ser:
+        if ports > 2:
+            cmd = bytes([255, 9, 0])
+        with serial.Serial(path, 9600, timeout=10) as ser:
             ser.write(cmd)
-            data = ser.read(3)
-        return data[2]
+            if ports > 2:
+                data = ser.read(ports)
+                if data[0] == 255:
+                    print("WARNING: Unexpected return value from KMTronic relay.")
+                    print("Make sure to configure ports correctly in your config.2")
+                    return -1
+                state = data[index-1]
+            else:
+                data = ser.read(3)
+                if data[0] != 255:
+                    print("WARNING: Unexpected return value from KMTronic relay.")
+                    print("Make sure to configure ports correctly in your config.1")
+                    return -1
+                state = data[2]
+        return state
 
 _relays = {}
 
@@ -28,9 +44,9 @@ def handle_set(path, index, status):
     relay = _get_relay(path)
     relay.set_output(path, index, status)
 
-def handle_get(path, index):
+def handle_get(path, index, ports):
     relay = _get_relay(path)
-    return relay.get_output(path, index)
+    return relay.get_output(path, index, ports)
 
 methods = {
     "set": handle_set,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -110,6 +110,11 @@ def test_all_modules():
     methods = aw.list()
     assert 'usb_hid_relay.set' in methods
     assert 'usb_hid_relay.get' in methods
+    aw.load('kmtronic_relay')
+    methods = aw.list()
+    assert 'kmtronic_relay.set' in methods
+    assert 'kmtronic_relay.get' in methods
+    
 
 def test_import_modules():
     import labgrid.util.agents

--- a/tests/test_kmtronicrelay.py
+++ b/tests/test_kmtronicrelay.py
@@ -1,0 +1,22 @@
+from labgrid.resource.udev import KMTronicRelay
+from labgrid.driver.kmtronicrelay import KMTronicRelayDriver
+
+
+def test_kmtronicrelay_resource(target):
+    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"})
+
+
+def test_kmtronicrelay_driver(target):
+    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"})
+    d = KMTronicRelayDriver(target, name=None)
+    target.activate(d)
+
+
+def test_kmtronicrelay_control(target):
+    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"})
+    d = KMTronicRelayDriver(target, name=None)
+    target.activate(d)
+    d.set(1)
+    assert d.get() == 1
+    d.set(0)
+    assert d.get() == 0

--- a/tests/test_kmtronicrelay.py
+++ b/tests/test_kmtronicrelay.py
@@ -3,17 +3,17 @@ from labgrid.driver.kmtronicrelay import KMTronicRelayDriver
 
 
 def test_kmtronicrelay_resource(target):
-    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"})
+    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"}, index=2)
 
 
 def test_kmtronicrelay_driver(target):
-    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"})
+    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"}, index=2)
     d = KMTronicRelayDriver(target, name=None)
     target.activate(d)
 
 
 def test_kmtronicrelay_control(target):
-    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"})
+    r = KMTronicRelay(target, name=None, match={"ID_SERIAL_SHORT": "AB0LBF2U"}, index=2, ports=4)
     d = KMTronicRelayDriver(target, name=None)
     target.activate(d)
     d.set(1)


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
This adds support for KMTronic usb relay controller. 

Tests has been done using a KMTronic four channel usb relay controller: https://kmtronic.com/product/2786/usb-relay-controller-four-channel-box.html
Small tests for the resource and driver has been written and run with pytest to see in the driver works. 
A small setup with coordinator and exporter has also been setup to make sure network resources are available and work with the driver,
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature

- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
- [ ] Add a section on how to use the feature to doc/usage.rst
--->
<!---
A library feature which other developers can use:
- [ ] Add a section on how to use the feature to doc/development.rst
--->
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
- [ ] Man pages have been regenerated
--->
<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
