### PR TITLE
remote/exporter: fix info message for version

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -871,7 +871,7 @@ class Exporter:
                 logging.debug("received message %s", out_message)
                 kind = out_message.WhichOneof("kind")
                 if kind == "hello":
-                    logging.info("connected to exporter version %s", out_message.hello.version)
+                    logging.info("connected to coordinator version %s", out_message.hello.version)
                 elif kind == "set_acquired_request":
                     logging.debug("acquire request")
                     success = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,7 @@ class Exporter(LabgridComponent):
             cwd=self.cwd)
         try:
             self.spawn.expect('exporter name: testhost')
-            self.spawn.expect('connected to exporter')
+            self.spawn.expect('connected to coordinator')
         except Exception as e:
             raise Exception(f"exporter startup failed with {self.spawn.before}") from e
 


### PR DESCRIPTION
We receive the coordinator version in the hello message from the coordinator on the exporter side. Correctly print out that we connected to a coordinator with the sent back version instead of confusingly printing that this is the exporter version.