### PR TITLE
Add support for Waveshare Modbus Relays

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -416,6 +416,32 @@ Arguments:
 Used by:
   - `ModbusCoilDriver`_
 
+WaveshareModbusTCPCoil
+++++++++++++++++++++++
+A :any:`WaveshareModbusTCPCoil` describes a Waveshare branded coil accessible via *Modbus TCP*.
+
+.. code-block:: yaml
+
+   WaveshareModbusTCPCoil:
+     host: '192.168.23.42'
+     coil: 1
+     coil_count: 8 
+
+The example describes the coil ``1`` (zero indexed) of ``8`` on the Waveshare Modbus TCP relay
+module ``192.168.23.42``.
+
+Arguments:
+  - host (str): hostname of the Modbus TCP server e.g. ``192.168.23.42:502``
+  - coil (int): index of the coil, e.g. ``3``
+  - invert (bool, default=False): whether the logic level is inverted
+    (active-low)
+  - write_multiple_coils (bool, default=False): whether to perform write
+    using "write multiple coils" method instead of "write single coil"
+
+Used by:
+  - `WaveShareModbusCoilDriver`_
+
+
 DeditecRelais8
 ++++++++++++++
 A :any:`DeditecRelais8` describes a *Deditec USB GPO module* with 8 relays.
@@ -2330,6 +2356,25 @@ Implements:
 .. code-block:: yaml
 
    ModbusCoilDriver: {}
+
+Arguments:
+  - None
+
+WaveShareModbusCoilDriver
+~~~~~~~~~~~~~~~~~~~~~~~~~
+A :any:`WaveShareModbusCoilDriver` controls a `WaveshareModbusTCPCoil`_ resource.
+It can set and get the current state of the resource.
+
+Binds to:
+  coil:
+    - `WaveshareModbusTCPCoil`_
+
+Implements:
+  - :any:`DigitalOutputProtocol`
+
+.. code-block:: yaml
+
+   WaveShareModbusCoilDriver: {}
 
 Arguments:
   - None

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -904,7 +904,7 @@ class ClientSession:
         action = self.args.action
         name = self.args.name
         target = self._get_target(place)
-        from ..resource import ModbusTCPCoil, OneWirePIO, HttpDigitalOutput
+        from ..resource import ModbusTCPCoil, OneWirePIO, HttpDigitalOutput, WaveshareModbusTCPCoil
         from ..resource.remote import NetworkDeditecRelais8, NetworkSysfsGPIO, NetworkLXAIOBusPIO, NetworkHIDRelay
 
         drv = None
@@ -912,7 +912,9 @@ class ClientSession:
             drv = target.get_driver("DigitalOutputProtocol", name=name)
         except NoDriverFoundError:
             for resource in target.resources:
-                if isinstance(resource, ModbusTCPCoil):
+                if isinstance(resource, WaveshareModbusTCPCoil):
+                    drv = self._get_driver_or_new(target, "WaveShareModbusCoilDriver", name=name)
+                elif isinstance(resource, ModbusTCPCoil):
                     drv = self._get_driver_or_new(target, "ModbusCoilDriver", name=name)
                 elif isinstance(resource, OneWirePIO):
                     drv = self._get_driver_or_new(target, "OneWirePIODriver", name=name)

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -1,7 +1,7 @@
 from .base import SerialPort, NetworkInterface, EthernetPort, SysfsGPIO
 from .ethernetport import SNMPEthernetPort
 from .serialport import RawSerialPort, NetworkSerialPort
-from .modbus import ModbusTCPCoil
+from .modbus import ModbusTCPCoil, WaveshareModbusTCPCoil
 from .modbusrtu import ModbusRTU
 from .networkservice import NetworkService
 from .onewireport import OneWirePIO

--- a/labgrid/resource/modbus.py
+++ b/labgrid/resource/modbus.py
@@ -21,3 +21,17 @@ class ModbusTCPCoil(Resource):
     write_multiple_coils = attr.ib(
         default=False, validator=attr.validators.instance_of(bool)
     )
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class WaveshareModbusTCPCoil(ModbusTCPCoil):
+    """This resource describes Waveshare brand Modbus TCP coil.
+
+    Args:
+        host (str): hostname of the Modbus TCP server e.g. "192.168.23.42:502"
+        coil (int): index of the coil e.g. 3
+        coil_count (int): The total number of coils on this module.
+        invert (bool): optional, whether the logic level is be inverted (active-low)
+        write_multiple_coils (bool): optional, whether write using multiple coils method"""
+
+    coil_count = attr.ib(default=8, validator=attr.validators.instance_of(int))


### PR DESCRIPTION
Waveshare only implement the ability to query the status of all relays (https://www.waveshare.com/wiki/Modbus_RTU_Relay#Read_States_of_Relays) not just one, so a modification to the existing drivers is required.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
