### PR TITLE
remote/exporter: poll resource on add

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -1000,7 +1000,10 @@ class Exporter:
         }
         proxy_req = self.isolated
         if issubclass(export_cls, ResourceExport):
-            group[resource_name] = export_cls(config, host=self.hostname, proxy=getfqdn(), proxy_required=proxy_req)
+            res = group[resource_name] = export_cls(
+                config, host=self.hostname, proxy=getfqdn(), proxy_required=proxy_req
+            )
+            res.poll()
         else:
             config["params"]["extra"] = {
                 "proxy": getfqdn(),


### PR DESCRIPTION
Instead of providing incomplete resources on startup since the resource information has not been polled yet, poll the resource once while adding it.