### PR TITLE
agentwrapper: Allow specifying agent prefix

### DIFF
--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -46,12 +46,13 @@ class AgentWrapper:
         agent = os.path.join(
             os.path.abspath(os.path.dirname(__file__)),
             'agent.py')
+        agent_prefix = os.environ.get("LG_AGENT_PREFIX", "")
         if host:
             # copy agent.py and run via ssh
             with open(agent, 'rb') as agent_fd:
                 agent_data = agent_fd.read()
             agent_hash = hashlib.sha256(agent_data).hexdigest()
-            agent_remote = f'.labgrid_agent_{agent_hash}.py'
+            agent_remote = os.path.join(agent_prefix, f'.labgrid_agent_{agent_hash}.py')
             connect_timeout = get_ssh_connect_timeout()
             ssh_opts = f'ssh -x -o ConnectTimeout={connect_timeout} -o PasswordAuthentication=no'.split()
             subprocess.check_call(

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -124,6 +124,10 @@ CI pipelines where the username may not be consistent between pipeline stages.
 .sp
 Set the connection timeout when using SSH (The \fBConnectTimeout\fP option). If
 unspecified, defaults to 30 seconds.
+.SS LG_AGENT_PREFIX
+.sp
+Add a prefix to \fB\&.labgrid_agent_{agent_hash}.py\fP allowing specification for
+where on the exporter it should be uploaded to.
 .SH MATCHES
 .sp
 Match patterns are used to assign a resource to a specific place. The format is:

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -116,6 +116,11 @@ LG_SSH_CONNECT_TIMEOUT
 Set the connection timeout when using SSH (The ``ConnectTimeout`` option). If
 unspecified, defaults to 30 seconds.
 
+LG_AGENT_PREFIX
+~~~~~~~~~~~~~~~~~~~~~~
+Add a prefix to ``.labgrid_agent_{agent_hash}.py`` allowing specification for
+where on the exporter it should be uploaded to. 
+
 MATCHES
 -------
 Match patterns are used to assign a resource to a specific place. The format is:


### PR DESCRIPTION
Allows client to specify where on the exporter .labgrid_agent_{agent_hash}.py should be copied to. Default is the user homedir.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
<!---
If you add a feature other drivers/resources can benefit from:
--->
<!---
A library feature which other developers can use:
--->
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
