### PR TITLE
Update UUUDriver

### DIFF
--- a/doc/man/device-config.rst
+++ b/doc/man/device-config.rst
@@ -154,8 +154,8 @@ TOOLS KEYS
     Path to the usbsdmux tool, used by the USBSDMuxDriver.
     See: https://github.com/linux-automation/usbsdmux
 
-``uuu-loader``
-    Path to the uuu-loader binary, used by the UUUDriver.
+``uuu``
+    Path to the uuu binary, used by the UUUDriver.
     See: https://github.com/nxp-imx/mfgtools
 
 ``ykushcmd``

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -169,8 +169,8 @@ Path to the usbmuxctl tool, used by the LXAUSBMuxDriver.
 Path to the usbsdmux tool, used by the USBSDMuxDriver.
 See: \X'tty: link https://github.com/linux-automation/usbsdmux'\fI\%https://github.com/linux\-automation/usbsdmux\fP\X'tty: link'
 .TP
-.B \fBuuu\-loader\fP
-Path to the uuu\-loader binary, used by the UUUDriver.
+.B \fBuuu\fP
+Path to the uuu binary, used by the UUUDriver.
 See: \X'tty: link https://github.com/nxp-imx/mfgtools'\fI\%https://github.com/nxp\-imx/mfgtools\fP\X'tty: link'
 .TP
 .B \fBykushcmd\fP


### PR DESCRIPTION

**Description**
Changes default binary name from `uuu-loader` to `uuu`. The driver will use the usb-path to pass it to `-m` parameter to specifiy the usb-device to monitor.

With this multiple i.MX devices can be attached to one exporter device.
This has been tested on a Raspberry Pi with 3 attached i.MX8M Nano SoCs in SDP-Mode.
The uuu-tool used the specified usb-device.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
   - not needed
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [x] Man pages have been regenerated

