### PR TITLE
USBStorageDriver cleanup remote resource

### DIFF
--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -99,9 +99,9 @@ class USBStorageDriver(Driver):
             target_path = str(pathlib.PurePath(mount_path) / target_rel)
 
             copied_sources = []
+            files = [ManagedFile(f, self.storage) for f in sources]
 
-            for f in sources:
-                mf = ManagedFile(f, self.storage)
+            for mf in files:
                 mf.sync_to_resource()
                 copied_sources.append(mf.get_remote_path())
 
@@ -114,6 +114,10 @@ class USBStorageDriver(Driver):
                 args = ["cp", "-T", copied_sources[0], target_path]
 
             processwrapper.check_output(self.storage.command_prefix + args)
+
+            for mf in files:
+                mf.cleanup_resource()
+
             self.proxy.unmount(self.devpath)
         except:
             # We are going to die with an exception anyway, so no point in waiting
@@ -200,6 +204,8 @@ class USBStorageDriver(Driver):
             self.storage.command_prefix + args,
             print_on_silent_log=True
         )
+
+        mf.cleanup_resource()
 
     def _get_devpath(self, partition):
         partition = "" if partition is None else partition

--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -78,6 +78,21 @@ class ManagedFile:
                 # --symbolic --force --no-dereference
                 conn.run_check(f"ln -sfn {self.rpath}{os.path.basename(self.local_path)} {symlink}")
 
+    def cleanup_resource(self, symlink=None):
+        if isinstance(self.resource, NetworkResource):
+            host = self.resource.host
+            conn = sshmanager.open(host)
+
+            if self._on_nfs(conn):
+                pass
+            else:
+                self.rpath = f"{self.get_user_cache_path()}/{self.get_hash()}/"
+                self.logger.info("Removing %s on %s", self.local_path, host)
+                conn.run_check(f"rm -rf {self.rpath}")
+
+            if symlink is not None:
+                self.logger.info("Removing symlink {symlink}")
+                conn.run_check(f"rm -f {symlink}")
 
     def _on_nfs(self, conn):
         if self._on_nfs_cached is not None:


### PR DESCRIPTION
<!---
--->
**Description**

Change the USBStorageDriver class to cleanup remote files (ManagedFile) when the remote copy of the files have been used.
This helps avoid running out of disk space on the remote resource, especially if using USBStorageDriver with large image files.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested (tested in our local setup, verifying that no files were left after running tests that without this change left large image files in /var/cache/labgrid) (tested with a rebase to stable-24.0 branch, as we don't have a working test setup on master branch)
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
