### PR TITLE
Extend copyright period to 2025

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,4 @@
-Release 24.1 (Unreleased)
+Release 25.0 (Unreleased)
 -------------------------
 As announced
 `before <https://github.com/labgrid-project/labgrid/discussions/1467#discussioncomment-10314852>`_,
@@ -14,25 +14,25 @@ That's why labgrid moves to gRPC with this release. gRPC is a well maintained
 RPC framework with a lot of users. As a side effect, the message transfer is
 more performant and the import times are shorter.
 
-New Features in 24.1
+New Features in 25.0
 ~~~~~~~~~~~~~~~~~~~~
 - All components can be installed into the same virtualenv again.
 - The `QEMUDriver` now supports setting the ``display`` option to
   ``qemu-default``, which will neither set the QEMU ``-display`` option
   or pass along ``-nographic``.
 
-Bug fixes in 24.1
+Bug fixes in 25.0
 ~~~~~~~~~~~~~~~~~
 
 FIXME
 
-Breaking changes in 24.1
+Breaking changes in 25.0
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Maintaining support for both crossbar/autobahn as well as gRPC in labgrid would
 be a lot of effort due to the different architectures of those frameworks.
 Therefore, a hard migration to gRPC is deemed the lesser issue.
 
-Due to the migration, 24.1 includes the following breaking changes:
+Due to the migration, 25.0 includes the following breaking changes:
 
 - The labgrid environment config option ``crossbar_url`` was renamed to
   ``coordinator_address``. The environment variable ``LG_CROSSBAR`` was renamed
@@ -51,7 +51,7 @@ Other breaking changes include:
   removed) xdrlib. See
   `issue #1507 <https://github.com/labgrid-project/labgrid/issues/1507>`_.
 
-Known issues in 24.1
+Known issues in 25.0
 ~~~~~~~~~~~~~~~~~~~~
 
 FIXME

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,8 @@
-labgrid (24.1.0) UNRELEASED; urgency=low
+labgrid (25.0.0) UNRELEASED; urgency=low
 
   * See https://github.com/labgrid-project/labgrid/blob/master/CHANGES.rst
 
- -- Bastian Krause <bst@pengutronix.de>  Tue, 13 Aug 2024 12:23:25 +0200
+ -- Bastian Krause <bst@pengutronix.de>  Fri, 21 Jan 2024 10:43:45 +0100
 
 labgrid (24.0.0) UNRELEASED; urgency=low
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -3,12 +3,12 @@ Upstream-Name: labgrid
 Source: https://github.com/labgrid-project/labgrid
 
 Files: *
-Copyright: Copyright (C) 2016-2024 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
-           Copyright (C) 2016-2024 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
+Copyright: Copyright (C) 2016-2025 Pengutronix, Jan Luebbe <entwicklung@pengutronix.de>
+           Copyright (C) 2016-2025 Pengutronix, Rouven Czerwinski <entwicklung@pengutronix.de>
 License: LGPL-2.1+
 
 Files: man/*
-Copyright: Copyright (C) 2016-2024 Pengutronix
+Copyright: Copyright (C) 2016-2025 Pengutronix
 License: LGPL-2.1+
 
 License: LGPL-2.1+

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,7 +57,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'labgrid'
-copyright = '2016-2024 Pengutronix, Jan Luebbe and Rouven Czerwinski'
+copyright = '2016-2025 Pengutronix, Jan Luebbe and Rouven Czerwinski'
 author = 'Jan Luebbe, Rouven Czerwinski'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-CLIENT" "1" "2017-04-15" "0.0.1" "embedded testing"
+.TH "LABGRID-CLIENT" "1" "" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-client \- labgrid-client interface to control boards
 .SH SYNOPSIS

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -291,7 +291,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2017 Pengutronix. This library is free software;
+Copyright (C) 2016-2025 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -7,7 +7,7 @@ labgrid-client interface to control boards
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Copyright: Copyright (C) 2016-2017 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2025 Pengutronix. This library is free software;
 	    you can redistribute it and/or modify it under the terms of the GNU
 	    Lesser General Public License as published by the Free Software
 	    Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -7,7 +7,6 @@ labgrid-client interface to control boards
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Date:   2017-04-15
 :Copyright: Copyright (C) 2016-2017 Pengutronix. This library is free software;
 	    you can redistribute it and/or modify it under the terms of the GNU
 	    Lesser General Public License as published by the Free Software

--- a/man/labgrid-coordinator.1
+++ b/man/labgrid-coordinator.1
@@ -61,7 +61,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2024 Pengutronix. This library is free software;
+Copyright (C) 2016-2025 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-coordinator.1
+++ b/man/labgrid-coordinator.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-COORDINATOR" "1" "2024-08-06" "0.0.1" "embedded testing"
+.TH "LABGRID-COORDINATOR" "1" "" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-coordinator \- labgrid-coordinator managing labgrid resources and places
 .SH SYNOPSIS

--- a/man/labgrid-coordinator.rst
+++ b/man/labgrid-coordinator.rst
@@ -8,7 +8,7 @@ labgrid-coordinator managing labgrid resources and places
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2025 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-coordinator.rst
+++ b/man/labgrid-coordinator.rst
@@ -8,7 +8,6 @@ labgrid-coordinator managing labgrid resources and places
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Date:   2024-08-06
 :Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -252,7 +252,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2024 Pengutronix. This library is free software;
+Copyright (C) 2016-2025 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-DEVICE-CONFIG" "5" "2017-04-15" "0.0.1" "embedded testing"
+.TH "LABGRID-DEVICE-CONFIG" "5" "" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-device-config \- labgrid test configuration files
 .SH SYNOPSIS

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -8,7 +8,7 @@ labgrid test configuration files
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2025 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -8,7 +8,6 @@ labgrid test configuration files
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Date:   2017-04-15
 :Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-EXPORTER" "1" "2017-04-15" "0.0.1" "embedded testing"
+.TH "LABGRID-EXPORTER" "1" "" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-exporter \- labgrid-exporter interface to control boards
 .SH SYNOPSIS

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -133,7 +133,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2024 Pengutronix. This library is free software;
+Copyright (C) 2016-2025 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -8,7 +8,7 @@ labgrid-exporter interface to control boards
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2025 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -8,7 +8,6 @@ labgrid-exporter interface to control boards
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Date:   2017-04-15
 :Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software

--- a/man/labgrid-pytest.7
+++ b/man/labgrid-pytest.7
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-PYTEST" "7" "2017-04-15" "0.0.1" "embedded testing"
+.TH "LABGRID-PYTEST" "7" "" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-pytest \- labgrid-pytest labgrid integration for pytest
 .SH SYNOPSIS

--- a/man/labgrid-pytest.7
+++ b/man/labgrid-pytest.7
@@ -62,7 +62,7 @@ Rouven Czerwinski <r.czerwinski@pengutronix.de>
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2024 Pengutronix. This library is free software;
+Copyright (C) 2016-2025 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-pytest.rst
+++ b/man/labgrid-pytest.rst
@@ -7,7 +7,7 @@ labgrid-pytest labgrid integration for pytest
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2025 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-pytest.rst
+++ b/man/labgrid-pytest.rst
@@ -7,7 +7,6 @@ labgrid-pytest labgrid integration for pytest
 
 :Author: Rouven Czerwinski <r.czerwinski@pengutronix.de>
 :organization: Labgrid-Project
-:Date:   2017-04-15
 :Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software

--- a/man/labgrid-suggest.1
+++ b/man/labgrid-suggest.1
@@ -86,7 +86,7 @@ USBSerialPort:
 
 Organization: Labgrid-Project
 .SH COPYRIGHT
-Copyright (C) 2016-2024 Pengutronix. This library is free software;
+Copyright (C) 2016-2025 Pengutronix. This library is free software;
 you can redistribute it and/or modify it under the terms of the GNU
 Lesser General Public License as published by the Free Software
 Foundation; either version 2.1 of the License, or (at your option)

--- a/man/labgrid-suggest.1
+++ b/man/labgrid-suggest.1
@@ -27,7 +27,7 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .\" new: \\n[rst2man-indent\\n[rst2man-indent-level]]
 .in \\n[rst2man-indent\\n[rst2man-indent-level]]u
 ..
-.TH "LABGRID-SUGGEST" "1" "2021-05-20" "0.0.1" "embedded testing"
+.TH "LABGRID-SUGGEST" "1" "" "0.0.1" "embedded testing"
 .SH NAME
 labgrid-suggest \- labgrid-suggest generator for YAML config files
 .SH SYNOPSIS

--- a/man/labgrid-suggest.rst
+++ b/man/labgrid-suggest.rst
@@ -7,7 +7,6 @@ labgrid-suggest generator for YAML config files
 
 
 :organization: Labgrid-Project
-:Date:   2021-05-20
 :Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software

--- a/man/labgrid-suggest.rst
+++ b/man/labgrid-suggest.rst
@@ -7,7 +7,7 @@ labgrid-suggest generator for YAML config files
 
 
 :organization: Labgrid-Project
-:Copyright: Copyright (C) 2016-2024 Pengutronix. This library is free software;
+:Copyright: Copyright (C) 2016-2025 Pengutronix. This library is free software;
             you can redistribute it and/or modify it under the terms of the GNU
             Lesser General Public License as published by the Free Software
             Foundation; either version 2.1 of the License, or (at your option)


### PR DESCRIPTION
**Description**
labgrid is under active development, so extend the copyright period to reflect that. Since we're using a calver version scheme, rename the next release to 25.0. While at it, drop outdated dates from the man pages.

**Checklist**
- [x] Man pages have been regenerated