### PR TITLE
Use add_color_level() conditionally

### DIFF
--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -43,7 +43,8 @@ def pytest_cmdline_main(config):
 
 
 def configure_pytest_logging(config, plugin):
-    plugin.log_cli_handler.formatter.add_color_level(logging.CONSOLE, "blue")
+    if hasattr(plugin.log_cli_handler.formatter, "add_color_level"):
+        plugin.log_cli_handler.formatter.add_color_level(logging.CONSOLE, "blue")
     plugin.log_cli_handler.setFormatter(StepFormatter(
         color=config.option.lg_colored_steps,
         parent=plugin.log_cli_handler.formatter,


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
According to [1] add_color_level() is a method of ColoredLevelFormatter
only. The exception AttributeError is raised for other formatters.

[1] https://github.com/pytest-dev/pytest/blob/main/src/_pytest/logging.py#L104

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->