### PR TITLE
logging: Stringify message in StepFormatter

### DIFF
--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -37,7 +37,7 @@ class StepFormatter:
                 if hasattr(record, "indent_level"):
                     self.indent_level = record.indent_level
 
-                record.msg = (" " * self.indent_level) + record.msg
+                record.msg = (" " * self.indent_level) + str(record.msg)
 
                 self.indent_level = getattr(
                     record, "next_indent_level", self.indent_level


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
The usage of `StepFormatter` could provide errors:

    self = <labgrid.logging.StepFormatter object at 0x7f63fdc59010>
    record = <LogRecord: foo, 30, .../test_logger.py, 10, "{1: 2}">

        def format(self, record):
            old_msg = record.msg
            try:
                if self.indent:
                    if hasattr(record, "indent_level"):
                        self.indent_level = record.indent_level

    >               record.msg = (" " * self.indent_level) + record.msg
    E               TypeError: can only concatenate str (not "dict") to str

if a message isn't a string.

**Reproduction**
The test file `test_logger.py`:
```python
import logging

logger = logging.getLogger("foo")

def test_foo():
    d = {1: 2}
    logger.debug(d)
    logger.info(d)
    logger.warning(d)
    logger.error(d)
```
I used clean upstream labgrid package (HEAD SHA c609d2d7a88016f4610f396a22cd29a676180045). Just in case I provide my env:
<details>
  <summary>Virtual environment</summary>
  
  ```
  ansicolors==1.1.8
  attrs==25.1.0
  certifi==2025.1.31
  charset-normalizer==3.4.1
  grpcio==1.70.0
  grpcio-reflection==1.70.0
  idna==3.10
  iniconfig==2.0.0
  Jinja2==3.1.5
  labgrid @ file:///home/rkuznecov/3dpty/labgrid
  MarkupSafe==3.0.2
  packaging==24.2
  pexpect==4.9.0
  pluggy==1.5.0
  protobuf==5.29.3
  ptyprocess==0.7.0
  pyserial-labgrid==3.5.0.2
  pytest==8.3.4
  pyudev==0.24.3
  pyusb==1.3.1
  PyYAML==6.0.2
  requests==2.32.3
  urllib3==2.3.0
  xmodem==0.4.7
  ```
  
</details>

Run:
```bash
$ pytest test_logger.py
...
self = <labgrid.logging.StepFormatter object at 0x7f377f713ce0>
record = <LogRecord: foo, 30, /home/rkuznecov/3dpty/labgrid-tests/test_logger.py, 10, "{1: 2}">

    def format(self, record):
        old_msg = record.msg
        try:
            if self.indent:
                if hasattr(record, "indent_level"):
                    self.indent_level = record.indent_level

>               record.msg = (" " * self.indent_level) + record.msg
E               TypeError: can only concatenate str (not "dict") to str

venv/lib/python3.12/site-packages/labgrid/logging.py:40: TypeError
================================== short test summary info ===================================FAILED test_logger.py::test_foo - TypeError: can only concatenate str (not "dict") to str     
===================================== 1 failed in 0.09s =====================================
```

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
