### PR TITLE
driver/networkinterfacedriver: add wait_state()'s expected argument to step

### DIFF
--- a/labgrid/driver/networkinterfacedriver.py
+++ b/labgrid/driver/networkinterfacedriver.py
@@ -60,7 +60,7 @@ class NetworkInterfaceDriver(Driver):
         self.proxy.configure(self.iface.ifname, settings)
 
     @Driver.check_active
-    @step()
+    @step(args=["expected"])
     def wait_state(self, expected, timeout=60):
         """Wait until the expected state is reached or the timeout expires.
 


### PR DESCRIPTION
**Description**
This makes it more clear what state the NetworkInterfaceDriver is waiting for.

**Checklist**
- [x] PR has been tested
