### PR TITLE
dockerfiles/build.sh: fix buildx detection

### DIFF
--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -31,7 +31,7 @@ has_buildx() {
     local docker_cmd
     docker_cmd="${1}"
 
-    "${docker_cmd}" buildx --help >/dev/null 2>&1
+    "${docker_cmd}" buildx version >/dev/null 2>&1
 }
 
 get_docker_cmd() {


### PR DESCRIPTION
**Description**
`docker <subcommand> --help` cannot be used to detect whether a sub command is available because it exits with 0 no matter if the sub command exists or not.

Use `docker buildx version` as a test for buildx support instead.

**Checklist**
- [ ] PR has been tested

Fixes: #1585