### PR TITLE
doc v2: hostname can have a '-' character

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1687,7 +1687,7 @@ Implements:
 .. code-block:: yaml
 
    ShellDriver:
-     prompt: 'root@\w+:[^ ]+ '
+     prompt: 'root@[\w-]+:[^ ]+ '
      login_prompt: ' login: '
      username: 'root'
 
@@ -3312,7 +3312,7 @@ Here is an example environment config:
          SerialDriver: {}
          BareboxDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
          BareboxStrategy: {}
@@ -3359,7 +3359,7 @@ Here is an example environment config:
          ManualPowerDriver: {}
          SerialDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
          ShellStrategy: {}
@@ -3407,7 +3407,7 @@ Here is an example environment config:
          SerialDriver: {}
          UBootDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
          UBootStrategy: {}

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -126,7 +126,7 @@ and ``password`` of the ShellDriver driver in ``local.yaml``:
             name: "example"
           SerialDriver: {}
           ShellDriver:
-            prompt: 'root@\w+:[^ ]+ '
+            prompt: 'root@[\w-]+:[^ ]+ '
             login_prompt: ' login: '
             username: 'root'
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -494,7 +494,7 @@ access this board:
       drivers:
         SerialDriver: {}
         ShellDriver:
-          prompt: 'root@\w+:[^ ]+ '
+          prompt: 'root@[\w-]+:[^ ]+ '
           login_prompt: ' login: '
           username: 'root'
 
@@ -665,7 +665,7 @@ setup:
         BareboxDriver:
           prompt: 'barebox@[^:]+:[^ ]+ '
         ShellDriver:
-          prompt: 'root@\w+:[^ ]+ '
+          prompt: 'root@[\w-]+:[^ ]+ '
           login_prompt: ' login: '
           username: 'root'
         BareboxStrategy: {}

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -226,7 +226,7 @@ targets:
     drivers:
       SerialDriver: {}
       ShellDriver:
-        prompt: \(aqroot@\ew+:[^ ]+ \(aq
+        prompt: \(aqroot@[\ew\-]+:[^ ]+ \(aq
         login_prompt: \(aq login: \(aq
         username: \(aqroot\(aq
 .EE
@@ -248,7 +248,7 @@ targets:
     drivers:
       SerialDriver: {}
       ShellDriver:
-        prompt: \(aqroot@\ew+:[^ ]+ \(aq
+        prompt: \(aqroot@[\ew\-]+:[^ ]+ \(aq
         login_prompt: \(aq login: \(aq
         username: \(aqroot\(aq
       IMXUSBDriver: {}

--- a/man/labgrid-device-config.rst
+++ b/man/labgrid-device-config.rst
@@ -218,7 +218,7 @@ A sample configuration with one `main` target, accessible via SerialPort
        drivers:
          SerialDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
 
@@ -236,7 +236,7 @@ in the loaded local python file:
        drivers:
          SerialDriver: {}
          ShellDriver:
-           prompt: 'root@\w+:[^ ]+ '
+           prompt: 'root@[\w-]+:[^ ]+ '
            login_prompt: ' login: '
            username: 'root'
 	 IMXUSBDriver: {}


### PR DESCRIPTION
rfc952 specifies:

  A "name" (Net, Host, Gateway, or Domain name) is a text string up
     to 24 characters drawn from the alphabet (A-Z), digits (0-9), minus
     sign (-), and period (.).  Note that periods are only allowed when
     they serve to delimit components of "domain style names".

v2: added the updated man pages
