### PR TITLE
Extend SerialPort

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -31,6 +31,7 @@ enumeration order.
    RawSerialPort:
      port: '/dev/ttyUSB0'
      speed: 115200
+     xonxoff: False
 
 The example would access the serial port ``/dev/ttyUSB0`` on the local computer
 with a baud rate of ``115200``.
@@ -38,6 +39,7 @@ with a baud rate of ``115200``.
 Arguments:
   - port (str): path to the serial device
   - speed (int, default=115200): desired baud rate
+  - xonxoff (bool, default=False): software flow control
 
 Used by:
   - `SerialDriver`_

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -137,15 +137,15 @@ specific driver set a binding mapping before creating the driver:
   >>>
   >>> t = Target("Test")
   >>> SerialPort(t, "First")
-  SerialPort(target=Target(name='Test', env=None), name='First', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
+  SerialPort(target=Target(name='Test', env=None), name='First', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200, xonxoff=False)
   >>> SerialPort(t, "Second")
-  SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
+  SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200, xonxoff=False)
   >>> t.set_binding_map({"port": "Second"})
   >>> sd = SerialDriver(t, "Driver")
   >>> sd
   SerialDriver(target=Target(name='Test', env=None), name='Driver', state=<BindingState.bound: 1>, txdelay=0.0, timeout=3.0)
   >>> sd.port
-  SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200)
+  SerialPort(target=Target(name='Test', env=None), name='Second', state=<BindingState.bound: 1>, avail=True, port=None, speed=115200, xonxoff=False)
 
 Priorities
 ~~~~~~~~~~

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -222,7 +222,7 @@ to the resource object created above:
 .. doctest::
 
   >>> sd.port
-  RawSerialPort(target=Target(name='example', env=None), name=None, state=<BindingState.bound: 1>, avail=True, port='/dev/ttyUSB0', speed=115200)
+  RawSerialPort(target=Target(name='example', env=None), name=None, state=<BindingState.bound: 1>, avail=True, port='/dev/ttyUSB0', speed=115200, xonxoff=False)
   >>> sd.port is rsp
   True
 

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -39,6 +39,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
         if isinstance(self.port, SerialPort):
             self.serial.port = self.port.port
             self.serial.baudrate = self.port.speed
+            self.serial.xonxoff = self.port.xonxoff
         else:
             host, port = proxymanager.get_host_and_port(self.port)
             if self.port.protocol == "rfc2217":

--- a/labgrid/resource/base.py
+++ b/labgrid/resource/base.py
@@ -10,9 +10,11 @@ class SerialPort(Resource):
 
     Args:
         port (str): port to connect to
-        speed (int): speed of the port, defaults to 115200"""
+        speed (int): speed of the port, defaults to 115200
+        xonxoff (bool): software flow control, defaults to False (=off)"""
     port = attr.ib(default=None)
     speed = attr.ib(default=115200, validator=attr.validators.instance_of(int))
+    xonxoff = attr.ib(default=False, validator=attr.validators.instance_of(bool))
 
 
 @target_factory.reg_resource

--- a/tests/test_serialport.py
+++ b/tests/test_serialport.py
@@ -10,4 +10,5 @@ class TestSerialPort:
         s = RawSerialPort(target, 'serial', 'port', 115200)
         assert (s.port == 'port')
         assert (s.speed == 115200)
+        assert (s.xonxoff == False)
         assert s in target.resources


### PR DESCRIPTION
**Description**
Adding software flow control parameter xonoff to SerialPort, since otherwise I could not get my current board to run with labgrid.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated

A library feature which other developers can use:

- [x] PR has been tested (with an Orin Linux Board)
- [x] Man pages have been regenerated
