### PR TITLE
SmallUBootDriver: Add check for empty response on command line

### DIFF
--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -96,8 +96,10 @@ class SmallUBootDriver(UBootDriver):
         cmp_command = f"echo{marker}; {cmd}; echo{marker}"
 
         self.console.sendline(cmp_command)
-        _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)
-
+        while True:
+            _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)
+            if len(before) > 3:
+                break
         data = re_vt100.sub(
             '', before.decode('utf-8'), count=1000000
         ).replace("\r", "").split("\n")


### PR DESCRIPTION
**Description**

Some UBoot systems will return a short 3 byte answer with ' \r\n' as the contents.  Adds a check to see if the length is greater than 3 on the UBoot cosnsole commands

**Checklist**
- [X] Tests for the feature 
- [X] PR has been tested on a D-Link COVR X1860 A1

Fixes #1598 
