### PR TITLE
Add powerdrivers for AMT and IPMI powered PC's

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: labgrid
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python3, ${misc:Pre-Depends}
 Depends: ${python3:Depends}, ${misc:Depends}, ${shlibs:Depends}
-Recommends: openssh-client, microcom, socat, sshfs, rsync, bash-completion
+Recommends: openssh-client, microcom, socat, sshfs, rsync, bash-completion, python3-amt
 Description: embedded board control python library
  Labgrid is an embedded board control python library with a focus on testing,
  development and general automation. It includes a remote control layer to

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Package: labgrid
 Architecture: any
 Pre-Depends: dpkg (>= 1.16.1), python3, ${misc:Pre-Depends}
 Depends: ${python3:Depends}, ${misc:Depends}, ${shlibs:Depends}
-Recommends: openssh-client, microcom, socat, sshfs, rsync, bash-completion, python3-amt
+Recommends: openssh-client, microcom, socat, sshfs, rsync, bash-completion, python3-amt, freeipmi-tools
 Description: embedded board control python library
  Labgrid is an embedded board control python library with a focus on testing,
  development and general automation. It includes a remote control layer to

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -328,6 +328,27 @@ Arguments:
 Used by:
   - `AMTPowerDriver`_
 
+IPMIPowerPort
++++++++++++++
+A :any:`IPMIPowerPort` describes a IPMI port accessible via `ipmi-power`.
+
+.. code-block:: yaml
+
+   IPMIPowerPort:
+     host: 'ipmi-hostname'
+     username: 'admin'
+     password: 'secret-password'
+
+Arguments:
+ - host (str): hostname or ip the IPMI interface of the PC is reachable
+ - username (str): username to use for IPMI login
+ - password (str): password to use for IPMI login
+ - timeout (int): timeout to use when polling the resource
+ - args (str): extra args to prepend the command with
+
+Used by:
+  - `IPMIPowerDriver`_
+
 USBPowerPort
 ++++++++++++
 A :any:`USBPowerPort` describes a generic switchable USB hub as supported by

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -310,6 +310,24 @@ NetworkYKUSHPowerPort
 A :any:`NetworkYKUSHPowerPort` describes a `YKUSHPowerPort`_ available on a
 remote computer.
 
+AMTPowerPort
+++++++++++++
+A :any:`AMTPowerPort` describes a AMT port accessible via `amtctrl`.
+
+.. code-block:: yaml
+
+   AMTPowerPort:
+     host: 'amt-hostname'
+     password: 'secret-password'
+
+Arguments:
+ - host (str): hostname or ip the AMT interface of the PC is reachable
+ - password (str): password to use for AMT login
+ - timeout (int): timeout to use when polling the resource
+
+Used by:
+  - `AMTPowerDriver`_
+
 USBPowerPort
 ++++++++++++
 A :any:`USBPowerPort` describes a generic switchable USB hub as supported by

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -15,7 +15,7 @@ from .onewiredriver import OneWirePIODriver
 from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
                          DigitalOutputPowerDriver, YKUSHPowerDriver, \
                          USBPowerDriver, SiSPMPowerDriver, NetworkPowerDriver, \
-                         PDUDaemonDriver
+                         PDUDaemonDriver, AMTPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver, BDIMXUSBDriver, RKUSBDriver, UUUDriver
 from .usbsdmuxdriver import USBSDMuxDriver
 from .usbsdwiredriver import USBSDWireDriver

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -15,7 +15,7 @@ from .onewiredriver import OneWirePIODriver
 from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
                          DigitalOutputPowerDriver, YKUSHPowerDriver, \
                          USBPowerDriver, SiSPMPowerDriver, NetworkPowerDriver, \
-                         PDUDaemonDriver, AMTPowerDriver
+                         PDUDaemonDriver, AMTPowerDriver, IPMIPowerDriver
 from .usbloader import MXSUSBDriver, IMXUSBDriver, BDIMXUSBDriver, RKUSBDriver, UUUDriver
 from .usbsdmuxdriver import USBSDMuxDriver
 from .usbsdwiredriver import USBSDWireDriver

--- a/labgrid/driver/powerdriver.py
+++ b/labgrid/driver/powerdriver.py
@@ -1,4 +1,5 @@
 import shlex
+import subprocess
 import time
 import math
 from importlib import import_module
@@ -488,3 +489,53 @@ class AMTPowerDriver(Driver, PowerResetMixin, PowerProtocol):
             return False
         else:
             raise ExecutionError(f"got unexpected power status {power}")
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class IPMIPowerDriver(Driver, PowerResetMixin, PowerProtocol):
+    """IPMIPowerDriver - Driver using an IPMI PowerPort"""
+    bindings = {"port": "IPMIPowerPort", }
+    delay = attr.ib(default=5.0, validator=attr.validators.instance_of(float))
+
+    def _ipmi_power(self, cmd):
+        runstr = f"ipmi-power -h {self.port.host} -u {self.port.username} "
+        runstr += f"--session-timeout={self.port.timeout*1000} "
+        runstr += f"-p {self.port.password} {cmd}"
+        runstr = runstr.split(' ')
+        if len(self.port.args) > 0:
+            runstr.extend(self.port.args.split(' '))
+        return subprocess.run(runstr, capture_output=True)
+
+    def _ipmi_cmd(self, cmd):
+        ret = self._ipmi_power(cmd)
+        stdout = ret.stdout.decode('utf-8').split(' ')
+        assert self.port.host == stdout[0][:-1]
+        assert "ok" == stdout[1][:-1]
+
+    @Driver.check_active
+    @step()
+    def on(self):
+        self._ipmi_cmd('--on')
+
+    @Driver.check_active
+    @step()
+    def off(self):
+        self._ipmi_cmd('--off')
+
+    @Driver.check_active
+    @step()
+    def cycle(self):
+        self._ipmi_cmd('--cycle')
+
+    @Driver.check_active
+    def get(self):
+        ret = self._ipmi_power('--stat')
+        stdout = ret.stdout.decode('utf-8').split(' ')
+        assert self.port.host == stdout[0][:-1]
+        power = stdout[1][:-1]
+        if power == 'off':
+            return False
+        elif power == 'on':
+            return True
+        raise ExecutionError(f"got unexpected power status {power}")

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -867,7 +867,7 @@ class ClientSession:
         target = self._get_target(place)
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort
-        from ..resource import TasmotaPowerPort, NetworkYKUSHPowerPort, AMTPowerPort
+        from ..resource import TasmotaPowerPort, NetworkYKUSHPowerPort, AMTPowerPort, IPMIPowerPort
         drv = None
         try:
             drv = target.get_driver("PowerProtocol", name=name)
@@ -889,6 +889,8 @@ class ClientSession:
                     drv = self._get_driver_or_new(target, "YKUSHPowerDriver", name=name)
                 elif isinstance(resource, AMTPowerPort):
                     drv = self._get_driver_or_new(target, "AMTPowerDriver", name=name)
+                elif isinstance(resource, IPMIPowerPort):
+                    drv = self._get_driver_or_new(target, "IPMIPowerDriver", name=name)
                 if drv:
                     break
 

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -867,8 +867,7 @@ class ClientSession:
         target = self._get_target(place)
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
         from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort
-        from ..resource import TasmotaPowerPort, NetworkYKUSHPowerPort
-
+        from ..resource import TasmotaPowerPort, NetworkYKUSHPowerPort, AMTPowerPort
         drv = None
         try:
             drv = target.get_driver("PowerProtocol", name=name)
@@ -888,6 +887,8 @@ class ClientSession:
                     drv = self._get_driver_or_new(target, "TasmotaPowerDriver", name=name)
                 elif isinstance(resource, NetworkYKUSHPowerPort):
                     drv = self._get_driver_or_new(target, "YKUSHPowerDriver", name=name)
+                elif isinstance(resource, AMTPowerPort):
+                    drv = self._get_driver_or_new(target, "AMTPowerDriver", name=name)
                 if drv:
                     break
 

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -5,7 +5,7 @@ from .modbus import ModbusTCPCoil
 from .modbusrtu import ModbusRTU
 from .networkservice import NetworkService
 from .onewireport import OneWirePIO
-from .power import NetworkPowerPort, PDUDaemonPort, AMTPowerPort
+from .power import NetworkPowerPort, PDUDaemonPort, AMTPowerPort, IPMIPowerPort
 from .remote import RemotePlace
 from .udev import (
     AlteraUSBBlaster,

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -5,7 +5,7 @@ from .modbus import ModbusTCPCoil
 from .modbusrtu import ModbusRTU
 from .networkservice import NetworkService
 from .onewireport import OneWirePIO
-from .power import NetworkPowerPort, PDUDaemonPort
+from .power import NetworkPowerPort, PDUDaemonPort, AMTPowerPort
 from .remote import RemotePlace
 from .udev import (
     AlteraUSBBlaster,

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -48,3 +48,22 @@ class AMTPowerPort(Resource):
     host = attr.ib(validator=attr.validators.instance_of(str))
     password = attr.ib(validator=attr.validators.instance_of(str))
     timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class IPMIPowerPort(Resource):
+    """The IPMIPowerPrt describes an IPMI controllable PC with BMC
+
+    Args:
+        host (str): hostname or ip the IPMI interface of the PC is reachable
+        username (str): username to use for IPMI login
+        password (str): password to use for IPMI login
+        timeout (int): timeout to use when polling the resource
+        args (str): extra args to prepend the command with
+    """
+    host = attr.ib(validator=attr.validators.instance_of(str))
+    username = attr.ib(validator=attr.validators.instance_of(str))
+    password = attr.ib(validator=attr.validators.instance_of(str))
+    timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))
+    args = attr.ib(default="", validator=attr.validators.instance_of(str))

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -33,3 +33,18 @@ class PDUDaemonPort(Resource):
     host = attr.ib(validator=attr.validators.instance_of(str))
     pdu = attr.ib(validator=attr.validators.instance_of(str))
     index = attr.ib(validator=attr.validators.instance_of(int), converter=int)
+
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class AMTPowerPort(Resource):
+    """The AMTPowerPort describes an Intel AMT power controllable PC with BMC
+
+    Args:
+        host (str): hostname or ip the AMT interface of the PC is reachable
+        password (str): password to use for AMT login
+        timeout (int): timeout to use when polling the resource
+    """
+    host = attr.ib(validator=attr.validators.instance_of(str))
+    password = attr.ib(validator=attr.validators.instance_of(str))
+    timeout = attr.ib(default=30, validator=attr.validators.instance_of(int))


### PR DESCRIPTION
**Description**

Adds resources/drivers to power on/off/get PC's which can be accessed via AMT/IPMI remotely.

- how did you verify the feature works?
  Just by running `labgrid-client` and Pytest powering such devices on/off, no direct tests implemented.
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
  Tests were executed using HPz620/HPz640 workstations for AMT and for  example ASRockRack EPYCD8-2T for IPMI.

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested
- [x] Man pages have been regenerated