### PR TITLE
remote: client: fix empty sys.excepthook error work around

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -48,6 +48,13 @@ from ..util.helper import processwrapper
 from ..driver import Mode, ExecutionError
 from ..logging import basicConfig, StepLogger
 
+# This is a workround for the gRPC issue
+# https://github.com/grpc/grpc/issues/38679.
+# Since Python 3.12, an empty exception message is printed from gRPC
+# during shutdown, although nothing seems to go wrong. As this is
+# confusing for users, suppress the message by adding an indirection.
+sys.excepthook = lambda type, value, traceback: sys.__excepthook__(type, value, traceback)
+
 
 class Error(Exception):
     pass
@@ -2169,13 +2176,6 @@ def main():
         except Exception:  # pylint: disable=broad-except
             traceback.print_exc(file=sys.stderr)
             exitcode = 2
-        if not args.debug:
-            # This is a workround for the gRPC issue
-            # https://github.com/grpc/grpc/issues/38679.
-            # Since Python 3.12, an empty exception message is printed from gRPC
-            # during shutdown, although nothing seems to go wrong. As this is
-            # confusing for users, suppress the message by closing stderr.
-            os.close(sys.stderr.fileno())
         exit(exitcode)
     else:
         parser.print_help(file=sys.stderr)


### PR DESCRIPTION
**Description**
The work around introduced with [1] makes labgrid-client exit with exit code 120. This happens due to sys.stderr being closed prematurely and Py_FinalizeEx() thus failing to flush stderr [2].

Instead of closing stderr, add a sys.excepthook indirection which also prevents the empty excepthook error from being displayed and should also allow actual errors to be displayed [3]. That means we can add it unconditionally.

[1] 2dc889cb ("remote/client: suppress gRPC error message on shutdown")
[2] https://hg.python.org/cpython/rev/6b08429a3932
[3] https://github.com/grpc/grpc/issues/36655#issuecomment-2356063198

**Checklist**
- [x] PR has been tested

Fixes: #1605