### PR TITLE
client: add power control to the client via the DigitalOutputPowerDriver

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -866,7 +866,7 @@ class ClientSession:
         name = self.args.name
         target = self._get_target(place)
         from ..resource.power import NetworkPowerPort, PDUDaemonPort
-        from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort
+        from ..resource.remote import NetworkUSBPowerPort, NetworkSiSPMPowerPort, NetworkSysfsGPIO
         from ..resource import TasmotaPowerPort, NetworkYKUSHPowerPort
 
         drv = None
@@ -888,6 +888,9 @@ class ClientSession:
                     drv = self._get_driver_or_new(target, "TasmotaPowerDriver", name=name)
                 elif isinstance(resource, NetworkYKUSHPowerPort):
                     drv = self._get_driver_or_new(target, "YKUSHPowerDriver", name=name)
+                elif isinstance(resource, NetworkSysfsGPIO):
+                    self._get_driver_or_new(target, "GpioDigitalOutputDriver", name=name)
+                    drv = self._get_driver_or_new(target, "DigitalOutputPowerDriver", name=name)
                 if drv:
                     break
 


### PR DESCRIPTION
**Description**

Adds support for the power protocol for DigitalOutputPowerDriver (SysfsGPIO) to labgrid-client

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [X] Tests for the feature done on the command line with labgrid-client 
- [X] PR has been tested
