### PR TITLE
contrib/systemd/labgrid-exporter: make service restart always and indefinitely

### DIFF
--- a/contrib/systemd/labgrid-exporter.service
+++ b/contrib/systemd/labgrid-exporter.service
@@ -8,9 +8,9 @@ Environment="PYTHONUNBUFFERED=1"
 # Should contain LG_COORDINATOR configuration
 EnvironmentFile=-/etc/environment
 ExecStart=/path/to/labgrid/venv/bin/labgrid-exporter /etc/labgrid/exporter.yaml
-Restart=on-failure
-RestartForceExitStatus=100
+Restart=always
 RestartSec=30
+StartLimitIntervalSec=0
 DynamicUser=yes
 # Adjust to your distribution (most often "dialout" or "tty")
 SupplementaryGroups=dialout plugdev


### PR DESCRIPTION
**Description**
The exporter sets `reexec=True` for known errors only. If other errors occur (e.g. network issues), the exporter exits with 0.

So set `Restart=always` to make sure even these exit conditions lead to a restarted exporter. Drop the now redundant `RestartForceExitStatus`. Add `StartLimitIntervalSec=0` to make it restart indefinitely.


**Checklist**
- [ ] PR has been tested
