### PR TITLE
doc: use importlib.metadata in favor of pkg_resources in conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ import os
 import sys
 sys.path.insert(0, os.path.abspath('..'))
 
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 # Import read_the_docs theme
 import sphinx_rtd_theme
@@ -65,7 +65,7 @@ author = 'Jan Luebbe, Rouven Czerwinski'
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_distribution('labgrid').version
+release = version('labgrid')
 # The short X.Y version.
 version = '.'.join(release.split('.')[:2])
 


### PR DESCRIPTION
As can be found here [1], pkg_resources is deprecated and is removed by default from python 3.12 according to [2]. The used alternative importlib.metadata is available from python 3.8 on according to [3].

[1] https://setuptools.pypa.io/en/latest/pkg_resources.html
[2] https://docs.python.org/3/whatsnew/3.12.html
[3] https://docs.python.org/3.12/library/importlib.metadata.html