### PR TITLE
contrib/systemd/labgrid-exporter: move StartLimitIntervalSec from Service to Unit section

### DIFF
--- a/contrib/systemd/labgrid-exporter.service
+++ b/contrib/systemd/labgrid-exporter.service
@@ -2,6 +2,7 @@
 Description=Labgrid Exporter
 After=network-online.target
 Wants=network-online.target
+StartLimitIntervalSec=0
 
 [Service]
 Environment="PYTHONUNBUFFERED=1"
@@ -10,7 +11,6 @@ EnvironmentFile=-/etc/environment
 ExecStart=/path/to/labgrid/venv/bin/labgrid-exporter /etc/labgrid/exporter.yaml
 Restart=always
 RestartSec=30
-StartLimitIntervalSec=0
 DynamicUser=yes
 # Adjust to your distribution (most often "dialout" or "tty")
 SupplementaryGroups=dialout plugdev


### PR DESCRIPTION
**Description**
`StartLimitIntervalSec` belongs in the "Unit" section, not in the "Service" section.

**Checklist**
- [ ] PR has been tested

Fixes: #1616
