### PR TITLE
Barebox/UBoot/SmallUBootDriver: handle hex arguements properly

### DIFF
--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -166,7 +166,13 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
 
             elif index == 1:
                 # we need to interrupt autoboot
-                self.console.write(self.interrupt.encode('ASCII'))
+                interrupt = self.interrupt.encode('ASCII')
+                if self.interrupt.startswith('\\x'):
+                    try:
+                        interrupt = bytearray.fromhex(self.interrupt[2:])
+                    except ValueError:
+                        pass
+                self.console.write(interrupt)
 
             elif index == 2:
                 # we need to enter the password

--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -61,10 +61,18 @@ class SmallUBootDriver(UBootDriver):
 
         # wait for boot expression. Afterwards enter secret
         self.console.expect(self.boot_expression, timeout=self.login_timeout)
+
+        secret = self.boot_secret.encode('ASCII')
+        if self.boot_secret.startswith('\\x'):
+            try:
+                secret = bytearray.fromhex(self.boot_secret[2:])
+            except ValueError:
+                pass
+
         if self.boot_secret_nolf:
-            self.console.write(self.boot_secret.encode('ASCII'))
+            self.console.write(secret)
         else:
-            self.console.sendline(self.boot_secret)
+            self.console.sendline(secret)
         self._status = 1
 
         # wait until UBoot has reached it's prompt

--- a/labgrid/driver/ubootdriver.py
+++ b/labgrid/driver/ubootdriver.py
@@ -172,7 +172,13 @@ class UBootDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
                 break
 
             elif index == 1:
-                self.console.write(self.interrupt.encode('ASCII'))
+                interrupt = self.interrupt.encode('ASCII')
+                if self.interrupt.startswith('\\x'):
+                    try:
+                        interrupt = bytearray.fromhex(self.interrupt[2:])
+                    except ValueError:
+                        pass
+                self.console.write(interrupt)
 
             elif index == 2:
                 if not self.password:


### PR DESCRIPTION
Checks to see if the interrupt string starts with \x and when that is the case, converts the remained of the string to a bytearray before sending the interrupt to the boot loader.

fixes #1622
