### PR TITLE
remote/exporter: add poll tracking override

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -135,7 +135,7 @@ class ResourceExport(ResourceEntry):
             raise
         self.start_params = None
 
-    def poll(self):
+    def poll(self, dirty=False):
         # poll and check for updated params/avail
         self.local.poll()
 
@@ -154,7 +154,6 @@ class ResourceExport(ResourceEntry):
                 self.stop()
 
         # check if resulting information has changed
-        dirty = False
         if self.avail != (self.local.avail and not self.broken):
             self.data["avail"] = self.local.avail and not self.broken
             dirty = True
@@ -1003,7 +1002,7 @@ class Exporter:
             res = group[resource_name] = export_cls(
                 config, host=self.hostname, proxy=getfqdn(), proxy_required=proxy_req
             )
-            res.poll()
+            res.poll(dirty=True)
         else:
             config["params"]["extra"] = {
                 "proxy": getfqdn(),


### PR DESCRIPTION
**Description**

The poll() function tracks whether the local information has changed vs the previous state and only takes the availability into account. Since we now poll() the resource on creation, the local state is immediately updated with the information on the resource. This also means that instead of a "clear" by sending an unavailable resource, we don't send an update to the coordinator in case the resource is still available.

Previously:
Create Resource -> unavailable
poll() -> update to coordinator

Now:
create resource, poll() -> availability stays the same and we skip the information update to the coordinator.

Add an explicit override to the poll function to mark the state as dirty for the first poll().

**Checklist**
- [x] PR has been tested
