### PR TITLE
driver/power: Add support for TAPO devices

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -264,6 +264,18 @@ Currently available are:
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
   for details.
 
+``tplink``
+  Controls *TP-Link power strips* via `python-kasa
+  <https://github.com/python-kasa/python-kasa>`_.
+
+``tapo``
+  Controls *Tapo power strips and single socket devices* via `python-kasa
+  <https://github.com/python-kasa/python-kasa>`_.
+  Requires valid TP-Link/TAPO cloud credentials to work.
+  See the `docstring in the module
+  <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/tapo.py>`__
+  for details.
+
 ``tinycontrol``
   Controls a tinycontrol.eu IP Power Socket via HTTP.
   It was tested on the *6G10A v2* model.

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -264,10 +264,6 @@ Currently available are:
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/simplerest.py>`__
   for details.
 
-``tplink``
-  Controls *TP-Link power strips* via `python-kasa
-  <https://github.com/python-kasa/python-kasa>`_.
-
 ``tapo``
   Controls *Tapo power strips and single socket devices* via `python-kasa
   <https://github.com/python-kasa/python-kasa>`_.

--- a/labgrid/driver/power/tapo.py
+++ b/labgrid/driver/power/tapo.py
@@ -73,7 +73,7 @@ async def _power_set(host: str, port: str, index: str, value: bool) -> None:
     await device.update()
 
     if device.children:
-        assert len(device.children) > index, "Trying to access non-existant plug socket on device"
+        assert len(device.children) > index, "Trying to access non-existent plug socket on device"
 
     target = device if not device.children else device.children[index]
     if value:
@@ -98,7 +98,7 @@ async def _power_get(host: str, port: str, index: str) -> bool:
     if not device.children:
         pwr_state = device.is_on
     else:
-        assert len(device.children) > index, "Trying to access non-existant plug socket on device"
+        assert len(device.children) > index, "Trying to access non-existent plug socket on device"
         pwr_state = device.children[index].is_on
     await device.disconnect()
     return pwr_state

--- a/labgrid/driver/power/tapo.py
+++ b/labgrid/driver/power/tapo.py
@@ -14,9 +14,16 @@ Requirements:
 
 import asyncio
 import os
-import sys
 
+import kasa
 from kasa import Credentials, Device, DeviceConfig, DeviceConnectionParameters, DeviceEncryptionType, DeviceFamily
+from packaging.version import parse
+
+
+def _using_old_kasa_api() -> bool:
+    target_kasa_version = parse("0.10.0")
+    current_kasa_version = parse(kasa.__version__)
+    return current_kasa_version < target_kasa_version
 
 
 def _get_credentials() -> Credentials:
@@ -28,10 +35,8 @@ def _get_credentials() -> Credentials:
 
 
 def _get_connection_type() -> DeviceConnectionParameters:
-    # Somewhere between python-kasa 0.7.7 and 0.10.2 the API changed
-    # Labgrid on Python <= 3.10 uses python-kasa 0.7.7
-    # Labgrid on Python >= 3.11 uses python-kasa 0.10.2
-    if sys.version_info < (3, 11):
+    # API changed between versions 0.9.1 and 0.10.0 of python-kasa
+    if _using_old_kasa_api():
         return DeviceConnectionParameters(
             device_family=DeviceFamily.SmartTapoPlug,
             encryption_type=DeviceEncryptionType.Klap,
@@ -49,10 +54,10 @@ def _get_connection_type() -> DeviceConnectionParameters:
 
 def _get_device_config(host: str) -> DeviceConfig:
     # Same as with `_get_connection_type` - python-kasa API changed
-    if sys.version_info < (3, 11):
+    if _using_old_kasa_api():
         return DeviceConfig(
             host=host, credentials=_get_credentials(), connection_type=_get_connection_type(), uses_http=True
-        )
+        )  # type: ignore[call-arg]
     return DeviceConfig(
         host=host, credentials=_get_credentials(), connection_type=_get_connection_type()
     )

--- a/labgrid/driver/power/tapo.py
+++ b/labgrid/driver/power/tapo.py
@@ -1,0 +1,101 @@
+"""Driver for controlling TP-Link Tapo smart plugs and power strips.
+
+This module provides functionality to control TP-Link Tapo smart power devices through
+the kasa library. It supports both single socket devices (like P100) and multi-socket
+power strips (like P300).
+
+Features:
+- Environment-based authentication using KASA_USERNAME and KASA_PASSWORD
+- Support for both single and multi-socket devices
+
+Requirements:
+- Valid TP-Link cloud credentials (username/password)
+"""
+
+import asyncio
+import os
+import sys
+
+from kasa import Credentials, Device, DeviceConfig, DeviceConnectionParameters, DeviceEncryptionType, DeviceFamily
+
+
+def _get_credentials() -> Credentials:
+    username = os.environ.get("KASA_USERNAME")
+    password = os.environ.get("KASA_PASSWORD")
+    if username is None or password is None:
+        raise EnvironmentError("KASA_USERNAME or KASA_PASSWORD environment variable not set")
+    return Credentials(username=username, password=password)
+
+
+def _get_connection_type() -> DeviceConnectionParameters:
+    # Somewhere between python-kasa 0.7.7 and 0.10.2 the API changed
+    # Labgrid on Python <= 3.10 uses python-kasa 0.7.7
+    # Labgrid on Python >= 3.11 uses python-kasa 0.10.2
+    if sys.version_info < (3, 11):
+        return DeviceConnectionParameters(
+            device_family=DeviceFamily.SmartTapoPlug,
+            encryption_type=DeviceEncryptionType.Klap,
+            https=False,
+            login_version=2,
+        )
+    return DeviceConnectionParameters(
+        device_family=DeviceFamily.SmartTapoPlug,
+        encryption_type=DeviceEncryptionType.Klap,
+        https=False,
+        login_version=2,
+        http_port=80,
+    )
+
+
+def _get_device_config(host: str) -> DeviceConfig:
+    # Same as with `_get_connection_type` - python-kasa API changed
+    if sys.version_info < (3, 11):
+        return DeviceConfig(
+            host=host, credentials=_get_credentials(), connection_type=_get_connection_type(), uses_http=True
+        )
+    return DeviceConfig(
+        host=host, credentials=_get_credentials(), connection_type=_get_connection_type()
+    )
+
+
+async def _power_set(host: str, port: str, index: str, value: bool) -> None:
+    """We embed the coroutines in an `async` function to minimise calls to `asyncio.run`"""
+    assert port is None
+    index = int(index)
+    device = await Device.connect(config=_get_device_config(host))
+    await device.update()
+
+    if device.children:
+        assert len(device.children) > index, "Trying to access non-existant plug socket on device"
+
+    target = device if not device.children else device.children[index]
+    if value:
+        await target.turn_on()
+    else:
+        await target.turn_off()
+    await device.disconnect()
+
+
+def power_set(host: str, port: str, index: str, value: bool) -> None:
+    asyncio.run(_power_set(host, port, index, value))
+
+
+async def _power_get(host: str, port: str, index: str) -> bool:
+    assert port is None
+    index = int(index)
+    device = await Device.connect(config=_get_device_config(host))
+    await device.update()
+
+    pwr_state: bool
+    # If the device has no children, it is a single plug socket
+    if not device.children:
+        pwr_state = device.is_on
+    else:
+        assert len(device.children) > index, "Trying to access non-existant plug socket on device"
+        pwr_state = device.children[index].is_on
+    await device.disconnect()
+    return pwr_state
+
+
+def power_get(host: str, port: str, index: str) -> bool:
+    return asyncio.run(_power_get(host, port, index))

--- a/labgrid/driver/power/tapo.py
+++ b/labgrid/driver/power/tapo.py
@@ -43,6 +43,8 @@ def _get_connection_type() -> DeviceConnectionParameters:
             https=False,
             login_version=2,
         )
+    # http_port parameter exists in new kasa (>= 0.10.0) API but not in old versions (<= 0.9.1)
+    # pylint: disable-next=unexpected-keyword-arg
     return DeviceConnectionParameters(
         device_family=DeviceFamily.SmartTapoPlug,
         encryption_type=DeviceEncryptionType.Klap,
@@ -55,12 +57,12 @@ def _get_connection_type() -> DeviceConnectionParameters:
 def _get_device_config(host: str) -> DeviceConfig:
     # Same as with `_get_connection_type` - python-kasa API changed
     if _using_old_kasa_api():
+        # uses_http parameter exists in old kasa (<= 0.9.1) API but not in new versions (>= 0.10.0)
+        # pylint: disable-next=unexpected-keyword-arg
         return DeviceConfig(
             host=host, credentials=_get_credentials(), connection_type=_get_connection_type(), uses_http=True
         )  # type: ignore[call-arg]
-    return DeviceConfig(
-        host=host, credentials=_get_credentials(), connection_type=_get_connection_type()
-    )
+    return DeviceConfig(host=host, credentials=_get_credentials(), connection_type=_get_connection_type())
 
 
 async def _power_set(host: str, port: str, index: str, value: bool) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
 
     # additional dev dependencies
     "psutil>=5.8.0",
+    "pytest-asyncio>=0.25.3",
     "pytest-benchmark>=4.0.0",
     "pytest-cov>=3.0.0",
     "pytest-dependency>=0.5.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ dev = [
 
     # additional dev dependencies
     "psutil>=5.8.0",
-    "pytest-asyncio>=0.25.3",
     "pytest-benchmark>=4.0.0",
     "pytest-cov>=3.0.0",
     "pytest-dependency>=0.5.1",
@@ -229,6 +228,7 @@ include = [
   "labgrid/driver/power/pe6216.py",
   "labgrid/driver/power/poe_netgear_plus.py",
   "labgrid/driver/power/shelly_gen2.py",
+  "labgrid/driver/power/tapo.py",
   "labgrid/driver/rawnetworkinterfacedriver.py",
   "labgrid/protocol/**/*.py",
   "labgrid/remote/**/*.py",

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -309,6 +309,10 @@ class TestNetworkPowerDriver:
         pytest.importorskip("kasa")
         import labgrid.driver.power.tplink
 
+    def test_import_backend_tapo(self):
+        pytest.importorskip("kasa")
+        import labgrid.driver.power.tapo
+
     def test_import_backend_siglent(self):
         pytest.importorskip("vxi11")
         import labgrid.driver.power.siglent

--- a/tests/test_tapo.py
+++ b/tests/test_tapo.py
@@ -9,11 +9,7 @@ from labgrid.driver.power.tapo import _get_credentials, _power_get, _power_set, 
 @pytest.fixture
 def mock_device_strip():
     device = AsyncMock()
-    device.children = [
-        AsyncMock(is_on=True),
-        AsyncMock(is_on=False),
-        AsyncMock(is_on=True)
-    ]
+    device.children = [AsyncMock(is_on=True), AsyncMock(is_on=False), AsyncMock(is_on=True)]
     return device
 
 
@@ -26,18 +22,18 @@ def mock_device_single_plug():
 
 @pytest.fixture
 def mock_env():
-    os.environ['KASA_USERNAME'] = 'test_user'
-    os.environ['KASA_PASSWORD'] = 'test_pass'
+    os.environ["KASA_USERNAME"] = "test_user"
+    os.environ["KASA_PASSWORD"] = "test_pass"
     yield
-    del os.environ['KASA_USERNAME']
-    del os.environ['KASA_PASSWORD']
+    del os.environ["KASA_USERNAME"]
+    del os.environ["KASA_PASSWORD"]
 
 
 class TestTapoPowerDriver:
     def test_get_credentials_should_raise_value_error_when_credentials_missing(self):
         # Save existing environment variables
-        saved_username = os.environ.pop('KASA_USERNAME', None)
-        saved_password = os.environ.pop('KASA_PASSWORD', None)
+        saved_username = os.environ.pop("KASA_USERNAME", None)
+        saved_password = os.environ.pop("KASA_PASSWORD", None)
 
         try:
             with pytest.raises(EnvironmentError, match="KASA_USERNAME or KASA_PASSWORD environment variable not set"):
@@ -45,29 +41,29 @@ class TestTapoPowerDriver:
         finally:
             # Restore environment variables if they existed
             if saved_username is not None:
-                os.environ['KASA_USERNAME'] = saved_username
+                os.environ["KASA_USERNAME"] = saved_username
             if saved_password is not None:
-                os.environ['KASA_PASSWORD'] = saved_password
+                os.environ["KASA_PASSWORD"] = saved_password
 
     def test_credentials_valid(self, mock_env):
         creds = _get_credentials()
-        assert creds.username == 'test_user'
-        assert creds.password == 'test_pass'
+        assert creds.username == "test_user"
+        assert creds.password == "test_pass"
 
     @pytest.mark.asyncio
     async def test_power_get_single_plug_turn_on(self, mock_device_single_plug, mock_env):
         mock_device_single_plug.is_on = True
 
-        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
-            result = await _power_get('192.168.1.100', None, "0")
+        with patch("kasa.Device.connect", return_value=mock_device_single_plug):
+            result = await _power_get("192.168.1.100", None, "0")
             assert result is True
 
     @pytest.mark.asyncio
     async def test_power_get_single_plug_turn_off(self, mock_device_single_plug, mock_env):
         mock_device_single_plug.is_on = False
 
-        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
-            result = await _power_get('192.168.1.100', None, "0")
+        with patch("kasa.Device.connect", return_value=mock_device_single_plug):
+            result = await _power_get("192.168.1.100", None, "0")
             assert result is False
 
     @pytest.mark.asyncio
@@ -75,68 +71,68 @@ class TestTapoPowerDriver:
         invalid_index_ignored = "7"
         mock_device_single_plug.is_on = True
 
-        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
-            result = await _power_get('192.168.1.100', None, invalid_index_ignored)
+        with patch("kasa.Device.connect", return_value=mock_device_single_plug):
+            result = await _power_get("192.168.1.100", None, invalid_index_ignored)
             assert result is True
 
     @pytest.mark.asyncio
     async def test_power_set_single_plug_turn_on(self, mock_device_single_plug, mock_env):
         mock_device_single_plug.is_on = False
-        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
-            await _power_set('192.168.1.100', None, "0", True)
+        with patch("kasa.Device.connect", return_value=mock_device_single_plug):
+            await _power_set("192.168.1.100", None, "0", True)
             mock_device_single_plug.turn_on.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_power_set_single_plug_turn_off(self, mock_device_single_plug, mock_env):
         mock_device_single_plug.is_on = True
-        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
-            await _power_set('192.168.1.100', None, "0", False)
+        with patch("kasa.Device.connect", return_value=mock_device_single_plug):
+            await _power_set("192.168.1.100", None, "0", False)
             mock_device_single_plug.turn_off.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_power_get_strip_valid_socket(self, mock_device_strip, mock_env):
-        with patch('kasa.Device.connect', return_value=mock_device_strip):
+        with patch("kasa.Device.connect", return_value=mock_device_strip):
             # Test first outlet (on)
-            result = await _power_get('192.168.1.100', None, "0")
+            result = await _power_get("192.168.1.100", None, "0")
             assert result is True
 
             # Test second outlet (off)
-            result = await _power_get('192.168.1.100', None, "1")
+            result = await _power_get("192.168.1.100", None, "1")
             assert result is False
 
             # Test third outlet (on)
-            result = await _power_get('192.168.1.100', None, "2")
+            result = await _power_get("192.168.1.100", None, "2")
             assert result is True
 
     @pytest.mark.asyncio
     async def test_power_set_strip_valid_socket(self, mock_device_strip, mock_env):
-        with patch('kasa.Device.connect', return_value=mock_device_strip):
-            await _power_set('192.168.1.100', None, "0", False)
+        with patch("kasa.Device.connect", return_value=mock_device_strip):
+            await _power_set("192.168.1.100", None, "0", False)
             mock_device_strip.children[0].turn_off.assert_called_once()
 
-            await _power_set('192.168.1.100', None, "1", True)
+            await _power_set("192.168.1.100", None, "1", True)
             mock_device_strip.children[1].turn_on.assert_called_once()
 
     def test_power_get_should_raise_assertion_error_when_invalid_index_strip(self, mock_device_strip, mock_env):
         invalid_socket = "5"
-        with patch('kasa.Device.connect', return_value=mock_device_strip):
+        with patch("kasa.Device.connect", return_value=mock_device_strip):
             with pytest.raises(AssertionError, match="Trying to access non-existant plug socket"):
-                power_get('192.168.1.100', None, invalid_socket)
+                power_get("192.168.1.100", None, invalid_socket)
 
     @pytest.mark.asyncio
     async def test_power_set_should_raise_assertion_error_when_invalid_index_strip(self, mock_device_strip, mock_env):
         invalid_socket = "5"
-        with patch('kasa.Device.connect', return_value=mock_device_strip):
+        with patch("kasa.Device.connect", return_value=mock_device_strip):
             with pytest.raises(AssertionError, match="Trying to access non-existant plug socket"):
-                await _power_set('192.168.1.100', None, invalid_socket, True)
+                await _power_set("192.168.1.100", None, invalid_socket, True)
 
     def test_port_not_none_strip(self, mock_device_strip):
-        with patch('kasa.Device.connect', return_value=mock_device_strip):
+        with patch("kasa.Device.connect", return_value=mock_device_strip):
             with pytest.raises(AssertionError):
-                power_get('192.168.1.100', '8080', "0")
+                power_get("192.168.1.100", "8080", "0")
 
     def test_port_not_none_single_socket(self, mock_device_single_plug):
         mock_device_single_plug.is_on = True
-        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+        with patch("kasa.Device.connect", return_value=mock_device_single_plug):
             with pytest.raises(AssertionError):
-                power_get('192.168.1.100', '8080', "0")
+                power_get("192.168.1.100", "8080", "0")

--- a/tests/test_tapo.py
+++ b/tests/test_tapo.py
@@ -1,0 +1,142 @@
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from labgrid.driver.power.tapo import _get_credentials, _power_get, _power_set, power_get
+
+
+@pytest.fixture
+def mock_device_strip():
+    device = AsyncMock()
+    device.children = [
+        AsyncMock(is_on=True),
+        AsyncMock(is_on=False),
+        AsyncMock(is_on=True)
+    ]
+    return device
+
+
+@pytest.fixture
+def mock_device_single_plug():
+    device = AsyncMock()
+    device.children = []
+    return device
+
+
+@pytest.fixture
+def mock_env():
+    os.environ['KASA_USERNAME'] = 'test_user'
+    os.environ['KASA_PASSWORD'] = 'test_pass'
+    yield
+    del os.environ['KASA_USERNAME']
+    del os.environ['KASA_PASSWORD']
+
+
+class TestTapoPowerDriver:
+    def test_get_credentials_should_raise_value_error_when_credentials_missing(self):
+        # Save existing environment variables
+        saved_username = os.environ.pop('KASA_USERNAME', None)
+        saved_password = os.environ.pop('KASA_PASSWORD', None)
+
+        try:
+            with pytest.raises(EnvironmentError, match="KASA_USERNAME or KASA_PASSWORD environment variable not set"):
+                _get_credentials()
+        finally:
+            # Restore environment variables if they existed
+            if saved_username is not None:
+                os.environ['KASA_USERNAME'] = saved_username
+            if saved_password is not None:
+                os.environ['KASA_PASSWORD'] = saved_password
+
+    def test_credentials_valid(self, mock_env):
+        creds = _get_credentials()
+        assert creds.username == 'test_user'
+        assert creds.password == 'test_pass'
+
+    @pytest.mark.asyncio
+    async def test_power_get_single_plug_turn_on(self, mock_device_single_plug, mock_env):
+        mock_device_single_plug.is_on = True
+
+        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+            result = await _power_get('192.168.1.100', None, "0")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_power_get_single_plug_turn_off(self, mock_device_single_plug, mock_env):
+        mock_device_single_plug.is_on = False
+
+        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+            result = await _power_get('192.168.1.100', None, "0")
+            assert result is False
+
+    @pytest.mark.asyncio
+    async def test_power_get_single_plug_should_not_care_for_index(self, mock_device_single_plug, mock_env):
+        invalid_index_ignored = "7"
+        mock_device_single_plug.is_on = True
+
+        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+            result = await _power_get('192.168.1.100', None, invalid_index_ignored)
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_power_set_single_plug_turn_on(self, mock_device_single_plug, mock_env):
+        mock_device_single_plug.is_on = False
+        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+            await _power_set('192.168.1.100', None, "0", True)
+            mock_device_single_plug.turn_on.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_power_set_single_plug_turn_off(self, mock_device_single_plug, mock_env):
+        mock_device_single_plug.is_on = True
+        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+            await _power_set('192.168.1.100', None, "0", False)
+            mock_device_single_plug.turn_off.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_power_get_strip_valid_socket(self, mock_device_strip, mock_env):
+        with patch('kasa.Device.connect', return_value=mock_device_strip):
+            # Test first outlet (on)
+            result = await _power_get('192.168.1.100', None, "0")
+            assert result is True
+
+            # Test second outlet (off)
+            result = await _power_get('192.168.1.100', None, "1")
+            assert result is False
+
+            # Test third outlet (on)
+            result = await _power_get('192.168.1.100', None, "2")
+            assert result is True
+
+    @pytest.mark.asyncio
+    async def test_power_set_strip_valid_socket(self, mock_device_strip, mock_env):
+        with patch('kasa.Device.connect', return_value=mock_device_strip):
+            await _power_set('192.168.1.100', None, "0", False)
+            mock_device_strip.children[0].turn_off.assert_called_once()
+
+            await _power_set('192.168.1.100', None, "1", True)
+            mock_device_strip.children[1].turn_on.assert_called_once()
+
+    def test_power_get_should_raise_assertion_error_when_invalid_index_strip(self, mock_device_strip, mock_env):
+        invalid_socket = "5"
+        with patch('kasa.Device.connect', return_value=mock_device_strip):
+            with pytest.raises(AssertionError, match="Trying to access non-existant plug socket"):
+                power_get('192.168.1.100', None, invalid_socket)
+
+    @pytest.mark.asyncio
+    async def test_power_set_should_raise_assertion_error_when_invalid_index_strip(self, mock_device_strip, mock_env):
+        invalid_socket = "5"
+        with patch('kasa.Device.connect', return_value=mock_device_strip):
+            with pytest.raises(AssertionError, match="Trying to access non-existant plug socket"):
+                await _power_set('192.168.1.100', None, invalid_socket, True)
+
+    def test_port_not_none_strip(self, mock_device_strip):
+        with patch('kasa.Device.connect', return_value=mock_device_strip):
+            with pytest.raises(AssertionError):
+                power_get('192.168.1.100', '8080', "0")
+
+    def test_port_not_none_single_socket(self, mock_device_single_plug):
+        mock_device_single_plug.is_on = True
+        with patch('kasa.Device.connect', return_value=mock_device_single_plug):
+            with pytest.raises(AssertionError):
+                power_get('192.168.1.100', '8080', "0")


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
This pull request adds support for `TAPO/TP-Link` programmable power strips and single socket devices using python-kasa.

This feature is used to manage `TAPO` power strip or single socket from Labgrid. It adds `tapo` model to `NetworkPowerPort`. As all `Tapo` devices require credentials this feature requires user to set `KASA_LOGIN` and `KASA_PASSWORD` env variables to work (see [python-kasa website](https://github.com/python-kasa/python-kasa?tab=readme-ov-file#supported-tapo1-devices) for details).

I have tested it manually with Labgrid (client build and run wth Python3.9 and 3.12). Additionally I wrote unit tests for it and also I have run the `tox -r` command (Python: 3.9, 3.10, 3.11 and 3.12). All worked without errors and all the tests passed.

I have used this driver with `Tapo P300` power strip and `Tapo P100` socket. So it should work with all `Tapo` strips and sockets. 

While there already is support for `KASA/TP-Link` products in Labgrid using python-kasa, it doesn't work with TAPO devices as they apparently use some other protocol and require password and login to work. In order to not complicate the implementation of `tplink` model I decided to implement support for `Tapo` devices as a separate one. Additionally KASA products are not available in Europe so I didn't have means to test current (`tplink`) solution, which was one more reason to separate this into another model.

Because of the necessity to create credentials this solution is a bit more complicated than the `tplink` model.

This solution is based on the `tplink` model. Two key differences are:
* Support for single sockets like `P100` that ignores value of `index`
* Requires `Tapo` cloud credentials in order to communicate with devices


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
