### PR TITLE
ShellDriver: add optional arg dest_authorized_keys

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1699,6 +1699,8 @@ Arguments:
     Can be an empty string.
   - keyfile (str): optional, keyfile to upload after login, making the
     `SSHDriver`_ usable
+  - dest_authorized_keys (str): optional, default="~/.ssh/authorized_keys", 
+    filename of the authorized_keys file
   - login_timeout (int, default=60): timeout for login prompt detection in
     seconds
   - await_login_timeout (int, default=2): time in seconds of silence that needs


### PR DESCRIPTION
ShellDriver: add optional arg dest_authorized_keys
    
Add an addition optional arg "dest_authorized_keys" with the default value of ```~/.ssh/authorized_keys```,

An example where this might be used is when an embedded system uses dropbear as it's ssh server daemon.  In such a case, the authorized_keys file is ```/etc/dropbear/authorized_keys```

Additionally, the ```put_key_file``` takes an optional ```dest_authorized_keys``` function parameter which defaults to the above arg.

Update docs

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature: runtime test with the arg set and without the arg set. 
- [x] PR has been tested locally

Fixes: #1626
