### PR TITLE
helpers: install as setuptools scripts

### DIFF
--- a/debian/labgrid-bound-connect
+++ b/debian/labgrid-bound-connect
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /opt/venvs/labgrid/bin/labgrid-bound-connect "$@"

--- a/debian/labgrid-raw-interface
+++ b/debian/labgrid-raw-interface
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /opt/venvs/labgrid/bin/labgrid-raw-interface "$@"

--- a/debian/labgrid.install
+++ b/debian/labgrid.install
@@ -5,6 +5,6 @@ debian/labgrid-coordinator /usr/bin
 debian/labgrid-exporter /usr/bin
 debian/labgrid-pytest /usr/bin
 debian/labgrid-suggest /usr/bin
-helpers/labgrid-bound-connect /usr/sbin
-helpers/labgrid-raw-interface /usr/sbin
+debian/labgrid-bound-connect /usr/sbin
+debian/labgrid-raw-interface /usr/sbin
 contrib/completion/labgrid-client.bash => /usr/share/bash-completion/completions/labgrid-client

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3242,10 +3242,11 @@ RawNetworkInterfaceDriver
 The :any:`RawNetworkInterfaceDriver` allows "raw" control of a network
 interface (such as Ethernet or WiFi).
 
-The labgrid-raw-interface helper (``helpers/labgrid-raw-interface``) needs to
-be installed in the PATH and usable via sudo without password.
-A configuration file ``/etc/labgrid/helpers.yaml`` must be installed on hosts
-exporting network interfaces for the RawNetworkInterfaceDriver, e.g.:
+The labgrid-raw-interface helper (``labgrid/helpers/raw_interface.py``,
+installed as ``<prefix>/bin/labgrid-raw-interface``) needs to be usable
+via sudo without password.  A configuration file
+``/etc/labgrid/helpers.yaml`` must be installed on hosts exporting network
+interfaces for the RawNetworkInterfaceDriver, e.g.:
 
 .. code-block:: yaml
 

--- a/labgrid/helpers/bound_connect.py
+++ b/labgrid/helpers/bound_connect.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 
 
 # This is intended to be used via sudo. For example, add via visudo:
-# %developers ALL = NOPASSWD: /usr/local/sbin/labgrid-bound-connect
+# %developers ALL = NOPASSWD: /usr/local/bin/labgrid-bound-connect
 
 import argparse
 import os
@@ -58,7 +58,7 @@ def main(ifname, address, port):
         raise RuntimeError("Missing socat binary") from e
 
 
-if __name__ == "__main__":
+def main_args():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '-d',
@@ -79,3 +79,5 @@ if __name__ == "__main__":
             traceback.print_exc()
         print(f"ERROR: {e}", file=sys.stderr)
 
+if __name__ == "__main__":
+    main_args()

--- a/labgrid/helpers/raw_interface.py
+++ b/labgrid/helpers/raw_interface.py
@@ -5,7 +5,7 @@
 # can deny access to network interfaces. See below.
 #
 # This is intended to be used via sudo. For example, add via visudo:
-# %developers ALL = NOPASSWD: /usr/sbin/labgrid-raw-interface
+# %developers ALL = NOPASSWD: /usr/local/bin/labgrid-raw-interface
 
 import argparse
 import os
@@ -123,7 +123,7 @@ def main(program, options):
         raise RuntimeError(f"Missing {program} binary") from e
 
 
-if __name__ == "__main__":
+def main_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("-d", "--debug", action="store_true", default=False, help="enable debug mode")
     subparsers = parser.add_subparsers(dest="program", help="program to run")
@@ -180,3 +180,7 @@ if __name__ == "__main__":
             traceback.print_exc(file=sys.stderr)
         print(f"ERROR: {e}", file=sys.stderr)
         exit(1)
+
+
+if __name__ == "__main__":
+    main_args()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,8 @@ labgrid-client = "labgrid.remote.client:main"
 labgrid-exporter = "labgrid.remote.exporter:main"
 labgrid-suggest = "labgrid.resource.suggest:main"
 labgrid-coordinator = "labgrid.remote.coordinator:main"
+labgrid-bound-connect = "labgrid.helpers.bound_connect:main_args"
+labgrid-raw-interface = "labgrid.helpers.raw_interface:main_args"
 
 # the following makes a plugin available to pytest
 [project.entry-points.pytest11]


### PR DESCRIPTION
Allow using e.g. labgrid-bound-connect also when installing labgrid using pip.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
We install labgrid using `pip` in a `Containerfile`, but need to use `labgrid-bound-connect` on the exporter. This isn't currently possible, as the two scripts in `./helpers/` aren't installed unless building a debian package.

To make it possible to configure the two helpers as scripts in `pyproject.toml` they must reside in the python package itself, so move the two files from `./helpers/` to `./labgrid/helpers`.

Both scripts are also changed to configure/parse arguments in a function instead of the global scope, as the setuptools scripts configuration needs to call a function from the specified files.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
