### PR TITLE
target: poll needed resources only when activating

### DIFF
--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -41,7 +41,7 @@ class Target:
         else:
             input(msg)
 
-    def update_resources(self):
+    def update_resources(self, resources=None):
         """
         Iterate over all relevant resources and deactivate any active but
         unavailable resources.
@@ -49,7 +49,7 @@ class Target:
         if (monotonic() - self.last_update) < 0.1:
             return
         self.last_update = monotonic()
-        for resource in self.resources:
+        for resource in self.resources if resources is None else resources:
             resource.poll()
             if not resource.avail and resource.state is BindingState.active:
                 deactivated = self.deactivate(resource)
@@ -71,7 +71,7 @@ class Target:
             timeout (float): optional timeout
             avail (bool): optionally wait until the resources are unavailable with avail=False
         """
-        self.update_resources()
+        self.update_resources(resources)
 
         waiting = set(r for r in resources if r.avail != avail)
         static = set(r for r in waiting if r.get_managed_parent() is None)
@@ -102,7 +102,7 @@ class Target:
                 filter=waiting
             )
 
-        self.update_resources()
+        self.update_resources(resources)
 
     def get_resource(self, cls, *, name=None, wait_avail=True):
         """


### PR DESCRIPTION
No need to wait for resources that aren't used when activating a specific resource.

This reduces invocation times of various operations significantly (at least in our case):

- `labgrid-client power get`
  3.2 -> 1.2 s
- `labrid-client io get ign`
  2.7 -> 1.1 s
- `labgrid-client ssh true`
  4.2 -> 3.1 s

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Waiting needlessly when interacting with a target can be frustrating, so after some good old `print()` debugging, it turned out to be the polling of resources that took up (at least some of) the time.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
