### PR TITLE
util/agents/network_interface: bail out if NM did not find an interface

### DIFF
--- a/labgrid/util/agents/network_interface.py
+++ b/labgrid/util/agents/network_interface.py
@@ -98,6 +98,8 @@ class NMDev:
     def __init__(self, interface):
         self._interface = interface
         self._nm_dev = nm.get_device_by_iface(interface)  # pylint: disable=possibly-used-before-assignment
+        if self._nm_dev is None:
+            raise ValueError(f"No device found for interface {interface}")
 
     def _delete_connection(self, con):
         future = Future()


### PR DESCRIPTION
**Description**
`nm.get_device_by_iface()` returns `None` if there is no device for an interface. This can happen if NetworkManager is not running, it it's in an undefined state or if it does not manage the interface at all.

Instead of trying to call methods on the returned None type, let's bail out early with a proper exception.

**Checklist**
- [x] PR has been tested