### PR TITLE
driver/power: Add support for tinycontrol tcPDU

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -248,6 +248,10 @@ Currently available are:
   It was tested on the *6G10A v2* model.
   `Manual <https://tinycontrol.pl/media/documents/manual_IP_Power_Socket__6G10A_v2_LANLIS-010-015_En-1.pdf>`__
 
+``tinycontrol_tcpdu``
+  Controls a Tinycontrol tcPDU via HTTP.
+  See the `documentation <https://docs.tinycontrol.pl/en/tcpdu/api/commands/>`__
+
 ``poe_mib``
   Controls PoE switches using the PoE SNMP administration MiBs.
 

--- a/labgrid/driver/power/tinycontrol_tcpdu.py
+++ b/labgrid/driver/power/tinycontrol_tcpdu.py
@@ -1,0 +1,33 @@
+""" A driver to control the Tinycontrol tcPDU
+    Reference: https://docs.tinycontrol.pl/en/tcpdu/api/commands
+
+    Example configuration to use port #3 on a device with URL 'http://172.17.180.53/'
+
+    NetworkPowerPort:
+      model: tinycontrol_tcpdu
+      host: 'http://172.17.180.53'
+      index: 3
+"""
+
+from urllib.parse import urljoin
+
+import requests
+
+
+def power_set(host, port, index, value):
+    assert port is None
+
+    index = int(index)
+    value = 1 if value else 0
+    r = requests.get(urljoin(host, f"/api/v1/save/?out{index}={value}"))
+    r.raise_for_status()
+
+
+def power_get(host, port, index):
+    assert port is None
+
+    index = int(index)
+    r = requests.get(urljoin(host, "/api/v1/read/status/?outValues"))
+    r.raise_for_status()
+    json_decoded = r.json()
+    return json_decoded[f'out{index}'] == 1

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -290,6 +290,7 @@ class TestNetworkPowerDriver:
         import labgrid.driver.power.eg_pms2_network
         import labgrid.driver.power.shelly_gen1
         import labgrid.driver.power.ubus
+        import labgrid.driver.power.tinycontrol_tcpdu
 
     def test_import_backend_eaton(self):
         pytest.importorskip("pysnmp")


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

This module adds a power driver for the tinycontrol tcPDU.

tcPDU is a network-enabled PDU: <https://tinycontrol.pl/en/tcpdu/>

Unfortunately, the existing 'tinycontrol'-driver cannot be reused because the API is quite different.
API-Documentation: <https://docs.tinycontrol.pl/en/tcpdu/api/commands/>


I have tested this code with real hardware with these versions: 
- HW: "v1.1" 
- SW: "1.28-tcpdu"

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested