### PR TITLE
gpiodriver: allow GpioDigitalOutputDriver match against MatchedSysfsGPIO

### DIFF
--- a/labgrid/driver/gpiodriver.py
+++ b/labgrid/driver/gpiodriver.py
@@ -14,7 +14,7 @@ from ..util.agentwrapper import AgentWrapper
 class GpioDigitalOutputDriver(Driver, DigitalOutputProtocol):
 
     bindings = {
-        "gpio": {"SysfsGPIO", "NetworkSysfsGPIO"},
+        "gpio": {"SysfsGPIO", "MatchedSysfsGPIO", "NetworkSysfsGPIO"},
     }
 
     def __attrs_post_init__(self):


### PR DESCRIPTION
The documentation states that the GpioDigitalOutputDriver should bind to the following three 'gpio' options:

- SysfsGPIO
- MatchedSysfsGPIO
- NetworkSysfsGPIO

However, the bindings list is:

    bindings = {
        "gpio": {"SysfsGPIO", "NetworkSysfsGPIO"},
    }

and as a result, if I try to bind these two in an environment, I see errors like:

labgrid.exceptions.NoSupplierFoundError: binding copilot-output-driver failed: no supplier matching {'NetworkSysfsGPIO', 'SysfsGPIO'} found in Target(name='beagleplay', env=Environment(config_file='bp-conf2.yaml')) (errors: [NoResourceFoundError(msg="no NetworkSysfsGPIO resource found in Target(name='beagleplay', env=Environment(config_file='bp-conf2.yaml'))", filter=None, found=None), NoResourceFoundError(msg="no SysfsGPIO resource found in Target(name='beagleplay', env=Environment(config_file='bp-conf2.yaml'))", filter=None, found=None)])

Adjust the list to include MatchedSysfsGPIO so that this works (and so that the docs are correct).
