### PR TITLE
driver/fastbootdriver: add erase method

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -110,6 +110,11 @@ class AndroidFastbootDriver(Driver):
             self.flash(partition)
 
     @Driver.check_active
+    @step(args=['partition'])
+    def erase(self, partition):
+        self('erase', partition)
+
+    @Driver.check_active
     @step(args=['cmd'])
     def run(self, cmd):
         self("oem", "exec", "--", cmd)


### PR DESCRIPTION
**Description**
"fastboot erase" erases a flash partition, so add a corresponding method for it.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] PR has been tested