### PR TITLE
contrib/sync-places: filter tags during creation

### DIFF
--- a/contrib/sync-places.py
+++ b/contrib/sync-places.py
@@ -117,11 +117,7 @@ def main():
                         await session.sync_with_coordinator()
                     changed = True
 
-            tags = config["places"][name].get("tags", {}).copy()
-            for k, v in tags.items():
-                if not isinstance(k, str) or not isinstance(v, str):
-                    del(tags[k])
-                    tags[str(k)] = str(v)
+            tags = { str(k): str(v) for k, v in config["places"][name].get("tags", {}).items() }
 
             if place_tags != tags:
                 print(


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
In older versions of python, when iterating over a dictionary, a copy would be created allowing us to modify the dictionary while we're iterating over it. Newer versions however do not make this copy and now raise runtime errors when the keys change while we're iterating over them.

Transform the key/values during creation of the 'tags' dictionary to avoid having to delete keys afterwards.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
Fixes #1312