### PR TITLE
Fix coordinator/exporter start in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -129,7 +129,7 @@ class Exporter(LabgridComponent):
         assert self.reader is None
 
         self.spawn = pexpect.spawn(
-            f'labgrid-exporter --name testhost {self.config}',
+            f'python -m labgrid.remote.exporter --name testhost {self.config}',
             logfile=Prefixer(sys.stdout.buffer, 'exporter'),
             cwd=self.cwd)
         try:


### PR DESCRIPTION

**Description**
Invoke exporter and coordinator like the client in the test, by using `python -m` instead of relying on a shell script wrapper.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested