### PR TITLE
NetworkPowerPort: add support for Shelly Gen2+

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -228,6 +228,13 @@ Currently available are:
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/shelly_gen1.py>`__
   for details.
 
+  ``shelly_gen2``
+  Controls relays of *Shelly* devices using the
+  `Gen2+ API <https://shelly-api-docs.shelly.cloud/gen2/General/RPCProtocol/>`__.
+  See the `docstring in the module
+  <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/shelly_gen2.py>`__
+  for details.
+
 ``siglent``
   Controls *Siglent SPD3000X* series modules via the `vxi11 Python module
   <https://pypi.org/project/python-vxi11/>`_.

--- a/labgrid/driver/power/shelly_gen2.py
+++ b/labgrid/driver/power/shelly_gen2.py
@@ -1,0 +1,30 @@
+"""Interface for controlling relays of Shelly devices using the Gen 2+ API
+
+  NetworkPowerPort:
+      model: shelly_gen2
+      host: 'http://192.168.0.42'
+      index: 0
+
+Will do a POST request to http://192.168.0.42/rpc to get the current
+relay state or change the state.
+
+Also, see the official Gen 2+ Device API documentation:
+https://shelly-api-docs.shelly.cloud/gen2/General/RPCProtocol
+"""
+
+import requests
+
+
+def power_set(host: str, port: int, index: int = 0, value: bool = True):
+    assert not port
+    payload = {"id": 1, "method": "Switch.Set", "params": {"id": index, "on": value}}
+    r = requests.post(f"{host}/rpc", json=payload)
+    r.raise_for_status()
+
+
+def power_get(host: str, port: int, index: int = 0):
+    assert not port
+    payload = {"id": 1, "method": "Switch.GetStatus", "params": {"id": index}}
+    r = requests.post(f"{host}/rpc", json=payload)
+    r.raise_for_status()
+    return r.json()["output"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -219,6 +219,7 @@ include = [
   "labgrid/driver/httpvideodriver.py",
   "labgrid/driver/manualswitchdriver.py",
   "labgrid/driver/power/gude8031.py",
+  "labgrid/driver/power/shelly_gen2.py",
   "labgrid/driver/rawnetworkinterfacedriver.py",
   "labgrid/protocol/**/*.py",
   "labgrid/remote/**/*.py",


### PR DESCRIPTION


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

The API changed and no longer excepts POST for the legacy API. This commit adds support for the "new" RPC API.

Ref: https://shelly-api-docs.shelly.cloud/gen2/General/RPCProtocol

Tested with a Shelly Plug S MTR Gen3

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
  - Added in docstring
- [x] Tests for the feature 
  - Tested with real hardware
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
