### PR TITLE
SSHDriver: Fix Timeout handling on start_own_master()

### DIFF
--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -97,13 +97,11 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         # connection refused during target startup
         connect_timeout = round(timeout.remaining)
         while True:
-            if connect_timeout == 0:
-                raise Exception("Timeout while waiting for ssh connection")
             try:
                 return self._start_own_master_once(connect_timeout)
             except ExecutionError as e:
                 if timeout.expired:
-                    raise e
+                    raise Exception("Timeout while waiting for ssh connection") from e
                 time.sleep(0.5)
                 connect_timeout = round(timeout.remaining)
 


### PR DESCRIPTION
**Description**
Without this change an Exception during `_start_own_master_once()` could get lost if the timeout happens at the wrong point in time.

With this change we re-raise the last exception that happened during `_start_own_master_once()`.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
