### PR TITLE
man/labgrid-client: improve readability

### DIFF
--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -133,41 +133,41 @@ and name is its name. Wild cards in match patterns are explicitly allowed, *
 matches anything.
 .SH LABGRID-CLIENT COMMANDS
 .sp
-\fBmonitor\fP                     Monitor events from the coordinator
+\fBmonitor\fP                                 Monitor events from the coordinator
 .sp
-\fBresources (r)\fP               List available resources
+\fBresources (r)\fP                           List available resources
 .sp
-\fBplaces (p)\fP                  List available places
+\fBplaces (p)\fP                              List available places
 .sp
-\fBwho\fP                         List acquired places by user
+\fBwho\fP                                     List acquired places by user
 .sp
-\fBshow\fP                        Show a place and related resources
+\fBshow\fP                                    Show a place and related resources
 .sp
-\fBcreate\fP                      Add a new place (name supplied by \-p parameter)
+\fBcreate\fP                                  Add a new place (name supplied by \-p parameter)
 .sp
-\fBdelete\fP                      Delete an existing place
+\fBdelete\fP                                  Delete an existing place
 .sp
-\fBadd\-alias\fP alias             Add an alias to a place
+\fBadd\-alias\fP \fB[alias]\fP                   Add an alias to a place
 .sp
-\fBdel\-alias\fP alias             Delete an alias from a place
+\fBdel\-alias\fP \fB[alias]\fP                   Delete an alias from a place
 .sp
-\fBset\-comment\fP comment         Update or set the place comment
+\fBset\-comment\fP \fB[comment]\fP               Update or set the place comment
 .sp
-\fBset\-tags\fP key=value          Set place tags (key=value)
+\fBset\-tags\fP \fB[key=value]\fP                Set place tags (key=value)
 .sp
-\fBadd\-match\fP match             Add one (or multiple) match pattern(s) to a place, see MATCHES
+\fBadd\-match\fP \fB[match]\fP                   Add one (or multiple) match pattern(s) to a place, see MATCHES
 .sp
-\fBdel\-match\fP match             Delete one (or multiple) match pattern(s) from a place, see MATCHES
+\fBdel\-match\fP \fB[match]\fP                   Delete one (or multiple) match pattern(s) from a place, see MATCHES
 .sp
-\fBadd\-named\-match\fP match name  Add one match pattern with a name to a place
+\fBadd\-named\-match\fP \fB[match]\fP \fB[name]\fP  Add one match pattern with a name to a place
 .sp
-\fBacquire (lock)\fP              Acquire a place
+\fBacquire (lock)\fP                          Acquire a place
 .sp
-\fBallow\fP user                  Allow another user to access a place
+\fBallow\fP \fB[user]\fP                        Allow another user to access a place
 .sp
-\fBrelease (unlock)\fP            Release a place
+\fBrelease (unlock)\fP                        Release a place
 .sp
-\fBrelease\-from\fP host/user      Atomically release a place, but only if acquired by a specific user.
+\fBrelease\-from\fP \fB[host/user]\fP            Atomically release a place, but only if acquired by a specific user.
 .INDENT 0.0
 .INDENT 3.5
 Note that this command returns success as long
@@ -177,59 +177,59 @@ not at all.
 .UNINDENT
 .UNINDENT
 .sp
-\fBenv\fP                         Generate a labgrid environment file for a place
+\fBenv\fP                                     Generate a labgrid environment file for a place
 .sp
-\fBpower (pw)\fP action           Change (or get) a place\(aqs power status, where action is one of get, on, off, cycle
+\fBpower (pw)\fP \fB[action]\fP                 Change (or get) a place\(aqs power status, where action is one of get, on, off, cycle
 .sp
-\fBio\fP action [name]            Interact with GPIO (OneWire, relays, ...) devices, where action is one of high, low, get
+\fBio\fP \fB[action]\fP \fB[name]\fP              Interact with GPIO (OneWire, relays, ...) devices, where action is one of high, low, get
 .sp
-\fBconsole (con)\fP [name]        Connect to the console
+\fBconsole (con)\fP \fB[name]\fP                Connect to the console
 .sp
-\fBdfu\fP arg                     Run dfu commands
+\fBdfu\fP \fB[arg]\fP                           Run dfu commands
 .sp
-\fBfastboot\fP arg                Run fastboot with argument
+\fBfastboot\fP \fB[arg]\fP                      Run fastboot with argument
 .sp
-\fBflashscript\fP script arg      Run arbitrary script with arguments to flash device
+\fBflashscript\fP \fB[script]\fP \fB[arg]\fP      Run arbitrary script with arguments to flash device
 .sp
-\fBbootstrap\fP filename          Start a bootloader
+\fBbootstrap\fP \fB[filename]\fP                Start a bootloader
 .sp
-\fBsd\-mux\fP action               Switch USB SD Muxer, where action is one of dut (device\-under\-test), host, off
+\fBsd\-mux\fP \fB[action]\fP                     Switch USB SD Muxer, where action is one of dut (device\-under\-test), host, off
 .sp
-\fBusb\-mux\fP action              Switch USB Muxer, where action is one of off, dut\-device, host\-dut, host\-device, host\-dut+host\-device
+\fBusb\-mux\fP \fB[action]\fP                    Switch USB Muxer, where action is one of off, dut\-device, host\-dut, host\-device, host\-dut+host\-device
 .sp
-\fBssh\fP [command]               Connect via SSH. Additional arguments are passed to ssh.
+\fBssh\fP \fB[command]\fP                       Connect via SSH. Additional arguments are passed to ssh.
 .sp
-\fBscp\fP source destination      Transfer file via scp (use \(aq:dir/file\(aq for the remote side)
+\fBscp\fP \fB[source]\fP \fB[destination]\fP      Transfer file via scp (use \(aq:dir/file\(aq for the remote side)
 .sp
-\fBrsync\fP source destination    Transfer files via rsync (use \(aq:dir/file\(aq for the remote side)
+\fBrsync\fP \fB[source]\fP \fB[destination]\fP    Transfer files via rsync (use \(aq:dir/file\(aq for the remote side)
 .sp
-\fBsshfs\fP remotepath mountpoint Mount a remote path via sshfs
+\fBsshfs\fP \fB[remotepath]\fP \fB[mountpoint]\fP Mount a remote path via sshfs
 .sp
-\fBforward\fP                     Forward local port to remote target
+\fBforward\fP                                 Forward local port to remote target
 .sp
-\fBtelnet\fP                      Connect via telnet
+\fBtelnet\fP                                  Connect via telnet
 .sp
-\fBvideo\fP                       Start a video stream
+\fBvideo\fP                                   Start a video stream
 .sp
-\fBaudio\fP                       Start an audio stream
+\fBaudio\fP                                   Start an audio stream
 .sp
-\fBtmc\fP command                 Control a USB TMC device
+\fBtmc\fP \fB[command]\fP                       Control a USB TMC device
 .sp
-\fBwrite\-files\fP filename(s)     Copy files onto mass storage device
+\fBwrite\-files\fP \fB[filename(s)]\fP           Copy files onto mass storage device
 .sp
-\fBwrite\-image\fP filename        Write images onto block devices (USBSDMux, USB Sticks, …)
+\fBwrite\-image\fP \fB[filename]\fP              Write images onto block devices (USBSDMux, USB Sticks, …)
 .sp
-\fBreserve\fP filter              Create a reservation
+\fBreserve\fP \fB[filter]\fP                    Create a reservation
 .sp
-\fBcancel\-reservation\fP token    Cancel a pending reservation
+\fBcancel\-reservation\fP \fB[token]\fP          Cancel a pending reservation
 .sp
-\fBwait\fP token                  Wait for a reservation to be allocated
+\fBwait\fP \fB[token]\fP                        Wait for a reservation to be allocated
 .sp
-\fBreservations\fP                List current reservations
+\fBreservations\fP                            List current reservations
 .sp
-\fBexport\fP filename             Export driver information to file (needs environment with drivers)
+\fBexport\fP \fB[filename]\fP                   Export driver information to file (needs environment with drivers)
 .sp
-\fBversion\fP                     Print the labgrid version
+\fBversion\fP                                 Print the labgrid version
 .SH ADDING NAMED RESOURCES
 .sp
 If a target contains multiple Resources of the same type, named matches need to

--- a/man/labgrid-client.rst
+++ b/man/labgrid-client.rst
@@ -126,100 +126,100 @@ matches anything.
 
 LABGRID-CLIENT COMMANDS
 -----------------------
-``monitor``                     Monitor events from the coordinator
+``monitor``                                 Monitor events from the coordinator
 
-``resources (r)``               List available resources
+``resources (r)``                           List available resources
 
-``places (p)``                  List available places
+``places (p)``                              List available places
 
-``who``                         List acquired places by user
+``who``                                     List acquired places by user
 
-``show``                        Show a place and related resources
+``show``                                    Show a place and related resources
 
-``create``                      Add a new place (name supplied by -p parameter)
+``create``                                  Add a new place (name supplied by -p parameter)
 
-``delete``                      Delete an existing place
+``delete``                                  Delete an existing place
 
-``add-alias`` alias             Add an alias to a place
+``add-alias`` ``[alias]``                   Add an alias to a place
 
-``del-alias`` alias             Delete an alias from a place
+``del-alias`` ``[alias]``                   Delete an alias from a place
+ 
+``set-comment`` ``[comment]``               Update or set the place comment
 
-``set-comment`` comment         Update or set the place comment
+``set-tags`` ``[key=value]``                Set place tags (key=value)
 
-``set-tags`` key=value          Set place tags (key=value)
+``add-match`` ``[match]``                   Add one (or multiple) match pattern(s) to a place, see MATCHES
 
-``add-match`` match             Add one (or multiple) match pattern(s) to a place, see MATCHES
+``del-match`` ``[match]``                   Delete one (or multiple) match pattern(s) from a place, see MATCHES
 
-``del-match`` match             Delete one (or multiple) match pattern(s) from a place, see MATCHES
+``add-named-match`` ``[match]`` ``[name]``  Add one match pattern with a name to a place
 
-``add-named-match`` match name  Add one match pattern with a name to a place
+``acquire (lock)``                          Acquire a place
 
-``acquire (lock)``              Acquire a place
+``allow`` ``[user]``                        Allow another user to access a place
 
-``allow`` user                  Allow another user to access a place
+``release (unlock)``                        Release a place
 
-``release (unlock)``            Release a place
-
-``release-from`` host/user      Atomically release a place, but only if acquired by a specific user.
+``release-from`` ``[host/user]``            Atomically release a place, but only if acquired by a specific user.
 
                                 Note that this command returns success as long
                                 as the specified user no longer owns the place,
                                 meaning it may be acquired by another user or
                                 not at all.
 
-``env``                         Generate a labgrid environment file for a place
+``env``                                     Generate a labgrid environment file for a place
 
-``power (pw)`` action           Change (or get) a place's power status, where action is one of get, on, off, cycle
+``power (pw)`` ``[action]``                 Change (or get) a place's power status, where action is one of get, on, off, cycle
 
-``io`` action [name]            Interact with GPIO (OneWire, relays, ...) devices, where action is one of high, low, get
+``io`` ``[action]`` ``[name]``              Interact with GPIO (OneWire, relays, ...) devices, where action is one of high, low, get
 
-``console (con)`` [name]        Connect to the console
+``console (con)`` ``[name]``                Connect to the console
 
-``dfu`` arg                     Run dfu commands
+``dfu`` ``[arg]``                           Run dfu commands
 
-``fastboot`` arg                Run fastboot with argument
+``fastboot`` ``[arg]``                      Run fastboot with argument
 
-``flashscript`` script arg      Run arbitrary script with arguments to flash device
+``flashscript`` ``[script]`` ``[arg]``      Run arbitrary script with arguments to flash device
 
-``bootstrap`` filename          Start a bootloader
+``bootstrap`` ``[filename]``                Start a bootloader
 
-``sd-mux`` action               Switch USB SD Muxer, where action is one of dut (device-under-test), host, off
+``sd-mux`` ``[action]``                     Switch USB SD Muxer, where action is one of dut (device-under-test), host, off
 
-``usb-mux`` action              Switch USB Muxer, where action is one of off, dut-device, host-dut, host-device, host-dut+host-device
+``usb-mux`` ``[action]``                    Switch USB Muxer, where action is one of off, dut-device, host-dut, host-device, host-dut+host-device
 
-``ssh`` [command]               Connect via SSH. Additional arguments are passed to ssh.
+``ssh`` ``[command]``                       Connect via SSH. Additional arguments are passed to ssh.
 
-``scp`` source destination      Transfer file via scp (use ':dir/file' for the remote side)
+``scp`` ``[source]`` ``[destination]``      Transfer file via scp (use ':dir/file' for the remote side)
 
-``rsync`` source destination    Transfer files via rsync (use ':dir/file' for the remote side)
+``rsync`` ``[source]`` ``[destination]``    Transfer files via rsync (use ':dir/file' for the remote side)
 
-``sshfs`` remotepath mountpoint Mount a remote path via sshfs
+``sshfs`` ``[remotepath]`` ``[mountpoint]`` Mount a remote path via sshfs
 
-``forward``                     Forward local port to remote target
+``forward``                                 Forward local port to remote target
 
-``telnet``                      Connect via telnet
+``telnet``                                  Connect via telnet
 
-``video``                       Start a video stream
+``video``                                   Start a video stream
 
-``audio``                       Start an audio stream
+``audio``                                   Start an audio stream
 
-``tmc`` command                 Control a USB TMC device
+``tmc`` ``[command]``                       Control a USB TMC device
 
-``write-files`` filename(s)     Copy files onto mass storage device
+``write-files`` ``[filename(s)]``           Copy files onto mass storage device
 
-``write-image`` filename        Write images onto block devices (USBSDMux, USB Sticks, …)
+``write-image`` ``[filename]``              Write images onto block devices (USBSDMux, USB Sticks, …)
 
-``reserve`` filter              Create a reservation
+``reserve`` ``[filter]``                    Create a reservation
 
-``cancel-reservation`` token    Cancel a pending reservation
+``cancel-reservation`` ``[token]``          Cancel a pending reservation
 
-``wait`` token                  Wait for a reservation to be allocated
+``wait`` ``[token]``                        Wait for a reservation to be allocated
 
-``reservations``                List current reservations
+``reservations``                            List current reservations
 
-``export`` filename             Export driver information to file (needs environment with drivers)
+``export`` ``[filename]``                   Export driver information to file (needs environment with drivers)
 
-``version``                     Print the labgrid version
+``version``                                 Print the labgrid version
 
 ADDING NAMED RESOURCES
 ----------------------


### PR DESCRIPTION
Change the formatting of argument placeholders for the `labgrid-client` docs so it's clearer for people looking through the documentation. This includes indentation with extra whitespace in man/labgrid-client.rst so that descriptions are lined up in an editor, although this part isn't reflected on the generated docs page.

- [X] Man pages have been regenerated

I've attached some before and after screenshots to compare how the docs look.

Before:

![labgrid_client_docs_before](https://github.com/user-attachments/assets/201c16d2-26a0-44d3-8a69-42f85e965db4)

After:
![labgrid_client_docs_after](https://github.com/user-attachments/assets/b410aa1e-e13d-41ee-8dbc-7add80e70d85)

