### PR TITLE
driver/bareboxdriver: change default interrupt key to CTRL+D

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,14 @@
+Release 25.1 (Unreleased)
+-------------------------
+
+New Features in 25.1
+~~~~~~~~~~~~~~~~~~~~
+
+- The default interrupt key for the `BareboxDriver` is now CTRL+D (``\x04``)
+  instead of a line feed (``\n``). barebox v2025.03.0 onwards handles
+  CTRL+D specially to halt autoboot countdown without running interactive
+  hooks like bringing up network interfaces automatically.
+
 Release 25.0 (Released May 7, 2025)
 -----------------------------------
 As announced `before

--- a/labgrid/driver/bareboxdriver.py
+++ b/labgrid/driver/bareboxdriver.py
@@ -32,7 +32,7 @@ class BareboxDriver(CommandMixin, Driver, CommandProtocol, LinuxBootProtocol):
     bindings = {"console": ConsoleProtocol, }
     prompt = attr.ib(default="", validator=attr.validators.instance_of(str))
     autoboot = attr.ib(default="stop autoboot", validator=attr.validators.instance_of(str))
-    interrupt = attr.ib(default="\n", validator=attr.validators.instance_of(str))
+    interrupt = attr.ib(default="\x04", validator=attr.validators.instance_of(str))
     bootstring = attr.ib(default=r"Linux version \d", validator=attr.validators.instance_of(str))
     password = attr.ib(default="", validator=attr.validators.instance_of(str))
     login_timeout = attr.ib(default=60, validator=attr.validators.instance_of(int))


### PR DESCRIPTION
For developer convenience, barebox v2022.11.0 onwards brings up network interfaces automatically in the background when the boot is aborted by user input. By the time a user then runs boot net for example, the seconds it takes for an Ethernet link to be established will have passed.

The effects of this have already been seen in Labgrid; Commit 6f7bf6614ffd ("driver/bareboxdriver: silence barebox in _await_prompt() and unsilence on boot()") changes the log level to suppress "ethX: N Mbps ... link detected" messages, but it leaves another problem unaddressed: A system that Labgrid aborts to run the boot command now behaves differently to a system that was left to boot normally, because network adapters are reconfigured that normally aren't.

This bit me while trying to use Labgrid to debug a network issue in Linux as barebox ifup changed the Linux behavior.

barebox v2025.03.0 introduces a new halt state that can be entered by ctrl-d that skips these automatic hooks. Using it should not introduce regressions for existing users, regardless of barebox version:

- Prior to barebox v2025.01.0, the only options for an abort key were ctrl-c or any and both line feed and CTRL+D behave the same with either option.

- After v2025.01.0, global.autoboot_abort_key can be set to an arbitrary single printable ASCII key and it seems not possible to set a new line this way.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
