### PR TITLE
Drop dependency on ansicolors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ classifiers = [
     "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
 ]
 dependencies = [
-    "ansicolors>=1.1.8",
     "attrs>=21.4.0",
     "grpcio>=1.64.1, <2.0.0",
     "grpcio-reflection>=1.64.1, <2.0.0",

--- a/tests/test_steplogger.py
+++ b/tests/test_steplogger.py
@@ -29,7 +29,6 @@ def test(target):
     return t
 
 def test_step_logger(power_env, pw_cycle_test):
-    from colors import strip_color
     # step reporter is called when -vv is given
     # -s is necessary for manual power driver confirmation
     with pexpect.spawn('pytest -vvs --lg-env {env} {test}'
@@ -37,7 +36,7 @@ def test_step_logger(power_env, pw_cycle_test):
 
         # rough match
         spawn.expect("→.*?ManualPowerDriver.*?cycle.*?\r\n".encode("utf-8"))
-        step_line = strip_color(spawn.after.decode("utf-8")).rstrip()
+        step_line = spawn.after.decode("utf-8").rstrip()
         # exact match
         assert step_line.endswith("→ ManualPowerDriver.cycle()"), f"'{step_line}' did not match"
 
@@ -47,7 +46,7 @@ def test_step_logger(power_env, pw_cycle_test):
 
         # rough match
         spawn.expect("←.*?ManualPowerDriver.*?cycle.*?\r\n".encode("utf-8"))
-        step_line = strip_color(spawn.after.decode("utf-8")).rstrip()
+        step_line = spawn.after.decode("utf-8").rstrip()
         # exact match
 
         assert re.match(r"← ManualPowerDriver.cycle\(\) \[[\d.]+s\]$", step_line), f"'{step_line}' did not match"


### PR DESCRIPTION
pytest doesn't emit colors if there is no terminal, so there is no need to filter out ANSI sequences. This drops the only remaining user of ansicolors, so the dpeendency can be dropped.

I noticed that while looking through the dependencies considering packaging for Debian.

For me the test suite continued to work fine with this change, but I'm ready for surprises :-)