### PR TITLE
tftp: add external_ip setting

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1289,10 +1289,12 @@ A :any:`TFTPProvider` resource describes a TFTP server.
    TFTPProvider:
      internal: '/srv/tftp/board-23/'
      external: 'board-23/'
+     external_ip: '192.168.1.100'  # optional
 
 Arguments:
   - internal (str): path prefix to the local directory accessible by the target
   - external (str): corresponding path prefix for use by the target
+  - external_ip (str, optional): IP address that the target should use to access the TFTP server. If not specified, defaults to empty string.
 
 Used by:
   - `TFTPProviderDriver`_
@@ -1339,11 +1341,13 @@ a remote computer.
      host: 'tftphost'
      internal: '/srv/tftp/board-23/'
      external: 'board-23/'
+     external_ip: '10.0.0.50'  # optional
 
 Arguments:
   - host (str): hostname of the remote host
   - internal (str): path prefix to the TFTP root directory on ``host``
   - external (str): corresponding path prefix for use by the target
+  - external_ip (str, optional): IP address that the target should use to access the TFTP server. If not specified, defaults to empty string.
 
 Used by:
   - `TFTPProviderDriver`_

--- a/labgrid/driver/provider.py
+++ b/labgrid/driver/provider.py
@@ -16,6 +16,7 @@ class BaseProviderDriver(Driver):
             "host": self.provider.host,
             "internal": self.provider.internal,
             "external": self.provider.external,
+            "external_ip": self.provider.external_ip,
         }
 
     @Driver.check_active

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -590,6 +590,7 @@ class ProviderGenericExport(ResourceExport):
             "host": self.host,
             "internal": self.local.internal,
             "external": self.local.external,
+            "external_ip": self.local.external_ip,
         }
 
 

--- a/labgrid/resource/provider.py
+++ b/labgrid/resource/provider.py
@@ -8,6 +8,7 @@ from .common import Resource
 class BaseProvider(Resource):
     internal = attr.ib(validator=attr.validators.instance_of(str))
     external = attr.ib(validator=attr.validators.instance_of(str))
+    external_ip = attr.ib(default="", validator=attr.validators.instance_of(str))
 
     def __attrs_post_init__(self):
         self.host = "localhost"

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -396,6 +396,7 @@ class RemoteNetworkInterface(NetworkResource, ManagedResource):
 class RemoteBaseProvider(NetworkResource):
     internal = attr.ib(validator=attr.validators.instance_of(str))
     external = attr.ib(validator=attr.validators.instance_of(str))
+    external_ip = attr.ib(default="", validator=attr.validators.instance_of(str))
 
 
 @target_factory.reg_resource

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -97,6 +97,7 @@ def test_export_tftp_provider(target):
         'LG__TFTP_HOST': 'localhost',
         'LG__TFTP_INTERNAL': '/srv/tftp/testboard/',
         'LG__TFTP_EXTERNAL': 'testboard/',
+        'LG__TFTP_EXTERNAL_IP': '',
     }
 
 
@@ -109,4 +110,31 @@ def test_export_remote_tftp_provider(target):
         'LG__TFTP_HOST': 'testhost',
         'LG__TFTP_INTERNAL': '/srv/tftp/testboard/',
         'LG__TFTP_EXTERNAL': 'testboard/',
+        'LG__TFTP_EXTERNAL_IP': '',
+    }
+
+
+def test_export_tftp_provider_with_external_ip(target):
+    TFTPProvider(target, None, internal='/srv/tftp/testboard/', external='testboard/', external_ip='192.168.1.100')
+    TFTPProviderDriver(target, "tftp")
+
+    exported = target.export()
+    assert exported == {
+        'LG__TFTP_HOST': 'localhost',
+        'LG__TFTP_INTERNAL': '/srv/tftp/testboard/',
+        'LG__TFTP_EXTERNAL': 'testboard/',
+        'LG__TFTP_EXTERNAL_IP': '192.168.1.100',
+    }
+
+
+def test_export_remote_tftp_provider_with_external_ip(target):
+    RemoteTFTPProvider(target, None, host='testhost', internal='/srv/tftp/testboard/', external='testboard/', external_ip='10.0.0.50')
+    TFTPProviderDriver(target, "tftp")
+
+    exported = target.export()
+    assert exported == {
+        'LG__TFTP_HOST': 'testhost',
+        'LG__TFTP_INTERNAL': '/srv/tftp/testboard/',
+        'LG__TFTP_EXTERNAL': 'testboard/',
+        'LG__TFTP_EXTERNAL_IP': '10.0.0.50',
     }


### PR DESCRIPTION
Just as with the `external` (path) setting, it's helpful for the DUT to know from which IP the server offers firmware.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
