### PR TITLE
Client io fix resource matching

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -917,6 +917,8 @@ class ClientSession:
             drv = target.get_driver("DigitalOutputProtocol", name=name)
         except NoDriverFoundError:
             for resource in target.resources:
+                if not resource.name == name:
+                    continue
                 if isinstance(resource, ModbusTCPCoil):
                     drv = self._get_driver_or_new(target, "ModbusCoilDriver", name=name)
                 elif isinstance(resource, OneWirePIO):


### PR DESCRIPTION
**Description**
`digital_io` tried to match against class only instead of class _and_ name.
This lead to an early fail and an uncaught exception when a resource was
found but the name did not match.

Bail out if the name does not match.

**Checklist**
- [x] PR has been tested

Fixes #1679 
