### PR TITLE
Introduce Broken Strategy State, Prevent Further Use and Skip Subsequent Tests

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -421,6 +421,10 @@ target (session scope)
 
 strategy (session scope)
   Used to access the :any:`Strategy` configured in the 'main' :any:`Target`.
+  If the Strategy enters broken state, all subsequent tests requesting it via
+  this fixture will be skipped.
+  See also :any:`never_retry` for an easy way to mark strategies broken on
+  error.
 
 Command-Line Options
 ~~~~~~~~~~~~~~~~~~~~

--- a/examples/qemu-networking/qemunetworkstrategy.py
+++ b/examples/qemu-networking/qemunetworkstrategy.py
@@ -17,7 +17,7 @@ import enum
 import attr
 
 from labgrid import target_factory, step
-from labgrid.strategy import Strategy, StrategyError
+from labgrid.strategy import Strategy, StrategyError, never_retry
 from labgrid.util import get_free_port
 
 
@@ -77,6 +77,7 @@ class QEMUNetworkStrategy(Strategy):
                 networkservice.address = new_address
                 networkservice.port = self.__remote_port
 
+    @never_retry
     @step(args=["state"])
     def transition(self, state, *, step):
         if not isinstance(state, Status):

--- a/examples/strategy/bareboxrebootstrategy.py
+++ b/examples/strategy/bareboxrebootstrategy.py
@@ -5,7 +5,7 @@ import attr
 from labgrid import target_factory, step
 from labgrid.driver import BareboxDriver, ShellDriver
 from labgrid.protocol import PowerProtocol
-from labgrid.strategy import Strategy
+from labgrid.strategy import Strategy, never_retry
 
 
 @attr.s(eq=False)
@@ -58,6 +58,7 @@ class BareboxRebootStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     @step(args=["new_status"])
     def transition(self, new_status, *, step):
         if not isinstance(new_status, Status):

--- a/examples/strategy/quartusstrategy.py
+++ b/examples/strategy/quartusstrategy.py
@@ -5,7 +5,7 @@ import attr
 from labgrid import target_factory, step
 from labgrid.driver import QuartusHPSDriver, SerialDriver
 from labgrid.protocol import PowerProtocol
-from labgrid.strategy import Strategy
+from labgrid.strategy import Strategy, never_retry
 
 
 @attr.s(eq=False)
@@ -37,6 +37,7 @@ class QuartusHPSStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     @step(args=["status"])
     def transition(self, status, *, step):
         if not isinstance(status, Status):

--- a/examples/usbpower/examplestrategy.py
+++ b/examples/usbpower/examplestrategy.py
@@ -5,7 +5,7 @@ import attr
 from labgrid.driver import BareboxDriver, ShellDriver, USBSDMuxDriver
 from labgrid import step, target_factory
 from labgrid.protocol import PowerProtocol
-from labgrid.strategy import Strategy
+from labgrid.strategy import Strategy, never_retry
 
 
 @attr.s(eq=False)
@@ -36,6 +36,7 @@ class ExampleStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     @step(args=["status"])
     def transition(self, status, *, step):
         if not isinstance(status, Status):

--- a/labgrid/pytestplugin/__init__.py
+++ b/labgrid/pytestplugin/__init__.py
@@ -1,2 +1,2 @@
 from .fixtures import pytest_addoption, env, target, strategy
-from .hooks import pytest_configure, pytest_collection_modifyitems, pytest_cmdline_main
+from .hooks import pytest_configure, pytest_collection_modifyitems, pytest_cmdline_main, pytest_runtest_setup

--- a/labgrid/strategy/__init__.py
+++ b/labgrid/strategy/__init__.py
@@ -1,4 +1,4 @@
-from .common import Strategy, StrategyError
+from .common import Strategy, StrategyError, never_retry
 from .bareboxstrategy import BareboxStrategy
 from .shellstrategy import ShellStrategy
 from .ubootstrategy import UBootStrategy

--- a/labgrid/strategy/bareboxstrategy.py
+++ b/labgrid/strategy/bareboxstrategy.py
@@ -4,7 +4,7 @@ import attr
 
 from ..factory import target_factory
 from ..step import step
-from .common import Strategy, StrategyError
+from .common import Strategy, StrategyError, never_retry
 
 
 class Status(enum.Enum):
@@ -30,6 +30,7 @@ class BareboxStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     @step(args=['status'])
     def transition(self, status, *, step):  # pylint: disable=redefined-outer-name
         if not isinstance(status, Status):
@@ -63,6 +64,7 @@ class BareboxStrategy(Strategy):
             )
         self.status = status
 
+    @never_retry
     @step(args=['status'])
     def force(self, status):
         if not isinstance(status, Status):

--- a/labgrid/strategy/common.py
+++ b/labgrid/strategy/common.py
@@ -26,6 +26,10 @@ class Strategy(Driver):  # reuse driver handling
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
+
+        # contains exception that broke the strategy or None
+        self.broken = None
+
         if self.target is None:
             raise BindingError(
                 "Strategies can only be created on a valid target"

--- a/labgrid/strategy/common.py
+++ b/labgrid/strategy/common.py
@@ -1,7 +1,31 @@
+import functools
+
 import attr
 
 from ..binding import BindingError
 from ..driver import Driver
+
+
+def never_retry(func):
+    """
+    Strategy method decorator storing the original exception in strategy.broken and raising a
+    StrategyError from it. All subsequent calls to the decorated method will lead to the same
+    exception.
+    """
+    @functools.wraps(func)
+    def wrapper(self, *args, **kwargs):
+        if self.broken:
+            # a previous call broke the strategy, raise the original exception again
+            raise StrategyError(f"{self.__class__.__name__} is in broken state") from self.broken
+
+        try:
+            return func(self, *args, **kwargs)
+        except Exception as e:
+            # store original exception and raise StrategyError from it
+            self.broken = e
+            raise StrategyError(f"{self.__class__.__name__} is in broken state") from self.broken
+
+    return wrapper
 
 
 @attr.s(eq=False)

--- a/labgrid/strategy/dockerstrategy.py
+++ b/labgrid/strategy/dockerstrategy.py
@@ -3,7 +3,7 @@ import enum
 import attr
 
 from ..factory import target_factory
-from .common import Strategy, StrategyError
+from .common import Strategy, StrategyError, never_retry
 from ..driver.dockerdriver import DockerDriver
 from ..step import step
 
@@ -33,6 +33,7 @@ class DockerStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     @step(args=['status'])
     def transition(self, status):
         if not isinstance(status, Status):

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -4,7 +4,7 @@ import attr
 
 from ..factory import target_factory
 from ..step import step
-from .common import Strategy, StrategyError
+from .common import Strategy, StrategyError, never_retry
 
 
 class Status(enum.Enum):
@@ -28,6 +28,7 @@ class ShellStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     @step(args=['status'])
     def transition(self, status, *, step):  # pylint: disable=redefined-outer-name
         if not isinstance(status, Status):
@@ -53,6 +54,7 @@ class ShellStrategy(Strategy):
             )
         self.status = status
 
+    @never_retry
     @step(args=['status'])
     def force(self, status, *, step):  # pylint: disable=redefined-outer-name
         if not isinstance(status, Status):

--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -3,7 +3,7 @@ import enum
 import attr
 
 from ..factory import target_factory
-from .common import Strategy, StrategyError
+from .common import Strategy, StrategyError, never_retry
 
 
 class Status(enum.Enum):
@@ -29,6 +29,7 @@ class UBootStrategy(Strategy):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
+    @never_retry
     def transition(self, status):
         if not isinstance(status, Status):
             status = Status[status]
@@ -58,6 +59,7 @@ class UBootStrategy(Strategy):
             raise StrategyError(f"no transition found from {self.status} to {status}")
         self.status = status
 
+    @never_retry
     def force(self, status):
         if not isinstance(status, Status):
             status = Status[status]

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -308,9 +308,17 @@ def test_docker_without_daemon(docker_env, mocker):
     with pytest.raises(StrategyError):
         strategy.transition("unknown")
 
+    # test and reset broken state
+    assert isinstance(strategy.broken, StrategyError)
+    strategy.broken = None
+
     # Also bonus: How are invalid state names handled?
-    with pytest.raises(KeyError):
+    with pytest.raises(StrategyError):
         strategy.transition("this is not a valid state")
+
+    # test and reset broken state
+    assert isinstance(strategy.broken, KeyError)
+    strategy.broken = None
 
     # Return to "gone" state - to also use that part of the DockerDriver code.
     strategy.transition("gone")


### PR DESCRIPTION
**Description**
Introduce a decorator for the Strategy's `transition()` and `force()` methods. It stores the original exception in the Strategy's new `broken` attribute and raises a `StrategyError` from it. All subsequent calls to the decorated method will lead to the original exception.

Now that a Strategy can be marked broken easily, check for that in labgrid's pytest plugin before executing a test and its fixtures. If a broken Strategy is found in one of the targets, skip the test. It's not worth continuing with it. It only leads to cascading and confusing errors.

Having a strategy prepared with the new decorator, a strategy exception now leads to either a test error (when triggered in a fixture) or a test fail (when triggered in the test itself). All subsequent tests requesting the broken strategy (via the `strategy` fixture) will be skipped.

In order to get the word out about the `@raise_if_broken` decorator, decorate the Strategies in labgrid with it.

Previously this kind of workaround was often used:
```python
@pytest.fixture
def shell(strategy, target):
    try:
        strategy.transition("shell")
        return target.get_driver("ShellDriver")
    except Exception:
        pytest.exit("Strategy failed")
```
This is now obsolete.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature (covered in `tests/test_docker.py::test_docker_without_daemon`)
- [x] Add a section on how to use the feature to doc/usage.rst
- [x] Add a section on how to use the feature to doc/development.rst
- [x] PR has been tested

Related to #1123.