### PR TITLE
client: Clarify error message when unlock is required

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -481,10 +481,11 @@ class ClientSession:
     def get_idle_place(self, place=None):
         place = self.get_place(place)
         if place.acquired:
-            _, user = place.acquired.split("/")
-            raise UserError(
-                f"place {place.name} is not idle (acquired by {place.acquired}). To work simultaneously, {user} can execute labgrid-client -p {place.name} allow {self.gethostname()}/{self.getuser()}"
-            )
+            err = "This operation requires the place to be idle."
+            if place.acquired == self.gethostname() + "/" + self.getuser():
+                raise UserError(f"{err} Please release {place.name}.")
+            else:
+                raise UserError(f"{err} Place {place.name} is acquired by {place.acquired}.")
         return place
 
     def get_acquired_place(self, place=None):
@@ -681,7 +682,21 @@ class ClientSession:
 
     async def acquire(self):
         """Acquire a place, marking it unavailable for other clients"""
-        place = self.get_idle_place()
+        place = self.get_place()
+        if place.acquired:
+            host, user = place.acquired.split("/")
+            allowhelp = f"'labgrid-client -p {place.name} allow {self.gethostname()}/{self.getuser()}' on {host}."
+            if self.getuser() == user:
+                if self.gethostname() == host:
+                    raise UserError("You have already acquired this place.")
+                else:
+                    raise UserError(
+                        f"You have already acquired this place on {host}. To work simultaneously, execute {allowhelp}"
+                    )
+            else:
+                raise UserError(
+                    f"Place {place.name} is already acquired by {place.acquired}. To work simultaneously, {user} can execute {allowhelp}"
+                )
         if not self.args.allow_unmatched:
             self.check_matches(place)
 


### PR DESCRIPTION

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Adding/removing aliases and matches requires a place to be idle. The error when message when not minding this, is misleading in these cases where really the place needs to be unlocked before the specific operation.

Mention that the specific operation needs the place be idle. Instruct the user to unlock if it's acquired by them.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
