### PR TITLE
pyproject.toml: use non-deprecated license specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools>=47.2.0",
+    "setuptools>=77.0.0",
     "wheel",
     "setuptools_scm[toml]",
 ]
@@ -15,7 +15,8 @@ authors = [
 ]
 description = "embedded systems control library for development, testing and installation"
 readme = "README.rst"
-license = { file="LICENSE" }
+license = "LGPL-2.0-or-later"
+license-files = ["LICENSE"]
 requires-python = ">=3.9"
 classifiers = [
     "Intended Audience :: Developers",
@@ -29,7 +30,6 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
 ]
 dependencies = [
     "attrs>=21.4.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = [
-    "setuptools>=47.2.0",
+    "setuptools>=77.0.0",
     "wheel",
     "setuptools_scm[toml]",
 ]
@@ -15,7 +15,8 @@ authors = [
 ]
 description = "embedded systems control library for development, testing and installation"
 readme = "README.rst"
-license = { file="LICENSE" }
+license = "LGPL-2.1-or-later"
+license-files = ["LICENSE"]
 requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",
@@ -29,7 +30,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
 ]
 dependencies = [
     "attrs>=21.4.0",


### PR DESCRIPTION
**Description**
Fixes these deprecation warnings during `python -m build`:
```
env/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!
        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
!!
```
```
env/lib/python3.11/site-packages/setuptools/config/_apply_pyprojecttoml.py:61: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!
        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:
        License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
!!
```

**Checklist**
- [ ] PR has been tested

Closes #1956