### PR TITLE
tplink: add support for kasa smart plugs

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -146,7 +146,7 @@ The example describes port 0 on the remote power switch
 Arguments:
   - model (str): model of the power switch
   - host (str): hostname of the power switch
-  - index (int): number of the port to switch
+  - index (int, default=0): optional, number of the port to switch
 
 The ``model`` property selects one of several `backend implementations
 <https://github.com/labgrid-project/labgrid/tree/master/labgrid/driver/power>`_.
@@ -267,7 +267,7 @@ Currently available are:
   See the `documentation <https://docs.tinycontrol.pl/en/tcpdu/api/commands/>`__
 
 ``tplink``
-  Controls *TP-Link power strips* via `python-kasa
+  Controls *TP-Link smart plugs and power strips* via `python-kasa
   <https://github.com/python-kasa/python-kasa>`_.
 
 ``ubus``

--- a/labgrid/driver/power/tplink.py
+++ b/labgrid/driver/power/tplink.py
@@ -1,6 +1,7 @@
 """ Tested with TP Link KP303, and should be compatible with any strip supported by kasa """
 
 import asyncio
+from kasa import DeviceType, Discover
 from kasa.iot import IotStrip
 
 
@@ -8,27 +9,42 @@ async def _power_set(host, port, index, value):
     """We embed the coroutines in an `async` function to minimise calls to `asyncio.run`"""
     assert port is None
     index = int(index)
-    strip = IotStrip(host)
-    await strip.update()
-    assert (
-        len(strip.children) > index
-    ), "Trying to access non-existant plug socket on strip"
-    if value is True:
-        await strip.children[index].turn_on()
-    elif value is False:
-        await strip.children[index].turn_off()
+    dev = await Discover.discover_single(host)
+    if dev.device_type == DeviceType("strip"):
+        strip = IotStrip(host)
+        await strip.update()
+        assert (
+            len(strip.children) > index
+        ), "Trying to access non-existant plug socket on strip"
+        if value is True:
+            await strip.children[index].turn_on()
+        elif value is False:
+            await strip.children[index].turn_off()
+    elif dev.device_type == DeviceType("plug"):
+        await dev.update()
+        if value is True:
+            await dev.turn_on()
+        elif value is False:
+            await dev.turn_off()
 
 
 def power_set(host, port, index, value):
     asyncio.run(_power_set(host, port, index, value))
 
-
-def power_get(host, port, index):
+async def _power_get(host, port, index):
     assert port is None
     index = int(index)
-    strip = IotStrip(host)
-    asyncio.run(strip.update())
-    assert (
-        len(strip.children) > index
-    ), "Trying to access non-existant plug socket on strip"
-    return strip.children[index].is_on
+    dev = await Discover.discover_single(host)
+    if dev.device_type == DeviceType("strip"):
+        strip = IotStrip(host)
+        await strip.update()
+        assert (
+            len(strip.children) > index
+        ), "Trying to access non-existant plug socket on strip"
+        return strip.children[index].is_on
+    elif dev.device_type == DeviceType("plug"):
+        await dev.update()
+        return dev.is_on
+
+def power_get(host, port, index):
+    return asyncio.run(_power_get(host, port, index))

--- a/labgrid/resource/power.py
+++ b/labgrid/resource/power.py
@@ -12,11 +12,11 @@ class NetworkPowerPort(Resource):
     Args:
         model (str): model of the external power switch
         host (str): host to connect to
-        index (str): index of the power port on the external switch
+        index (str): optional, index of the power port on the external switch
     """
     model = attr.ib(validator=attr.validators.instance_of(str))
     host = attr.ib(validator=attr.validators.instance_of(str))
-    index = attr.ib(validator=attr.validators.instance_of(str),
+    index = attr.ib(default="0", validator=attr.validators.instance_of(str),
                     converter=lambda x: str(int(x)))
 
 

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -180,6 +180,12 @@ class TestNetworkPowerDriver:
         d = NetworkPowerDriver(target, 'power')
         assert isinstance(d, NetworkPowerDriver)
 
+    def test_default_index(self, target):
+        r = NetworkPowerPort(target, 'power', model='netio', host='dummy')
+        d = NetworkPowerDriver(target, 'power')
+        assert r.index == '0'
+        assert isinstance(d, NetworkPowerDriver)
+
     @pytest.mark.parametrize('backend', ('rest', 'simplerest'))
     @pytest.mark.parametrize(
         'host',


### PR DESCRIPTION
**Description**

- Extend the `tplink` resource definition to support smart plug devices like the [HS103](https://www.kasasmart.com/us/products/smart-plugs/kasa-smart-wifi-mini-plug-hs103), in addition to the existing IotStrip functionality.
- Since these only have one port, make the `index` argument for `NetworkPowerPort` optional and default to `0` if not provided.
- Also update the docs to indicate that `index` is now optional.

Tested locally using both a KP303 strip (already supported) and an HS103. Here's the latter's `kasa discover` data:

```
(labgrid-venv) tgamblin@ecogrid:~/labgrid$ kasa discover                                                                                                                                           
Discovering devices on 255.255.255.255 for 10 seconds                                            
== workspace - HS103 ==                         
Host: 192.168.40.218                            
Port: 9999                                      
Device state: True                                                                               
Time:         2025-07-11 13:26:06-05:00 (tz: EST)
Hardware:     5.0 (US)                
Firmware:     1.0.13 Build 240117 Rel.162355                                                     
MAC (rssi):   98:25:4A:08:63:35 (-60)           

== Primary features ==
State (state): True

== Information ==
On since (on_since): 2025-07-11 13:13:31-05:00
Cloud connection (cloud_connection): True

== Configuration ==
LED (led): True                                                                                                                                                                                    

== Debug ==
RSSI (rssi): -60 dBm
Reboot (reboot): <Action>
```

And here is the sample exporter config:

```
thinkcentre:                                                                                                                                                                                       
  location: ecogrid                                                                                                                                                                                
  thinkcentre-kasa-plug:                                                                                                                                                                           
    cls: 'NetworkPowerPort'                                                                                                                                                                        
    model: 'tplink'                                                                                                                                                                                
    host: '192.168.40.218'
```

**Checklist**
- [X] Documentation for the feature
- [X] Tests for the feature - I think the existing tests may be adequate, but review would be good.
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested
