### PR TITLE
WaveShare Modbus Fixes

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -436,7 +436,7 @@ A :any:`WaveshareModbusTCPCoil` describes a Waveshare branded coil accessible vi
    WaveshareModbusTCPCoil:
      host: '192.168.23.42'
      coil: 1
-     coil_count: 8 
+     coil_count: 8
 
 The example describes the coil ``1`` (zero indexed) of ``8`` on the Waveshare Modbus TCP relay
 module ``192.168.23.42``.
@@ -451,7 +451,6 @@ Arguments:
 
 Used by:
   - `WaveShareModbusCoilDriver`_
-
 
 DeditecRelais8
 ++++++++++++++

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -444,6 +444,7 @@ module ``192.168.23.42``.
 Arguments:
   - host (str): hostname of the Modbus TCP server e.g. ``192.168.23.42:502``
   - coil (int): index of the coil, e.g. ``3``
+  - coil_count (int, default=8): total number of coils on this module
   - invert (bool, default=False): whether the logic level is inverted
     (active-low)
   - write_multiple_coils (bool, default=False): whether to perform write

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -21,7 +21,7 @@ from .usbsdmuxdriver import USBSDMuxDriver
 from .usbsdwiredriver import USBSDWireDriver
 from .common import Driver
 from .qemudriver import QEMUDriver
-from .modbusdriver import ModbusCoilDriver
+from .modbusdriver import ModbusCoilDriver, WaveShareModbusCoilDriver
 from .modbusrtudriver import ModbusRTUDriver
 from .sigrokdriver import SigrokDriver, SigrokPowerDriver, SigrokDmmDriver
 from .usbstoragedriver import USBStorageDriver, NetworkUSBStorageDriver, Mode


### PR DESCRIPTION
**Description**
Document missing WaveshareModbusTCPCoil `coil_count` argument, add generic driver import.

Fixes #1575 (/cc @ep1cman)
