### PR TITLE
driver: remove deprecated NetworkUSBStorageDriver

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Breaking changes in 25.1
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - The deprecated pytest plugin option ``--env-config`` has been removed. Use
   ``--lg-env`` instead.
+- The deprecated ``NetworkUSBStorageDriver`` has been removed. Use the
+  `USBStorageDriver` instead.
 
 Release 25.0 (Released May 7, 2025)
 -----------------------------------
@@ -693,7 +695,7 @@ Breaking changes in 0.3.0
 - The ``HawkbitTestClient`` and ``USBStick`` classes have been removed
 - The original USBStorageDriver was removed, ``NetworkUSBStorageDriver`` was
   renamed to `USBStorageDriver`.
-  A deprecated `NetworkUSBStorageDriver` exists temporarily for compatibility
+  A deprecated ``NetworkUSBStorageDriver`` exists temporarily for compatibility
   reasons.
 
 Known issues in 0.3.0

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -24,7 +24,7 @@ from .qemudriver import QEMUDriver
 from .modbusdriver import ModbusCoilDriver
 from .modbusrtudriver import ModbusRTUDriver
 from .sigrokdriver import SigrokDriver, SigrokPowerDriver, SigrokDmmDriver
-from .usbstoragedriver import USBStorageDriver, NetworkUSBStorageDriver, Mode
+from .usbstoragedriver import USBStorageDriver, Mode
 from .resetdriver import DigitalOutputResetDriver
 from .gpiodriver import GpioDigitalOutputDriver
 from .filedigitaloutput import FileDigitalOutputDriver

--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -240,13 +240,3 @@ class USBStorageDriver(Driver):
         except ValueError:
             # when the medium gets ready the sysfs attribute is empty for a short time span
             return 0
-
-
-@target_factory.reg_driver
-@attr.s(eq=False)
-class NetworkUSBStorageDriver(USBStorageDriver):
-    def __attrs_post_init__(self):
-        import warnings
-        warnings.warn("NetworkUSBStorageDriver is deprecated, use USBStorageDriver instead",
-                      DeprecationWarning)
-        super().__attrs_post_init__()


### PR DESCRIPTION
**Description**
The NetworkUSBStorageDriver is deprecated since labgrid v0.3.0 (released in 2020). It's time to remove it.
