### PR TITLE
pytestplugin: remove deprecated --env-config option

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ New Features in 25.1
   CTRL+D specially to halt autoboot countdown without running interactive
   hooks like bringing up network interfaces automatically.
 
+Breaking changes in 25.1
+~~~~~~~~~~~~~~~~~~~~~~~~
+- The deprecated pytest plugin option ``--env-config`` has been removed. Use
+  ``--lg-env`` instead.
+
 Release 25.0 (Released May 7, 2025)
 -----------------------------------
 As announced `before

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -433,7 +433,7 @@ This allows debugging during the writing of tests and inspection during test run
 
 Other labgrid-related pytest plugin options are:
 
-``--lg-env=LG_ENV`` (was ``--env-config=ENV_CONFIG``)
+``--lg-env=LG_ENV``
   Specify a labgrid environment config file.
   This is equivalent to labgrid-client's ``-c``/``--config``.
 

--- a/labgrid/pytestplugin/fixtures.py
+++ b/labgrid/pytestplugin/fixtures.py
@@ -15,11 +15,6 @@ from .hooks import LABGRID_ENV_KEY
 def pytest_addoption(parser):
     group = parser.getgroup('labgrid')
     group.addoption(
-        '--env-config',
-        action='store',
-        dest='env_config',
-        help='labgrid environment config file (deprecated).')
-    group.addoption(
         '--lg-env',
         action='store',
         dest='lg_env',

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -1,5 +1,4 @@
 import os
-import warnings
 import logging
 import pytest
 
@@ -75,16 +74,8 @@ def pytest_configure(config):
     lg_log = config.option.lg_log
     if lg_log:
         ConsoleLoggingReporter(lg_log)
-    env_config = config.option.env_config
     lg_env = config.option.lg_env
     lg_coordinator = config.option.lg_coordinator
-
-    if lg_env is None:
-        if env_config is not None:
-            warnings.warn(pytest.PytestWarning(
-                "deprecated option --env-config (use --lg-env instead)",
-                __file__))
-            lg_env = env_config
 
     env = None
     if lg_env is None:

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -47,13 +47,6 @@ def test_env_fixture_no_logging(short_env, short_test):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before
 
-def test_env_old_fixture(short_env, short_test):
-    with pexpect.spawn(f'pytest --env-config {short_env} {short_test}') as spawn:
-        spawn.expect("deprecated option --env-config")
-        spawn.expect(pexpect.EOF)
-        spawn.close()
-        assert spawn.exitstatus == 0
-
 def test_env_env_fixture(short_env, short_test):
     env=os.environ.copy()
     env['LG_ENV'] = short_env


### PR DESCRIPTION
**Description**
The option is deprecated since labgrid v0.1.0 (released in 2017). It's time to remove it.