### PR TITLE
driver: Fix SmallUBootDriver for garbage

### DIFF
--- a/labgrid/driver/smallubootdriver.py
+++ b/labgrid/driver/smallubootdriver.py
@@ -96,7 +96,10 @@ class SmallUBootDriver(UBootDriver):
         cmp_command = f"echo{marker}; {cmd}; echo{marker}"
 
         self.console.sendline(cmp_command)
-        _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)
+        while True:
+            _, before, _, _ = self.console.expect(self.prompt, timeout=timeout)
+            if len(before) > 4:
+                break
 
         data = re_vt100.sub(
             '', before.decode('utf-8'), count=1000000


### PR DESCRIPTION


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

The SmallUBoot spits out random chars which confuse the expect function, likely breaking it. This commit ignore two short answers and thereby fixing the issue. There might be cleaner implementations but this does the trick reliably for multiple device I'm using for testing.

An error how this looks without the patch:

```shell
CONSOLE SerialLogger.ma:   SerialDriver(main) > tpl␤␍␤
INFO         StepLogger:   → SerialDriver.expect(pattern='ap135>')
CONSOLE SerialLogger.ma:    SerialDriver(main) < ap135> ␍␤
INFO         StepLogger:   ← SerialDriver.expect() result=(0, b'\r\n', <re.Match object; span=(2, 8), match=b'ap135>'>, b'ap135>') [0.002s]
CONSOLE SerialLogger.ma:   SerialDriver(main) > echoPBTAJJAOZT; setenv serverip 192.168.1.99; echoPBTAJJAOZT␤␍␤
INFO         StepLogger:   → SerialDriver.expect(pattern='ap135>')
CONSOLE SerialLogger.ma:    SerialDriver(main) < ␍␍␤
CONSOLE SerialLogger.ma:    SerialDriver(main) < ap135> echoPBTAJJAOZT; setenv serverip 192.168.1.99; echoPBTAJJAOZT␍␤
INFO         StepLogger:   ← SerialDriver.expect() result=(0, b' \r\r\n', <re.Match object; span=(4, 10), match=b'ap135>'>, b'ap135>') [0.002s]
INFO         StepLogger:  ⚠ SmallUBootDriver._await_prompt() [7.811s] exception="Unknown command 'echoPBTAJJAOZT' - try 'help'" is not in list
ERROR          conftest:  Failed to transition to state shell
Traceback (most recent call last):
  File "/Users/user/src/openwrt/tests/tests/conftest.py", line 93, in shell_command
    strategy.transition("shell")
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/user/src/openwrt/tests/targets/../strategies/tftpstrategy.py", line 75, in transition
    self.transition(Status.uboot)
    ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/Users/user/src/openwrt/tests/targets/../strategies/tftpstrategy.py", line 72, in transition
    self.target.activate(self.uboot)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/Users/user/src/labgrid/labgrid/labgrid/target.py", line 472, in activate
    client.on_activate()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/user/src/labgrid/labgrid/labgrid/driver/ubootdriver.py", line 61, in on_activate
    self._await_prompt()
    ~~~~~~~~~~~~~~~~~~^^
  File "/Users/user/src/labgrid/labgrid/labgrid/step.py", line 215, in wrapper
    _result = func(*_args, **_kwargs)
  File "/Users/user/src/labgrid/labgrid/labgrid/driver/smallubootdriver.py", line 73, in _await_prompt
    self._run(command)
    ~~~~~~~~~^^^^^^^^^
  File "/Users/user/src/labgrid/labgrid/labgrid/driver/smallubootdriver.py", line 105, in _run
    data = data[data.index(f"Unknown command 'echo{marker}' - try 'help'") +1 :]
                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: "Unknown command 'echoPBTAJJAOZT' - try 'help'" is not in list
```

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
