### PR TITLE
udev: Enable RKUSBLoader for rk3568 and rk3588

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -301,7 +301,10 @@ class RKUSBLoader(USBResource):
     def filter_match(self, device):
         match = (device.properties.get('ID_VENDOR_ID'), device.properties.get('ID_MODEL_ID'))
 
-        if match not in [("2207", "110a")]:
+        if match not in [("2207", "110a"),
+                         ("2207", "350a"),
+                         ("2207", "350b"),
+                         ]:
             return False
 
         return super().filter_match(device)


### PR DESCRIPTION
**Description**

Add the `VENDOR_ID` and `MODEL_ID` for the Maskrom mode of the Rockchip rk3568 and rk3588 to the possible matches for RKUSBLoader to allow using the RKUSBLoader with these SoCs.

With this change, `labgrid-suggest` recognizes Rockchip rk3568 and rk3588 SoCs if booted into Maskrom mode.

**Checklist**
- [x] PR has been tested:
