### PR TITLE
RKUSBDriver: allow to specify the offset at which the image should be flashed

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2616,6 +2616,7 @@ Implements:
          RKUSBDriver:
            image: 'mybootloaderkey'
            usb_loader: 'myloaderkey'
+           offset: 0x100
 
    images:
      mybootloaderkey: 'path/to/mybootloader.img'
@@ -2626,6 +2627,8 @@ Arguments:
     of an image to bootstrap onto the target
   - usb_loader (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
     of a first-stage bootloader image to write
+  - offset (int): optional, offset (in multiples of 512 bytes) at which the image passed as argument
+    should be written. If missing, 0x40 is assumed
 
 UUUDriver
 ~~~~~~~~~

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -94,6 +94,7 @@ class RKUSBDriver(Driver, BootstrapProtocol):
 
     image = attr.ib(default=None)
     usb_loader = attr.ib(default=None)
+    offset = attr.ib(default=0x40)
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -140,7 +141,7 @@ class RKUSBDriver(Driver, BootstrapProtocol):
             try:
                 processwrapper.check_output(
                     self.loader.command_prefix +
-                    [self.tool, 'wl', '0x40', mf.get_remote_path()],
+                    [self.tool, 'wl', hex(int(self.offset)), mf.get_remote_path()],
                     print_on_silent_log=True
                 )
                 break


### PR DESCRIPTION
**Description**

RKUSBDriver flashes an image onto a storage medium. Typically, on eMMC the starting offset is 0x40 (i.e. 64 blocks of 512KiB, iow 32KiB) to leave enough room for a partition table before but it doesn't *have to*. Barebox's update mechanism (bbu/CONFIG_BAREBOX_UPDATE) specifies multiple possible offsets for Rockchip: 0x40 to 0x44[1].

Additionally, it is possible (on RK3399 at the very least) to have the first stage bootloader at offset 0 on SPI-NOR flashes. This is currently the choice made for Theobroma Systems's Puma RK3399 SoM in U-Boot.

Let's give the user the ability to provide an offset from the configuration file.

[1] https://github.com/barebox/barebox/blob/master/arch/arm/mach-rockchip/bbu.c#L19-L24

**Checklist**
- [X] The arguments and description in doc/configuration.rst have been updated
- [X] PR has been tested