### PR TITLE
agents/sysfsgpio: fix misleading Python error when permission denied

### DIFF
--- a/labgrid/util/agents/sysfsgpio.py
+++ b/labgrid/util/agents/sysfsgpio.py
@@ -24,6 +24,7 @@ class GpioDigitalOutput:
             raise ValueError("Device not found")
 
     def __init__(self, index):
+        self.gpio_sysfs_value_fd = None
         self._logger = logging.getLogger("Device: ")
         GpioDigitalOutput._assert_gpio_line_is_exported(index)
         gpio_sysfs_path = os.path.join(GpioDigitalOutput._gpio_sysfs_path_prefix,
@@ -41,7 +42,8 @@ class GpioDigitalOutput:
         self.gpio_sysfs_value_fd = os.open(gpio_sysfs_value_path, flags=(os.O_RDWR | os.O_SYNC))
 
     def __del__(self):
-        os.close(self.gpio_sysfs_value_fd)
+        if self.gpio_sysfs_value_fd:
+            os.close(self.gpio_sysfs_value_fd)
         self.gpio_sysfs_value_fd = None
 
     def get(self):


### PR DESCRIPTION
**Description**

If the executor doesn't have the proper permissions to control the GPIO or export it, a Permission Denied will be raised. However, __del__ is called regardless and gpio_sysfs_value_fd attribute isn't present if the __init__ doesn't finish.

Thus, Python prints the following:
"""
Exception ignored in: <function GpioDigitalOutput.__del__ at 0x7f5b017f80e0>
Traceback (most recent call last):
  File "<loaded sysfsgpio>", line 44, in __del__
AttributeError: 'GpioDigitalOutput' object has no attribute 'gpio_sysfs_value_fd'
""" before the raised Exception, possibly misleading the user on their debugging quest.

Therefore, let's make sure the attribute exists before anything can throw an Exception in __init__.

os.close() can only be called on a valid file descriptor, which None isn't, therefore only call os.close() if self.gpio_sysfs_value_fd is not None.

This has been tested by running labgrid with a non-root user with the GPIO not exported and the non-root user not having permission to write to `/sys/class/gpio/export`.

**Checklist**
- [X] PR has been tested