### PR TITLE
doc/configuration: add more info on TFTP server requirements

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    =
+SPHINXOPTS    = -j auto
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = labgrid
 SOURCEDIR     = .

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1366,6 +1366,17 @@ see below.
 For now, the TFTP/NFS/HTTP server needs to be configured before using it from
 labgrid.
 
+Because labgrid uses absolute paths as targets for symlinks for exposing files
+on the TFTP server and because the target of those symlinks is in
+``/var/cache/labgrid/``, the TFTP server needs to follow symlinks whose target
+path is both absolute and in ``/var/cache/labgrid``. Note that depending on the
+configuration of the TFTP server, ``/var/cache/labgrid`` may not be the root
+directory of your TFTP server.
+
+`atftpd <https://sourceforge.net/projects/atftp/>`_ is known to work whereas
+`tftpd-hpa <https://git.kernel.org/pub/scm/network/tftp/tftp-hpa.git/>`_ doesn't
+seem to be working well with such symlinks.
+
 TFTPProvider
 ++++++++++++
 A :any:`TFTPProvider` resource describes a TFTP server.


### PR DESCRIPTION
**Description**

While trying to make TFTPProviderDriver work with tftpd-hpa on Debian Bookworm, I hit various different issues and ultimately couldn't really make things work properly. The closest I got was by removing --secure from the server's option but I would then need U-Boot to provide the full path to the files and not relative to the TFTP server's root directory, which makes things not go nicely in general and especially not with labgrid (it uses external property as prefix for the path, and not internal).

I installed atftpd instead and things worked out nicely out-of-the-box on Debian Bookworm, so let's mention that in the docs along with the requirements for the labgrid setup to work with the TFTPProvider.

A small unrelated commit crept in to make building the docs faster  by using as many processes as CPU threads (nproc).

PR tested by building the documentation locally.

**Checklist**
- [X] PR has been tested