### PR TITLE
Generate labgrid-client subcommand and option documentation from argparse

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -40,8 +40,11 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.napoleon',
               'sphinx.ext.coverage',
               'sphinx.ext.viewcode',
+              'sphinxarg.ext', # sphinx-argparse
               'sphinx.ext.autosectionlabel',
               'sphinx_rtd_theme']
+
+suppress_warnings = ['autosectionlabel.*']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['.templates']
@@ -156,6 +159,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     (master_doc, 'labgrid', 'labgrid Documentation',
+     [author], 1),
+    ('man/client', 'labgrid-client', 'labgrid\'s client interface to control boards',
      [author], 1)
 ]
 
@@ -181,7 +186,14 @@ autodoc_default_options = {
 autodoc_mock_imports = ['onewire',
                         'gi',
                         'gi.repository',
-                        'vxi11']
+                        'vxi11',
+                        'pysnmp',
+                        'kasa',
+                        'labgrid.driver.power.eaton',
+                        'labgrid.driver.power.poe_mib',
+                        'labgrid.driver.power.raritan',
+                        'labgrid.driver.power.tplink',
+                        ]
 
 # -- Options for autosection ----------------------------------------------
 autosectionlabel_prefix_document = True

--- a/doc/man/client.rst
+++ b/doc/man/client.rst
@@ -3,19 +3,30 @@
 labgrid-client
 ==============
 
+Description
+-----------
+
 Labgrid is a scalable infrastructure and test architecture for embedded (linux) systems.
 
 This is the client to control a boards status and interface with it on remote machines.
+
+Synopsis
+--------
+
+Options
+=======
+
+.. currentmodule:: labgrid.remote.client
+
 
 .. argparse::
    :module: labgrid.remote.client
    :func: get_parser
    :prog: labgrid-client
-   :noepilog:
-   :nodescription:
 
-   help : @skip
-        skip help
+   available subcommands : @skip
+        skip list of commands
+
 
 Configuration File
 ------------------

--- a/doc/man/client.rst
+++ b/doc/man/client.rst
@@ -1,2 +1,138 @@
 .. _labgrid-client:
-.. include:: ../../man/labgrid-client.rst
+
+labgrid-client
+==============
+
+Labgrid is a scalable infrastructure and test architecture for embedded (linux) systems.
+
+This is the client to control a boards status and interface with it on remote machines.
+
+.. argparse::
+   :module: labgrid.remote.client
+   :func: get_parser
+   :prog: labgrid-client
+   :noepilog:
+   :nodescription:
+
+   help : @skip
+        skip help
+
+Configuration File
+------------------
+The configuration file follows the description in ``labgrid-device-config``\(5).
+
+Environment Variables
+---------------------
+Various labgrid-client commands use the following environment variable:
+
+LG_PLACE
+~~~~~~~~
+This variable can be used to specify a place without using the ``-p`` option, the ``-p`` option overrides it.
+
+LG_TOKEN
+~~~~~~~~
+This variable can be used to specify a reservation for the ``wait`` command and
+for the ``+`` place expansion.
+
+LG_STATE
+~~~~~~~~
+This variable can be used to specify a state which the device transitions into
+before executing a command. Requires a configuration file and a Strategy
+specified for the device.
+
+LG_INITIAL_STATE
+~~~~~~~~~~~~~~~~
+This variable can be used to specify an initial state the device is known to
+be in.
+This is useful during development. The Strategy used must implement the
+``force()`` method.
+A desired state must be set using ``LG_STATE`` or ``-s``/``--state``.
+
+LG_ENV
+~~~~~~
+This variable can be used to specify the configuration file to use without
+using the ``--config`` option, the ``--config`` option overrides it.
+
+LG_COORDINATOR
+~~~~~~~~~~~~~~
+This variable can be used to set the default coordinator in the format
+``HOST[:PORT]`` (instead of using the ``-x`` option).
+
+LG_PROXY
+~~~~~~~~
+This variable can be used to specify a SSH proxy hostname which should be used
+to connect to the coordinator and any resources which are normally accessed
+directly.
+
+LG_HOSTNAME
+~~~~~~~~~~~
+Override the hostname used when accessing a resource. Typically only useful for
+CI pipelines where the hostname may not be consistent between pipeline stages.
+
+LG_USERNAME
+~~~~~~~~~~~
+Override the username used when accessing a resource. Typically only useful for
+CI pipelines where the username may not be consistent between pipeline stages.
+
+LG_SSH_CONNECT_TIMEOUT
+~~~~~~~~~~~~~~~~~~~~~~
+Set the connection timeout when using SSH (The ``ConnectTimeout`` option). If
+unspecified, defaults to 30 seconds.
+
+LG_AGENT_PREFIX
+~~~~~~~~~~~~~~~~~~~~~~
+Add a prefix to ``.labgrid_agent_{agent_hash}.py`` allowing specification for
+where on the exporter it should be uploaded to. 
+
+Matches
+-------
+Match patterns are used to assign a resource to a specific place. The format is:
+exporter/group/cls/name, exporter is the name of the exporting machine, group is
+a name defined within the exporter, cls is the class of the exported resource
+and name is its name. Wild cards in match patterns are explicitly allowed, *
+matches anything.
+
+Adding Named Resources
+----------------------
+If a target contains multiple Resources of the same type, named matches need to
+be used to address the individual resources. In addition to the `match` taken by
+`add-match`, `add-named-match` also takes a name for the resource. The other
+client commands support the name as an optional parameter and will inform the
+user that a name is required if multiple resources are found, but no name is
+given.
+
+If one of the resources should be used by default when no resource name is
+explicitly specified, it can be named ``default``.
+
+Examples
+--------
+
+To retrieve a list of places run:
+
+.. code-block:: bash
+
+   $ labgrid-client places
+
+To access a place, it needs to be acquired first, this can be done by running
+the ``acquire command`` and passing the placename as a -p parameter:
+
+.. code-block:: bash
+
+   $ labgrid-client -p <placename> acquire
+
+Open a console to the acquired place:
+
+.. code-block:: bash
+
+   $ labgrid-client -p <placename> console
+
+Add all resources with the group "example-group" to the place example-place:
+
+.. code-block:: bash
+
+   $ labgrid-client -p example-place add-match */example-group/*/*
+
+See Also
+--------
+
+``labgrid-exporter``\(1)

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1704,7 +1704,8 @@ class ExportFormat(enum.Enum):
     def __str__(self):
         return self.value
 
-def get_parser() -> argparse.ArgumentParser:
+
+def get_parser(include_undocumented=False) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-x",
@@ -1743,11 +1744,12 @@ def get_parser() -> argparse.ArgumentParser:
         metavar="COMMAND",
     )
 
-    subparser = subparsers.add_parser("help")
+    if include_undocumented:
+        subparser = subparsers.add_parser("help")
 
-    subparser = subparsers.add_parser("complete")
-    subparser.add_argument("type", choices=["resources", "places", "matches", "match-names"])
-    subparser.set_defaults(func=ClientSession.complete)
+        subparser = subparsers.add_parser("complete")
+        subparser.add_argument("type", choices=["resources", "places", "matches", "match-names"])
+        subparser.set_defaults(func=ClientSession.complete)
 
     subparser = subparsers.add_parser("monitor", help="monitor events from the coordinator")
     subparser.set_defaults(func=ClientSession.do_monitor)
@@ -1996,7 +1998,7 @@ def get_parser() -> argparse.ArgumentParser:
         "-p",
         "--partition",
         type=int,
-        choices=range(0, 256),
+        choices=(range(0, 256) if include_undocumented else None),
         metavar="0-255",
         default=1,
         help="partition number to mount or 0 to mount whole disk (default: %(default)s)",
@@ -2090,7 +2092,7 @@ def main():
     initial_state = os.environ.get("LG_INITIAL_STATE", None)
     token = os.environ.get("LG_TOKEN", None)
 
-    parser = get_parser()
+    parser = get_parser(include_undocumented=True)
 
     # make any leftover arguments available for some commands
     args, leftover = parser.parse_known_args()

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1704,24 +1704,7 @@ class ExportFormat(enum.Enum):
     def __str__(self):
         return self.value
 
-
-def main():
-    basicConfig(
-        level=logging.WARNING,
-        stream=sys.stderr,
-    )
-
-    StepLogger.start()
-    processwrapper.enable_logging()
-
-    # Support both legacy variables and properly namespaced ones
-    place = os.environ.get("PLACE", None)
-    place = os.environ.get("LG_PLACE", place)
-    state = os.environ.get("STATE", None)
-    state = os.environ.get("LG_STATE", state)
-    initial_state = os.environ.get("LG_INITIAL_STATE", None)
-    token = os.environ.get("LG_TOKEN", None)
-
+def get_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "-x",
@@ -1734,24 +1717,19 @@ def main():
         "-c",
         "--config",
         type=str,
-        default=os.environ.get("LG_ENV"),
         help="env config file (default: value from env variable LG_ENV)",
     )
-    parser.add_argument(
-        "-p", "--place", type=str, default=place, help="place name/alias (default: value from env variable LG_PLACE)"
-    )
+    parser.add_argument("-p", "--place", type=str, help="place name/alias (default: value from env variable LG_PLACE)")
     parser.add_argument(
         "-s",
         "--state",
         type=str,
-        default=state,
         help="strategy state to switch into before command (default: value from env varibale LG_STATE)",
     )
     parser.add_argument(
         "-i",
         "--initial-state",
         type=str,
-        default=initial_state,
         help="strategy state to force into before switching to desired state",
     )
     parser.add_argument(
@@ -2065,11 +2043,11 @@ def main():
     subparser.set_defaults(func=ClientSession.create_reservation)
 
     subparser = subparsers.add_parser("cancel-reservation", help="cancel a reservation")
-    subparser.add_argument("token", type=str, default=token, nargs="?" if token else None)
+    subparser.add_argument("token", type=str, nargs="?")
     subparser.set_defaults(func=ClientSession.cancel_reservation)
 
     subparser = subparsers.add_parser("wait", help="wait for a reservation to be allocated")
-    subparser.add_argument("token", type=str, default=token, nargs="?" if token else None)
+    subparser.add_argument("token", type=str, nargs="?")
     subparser.set_defaults(func=ClientSession.wait_reservation)
 
     subparser = subparsers.add_parser("reservations", help="list current reservations")
@@ -2092,12 +2070,54 @@ def main():
     subparser = subparsers.add_parser("version", help="show version")
     subparser.set_defaults(func=ClientSession.print_version)
 
+    return parser
+
+
+def main():
+    basicConfig(
+        level=logging.WARNING,
+        stream=sys.stderr,
+    )
+
+    StepLogger.start()
+    processwrapper.enable_logging()
+
+    # Support both legacy variables and properly namespaced ones
+    place = os.environ.get("PLACE", None)
+    place = os.environ.get("LG_PLACE", place)
+    state = os.environ.get("STATE", None)
+    state = os.environ.get("LG_STATE", state)
+    initial_state = os.environ.get("LG_INITIAL_STATE", None)
+    token = os.environ.get("LG_TOKEN", None)
+
+    parser = get_parser()
+
     # make any leftover arguments available for some commands
     args, leftover = parser.parse_known_args()
     if args.command not in ["ssh", "rsync", "forward"]:
         args = parser.parse_args()
     else:
         args.leftover = leftover
+
+    # handle dynamic defaults
+    if args.config is None:
+        args.config = os.environ.get("LG_ENV")
+
+    if args.place is None:
+        args.place = place
+
+    if args.state is None:
+        args.state = state
+
+    if args.initial_state is None:
+        args.initial_state = initial_state
+
+    if args.command in ["cancel-reservation", "wait"] and args.token is None:
+        if token:
+            args.token = token
+        else:
+            print("Please provide a token", file=sys.stderr)
+            exit(1)
 
     if args.verbose:
         logging.getLogger().setLevel(logging.INFO)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dynamic = ["version"]  # via setuptools_scm
 doc = [
     "sphinx_rtd_theme>=1.0.0",
     "Sphinx>=2.0.0",
+    "sphinx-argparse",
 ]
 docker = ["docker>=5.0.2"]
 graph = ["graphviz>=0.17.0"]


### PR DESCRIPTION
Manage the documentation with sphinx and auto-document labgrid-client arguments and subcommands from source using sphinx-argparse.

Sections from the original man/labgrid-client.rst which are not obsoleted by the autogenerated reference are migrated into sphinx. Sphinx generates both the manpages as well as their html documentation counterpart.

I believe the result of this is much more useful than the current manpages we have that just don't sufficiently document usage of the subcommands.

See the readthedocs builds for results.