### PR TITLE
shelldriver: Disable kernel messages after console_ready

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -169,6 +169,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                 # lets start over again and see if login or prompt will appear
                 # now.
                 self.console.sendline("")
+                did_login = True
 
             last_before = before
 


### PR DESCRIPTION
**Description**

With this change the ShellDriver treats console activation like a new login and thus disabling kernel messages on that shell.

Until now the ShellDriver would _not_ silence the kernel messages on a console, if it was only activated but no login was needed.

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [x] PR has been tested
