### PR TITLE
driver: add support for Guermok HDMI to USB 3.0 capture dongle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ New Features in 25.1
   CTRL+D specially to halt autoboot countdown without running interactive
   hooks like bringing up network interfaces automatically.
 
+- Guermok HDMI to USB 3.0 capture dongle supported
+
 Breaking changes in 25.1
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - The deprecated pytest plugin option ``--env-config`` has been removed. Use

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -75,8 +75,14 @@ class USBVideoDriver(Driver, VideoProtocol):
                 ("mid", "image/jpeg,width=864,height=480,pixel-aspect-ratio=1/1,framerate=30/1"),
                 ("high", "image/jpeg,width=1280,height=1024,pixel-aspect-ratio=1/1,framerate=30/1"),
                 ])
+        elif match == (0x345f, 0x2130):  # UltraSemi USB3 Video
+            return ("mid", [
+                ("low", "image/jpeg,width=1024,height=768,pixel-aspect-ratio=1/1,framerate=30/1"),
+                ("mid", "image/jpeg,width=1920,height=1080,pixel-aspect-ratio=1/1,framerate=30/1"),
+                ("high", "image/jpeg,width=3840,height=2160,pixel-aspect-ratio=1/1,framerate=18/1"),
+                ])
         self.logger.warning(
-            "Unkown USB video device {:04x}:{:04x}, using fallback pipeline."
+            "Unknown USB video device {:04x}:{:04x}, using fallback pipeline."
             .format(*match))
         return ("mid", [
             ("low", "image/jpeg,width=640,height=480,framerate=30/1"),


### PR DESCRIPTION
**Description**

This low-cost[1] capture dongle supports MJPEG (and YUYV) and supports
up to 3840x2160@18 on USB 3.0 speeds.
When connected over USB 2.0, the highest supported mode is 1920x1080@50
as reported by v4l2-ctl[2].

Choose MJPEG to conserve USB bandwidth and add 1920x1080 as default
mode.

[1]: https://www.amazon.de/dp/B08Z3XDYQ7
[2]: https://gist.github.com/a3f/70b1156464caa670a469c86912e4ba9c

- what do you use the feature for?

See HDMI output of DUT

- how does labgrid benefit as a testing library from the feature?

We already support a number of Webcams. Low cost HDMI grabbers and pixel perfect capture could allow better automated testing

- how did you verify the feature works?

Installed manually and tested it out both over USB 3.0 and USB 2.0

- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

https://www.amazon.de/dp/B08Z3XDYQ7

**Checklist**
- [x] PR has been tested