### PR TITLE
driver: usbvideodriver: add support for overlaying FPS

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ New Features in 25.1
 
 - The `USBVideoDriver`'s ``stream`` method can now be called with ``fps=True``
   to embed an overlay with FPS statistics into the video stream.
+  This is exposed in ``labgrid-client video`` via the new ``--fps`` option.
 
 Breaking changes in 25.1
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,9 @@ New Features in 25.1
 
 - Guermok HDMI to USB 3.0 capture dongle supported
 
+- The `USBVideoDriver`'s ``stream`` method can now be called with ``fps=True``
+  to embed an overlay with FPS statistics into the video stream.
+
 Breaking changes in 25.1
 ~~~~~~~~~~~~~~~~~~~~~~~~
 - The deprecated pytest plugin option ``--env-config`` has been removed. Use

--- a/contrib/completion/labgrid-client.bash
+++ b/contrib/completion/labgrid-client.bash
@@ -661,7 +661,7 @@ _labgrid_client_video()
 
     case "$cur" in
     -*)
-        COMPREPLY=( $(compgen -W "--quality --controls --name $_labgrid_shared_options" -- "$cur") )
+        COMPREPLY=( $(compgen -W "--quality --controls --fps --name $_labgrid_shared_options" -- "$cur") )
         ;;
     esac
 }

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -139,13 +139,15 @@ class USBVideoDriver(Driver, VideoProtocol):
         return pipeline
 
     @Driver.check_active
-    def stream(self, caps_hint=None, controls=None):
+    def stream(self, caps_hint=None, controls=None, fps=False):
         caps = self.select_caps(caps_hint)
         pipeline = self.get_pipeline(self.video.path, caps, controls)
 
         tx_cmd = self.video.command_prefix + ["gst-launch-1.0", "-q"]
         tx_cmd += pipeline.split()
         rx_cmd = ["gst-launch-1.0", "playbin3", "buffer-duration=0", "uri=fd://0"]
+        if fps:
+            rx_cmd += ["video-sink=fpsdisplaysink"]
 
         tx = subprocess.Popen(
             tx_cmd,

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1313,6 +1313,7 @@ class ClientSession:
     def video(self):
         place = self.get_acquired_place()
         quality = self.args.quality
+        fps = self.args.fps
         controls = self.args.controls
         target = self._get_target(place)
         name = self.args.name
@@ -1342,7 +1343,7 @@ class ClientSession:
                 mark = "*" if default == name else " "
                 print(f"{mark} {name:<10s} {caps:s}")
         else:
-            res = drv.stream(quality, controls=controls)
+            res = drv.stream(quality, controls=controls, fps=fps)
             if res:
                 exc = InteractiveCommandError("gst-launch-1.0 error")
                 exc.exitcode = res
@@ -1972,6 +1973,7 @@ def main():
 
     subparser = subparsers.add_parser("video", help="start a video stream")
     subparser.add_argument("-q", "--quality", type=str, help="select a video quality (use 'list' to show options)")
+    subparser.add_argument("-f", "--fps", action="store_true", help="Overlay FPS statistics")
     subparser.add_argument(
         "-c", "--controls", type=str, help="configure v4l controls (such as 'focus_auto=0,focus_absolute=40')"
     )


### PR DESCRIPTION
**Description**

We encourage addition of multiple quality settings for USB Video
devices, but there is no easy way to get feedback how many frames per
second are actually processed on the receiver side, which could
influence which quality settings would be chosen for Labgrid, especially as connection over USB 2.0/USB 3.0 can impact what frame rates we can achieve.

To allow for an easy evaluation of video devices and how they're
connected, expose the newly added fps feature in USBVideoDriver as
--fps command line option.

- what do you use the feature for?

Check that I indeed am able to get the framerate configured in the quality

- how does labgrid benefit as a testing library from the feature?

Makes it easier to evaluate cameras/HDMI grabbers

- how did you verify the feature works?

I ran the command with and without --fps and with the different quality settings

- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?

I tested against the Guermok HDMI grabber added in https://github.com/labgrid-project/labgrid/pull/1709

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst

The existing arguments aren't documented/test either. The `--fps`` is documented in the help text.