### PR TITLE
usbstoragedriver: Allow to define a different waiting medium timeout

### DIFF
--- a/labgrid/driver/usbstoragedriver.py
+++ b/labgrid/driver/usbstoragedriver.py
@@ -39,15 +39,22 @@ class USBStorageDriver(Driver):
             "NetworkUSBSDWireDevice",
         },
     }
+
     image = attr.ib(
         default=None,
         validator=attr.validators.optional(attr.validators.instance_of(str))
     )
-    WAIT_FOR_MEDIUM_TIMEOUT = 10.0 # s
+    timeout = attr.ib(
+        default=10.0,
+        validator=attr.validators.instance_of(float)
+    )
+
     WAIT_FOR_MEDIUM_SLEEP = 0.5 # s
     MOUNT_RETRIES = 5
 
     def __attrs_post_init__(self):
+        if self.timeout < 0.0:
+            raise ValueError("timeout must be positive")
         super().__attrs_post_init__()
         self.wrapper = None
         self.proxy = None
@@ -208,7 +215,7 @@ class USBStorageDriver(Driver):
 
     @Driver.check_active
     def _wait_for_medium(self, partition):
-        timeout = Timeout(self.WAIT_FOR_MEDIUM_TIMEOUT)
+        timeout = Timeout(self.timeout)
         while not timeout.expired:
             if self.get_size(partition) > 0:
                 break


### PR DESCRIPTION
Nice to have a way to define a timeout for usb storage driver if it used after a usb switch. This will make this code more simpler

mux_driver = target.get_driver('LXAUSBMuxDriver')
mux_driver.set_links(['host-device'])
time.sleep(3) <-- avoid to use a new sleep here

usb = target.get_driver('USBStorageDriver')
assert usb.get_size() > 0

Let's consider this as first interaction with the project. Could be that somenthing is missing here and there. It's more an RFC patch