### PR TITLE
ConsoleProtocol: Update Signatures to match ConsoleExpectMixin

### DIFF
--- a/labgrid/protocol/consoleprotocol.py
+++ b/labgrid/protocol/consoleprotocol.py
@@ -1,11 +1,13 @@
 import abc
+from typing import Optional, Union
+from pexpect import EOF, TIMEOUT
 
 
 class ConsoleProtocol(abc.ABC):
     """Abstract class for the ConsoleProtocol"""
 
     @abc.abstractmethod
-    def read(self):
+    def read(self, size: int = 1, timeout: float = 0.0, max_size: Optional[int] = None):
         """
         Read data from underlying port
         """
@@ -24,7 +26,11 @@ class ConsoleProtocol(abc.ABC):
     def sendcontrol(self, char: str):
         raise NotImplementedError
 
-    def expect(self, pattern: str):
+    def expect(
+        self,
+        pattern: Union[str, bytes, type[EOF], type[TIMEOUT], list[Union[str, bytes, type[EOF], type[TIMEOUT]]]],
+        timeout: float = -1,
+    ):
         raise NotImplementedError
 
     class Client(abc.ABC):


### PR DESCRIPTION
**Description**

The ConsoleExpectMixin has learned some new tricks over time. But the ConsoleProtocol was not updated accordingly.

Every class implementing the ConsoleProtocol also uses the ConsoleExpectMixin - so it's safe to update the signatures according to the ConsoleExpectMixin.

For ConsoleProtocol.expect() I've used the type definition of the underlying pexpect library.

I have not updated the return types, since it's not clear to me what the ConsoleExpectMixin should return.

This helps users with IDEs to get better type hinting when using the ConsoleProtocol.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 

<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
