### PR TITLE
IMXUSBDriver: conditionally check image

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2551,6 +2551,9 @@ An :any:`IMXUSBDriver` is used to upload an image into a device in the *i.MX
 USB loader state*.
 This is useful to bootstrap a bootloader onto a device.
 This driver uses the ``imx-usb-loader`` tool from barebox.
+If your device has the ``SDP_READ_DISABLE`` fuse burnt, then reading back data
+over USB is not possible anymore, which means, that the verification of the
+image is not possible anymore. Set ``verify`` to False in this case.
 
 Binds to:
   loader:
@@ -2569,6 +2572,7 @@ Implements:
        drivers:
          IMXUSBDriver:
            image: 'mybootloaderkey'
+           verify: True
 
    images:
      mybootloaderkey: 'path/to/mybootloader.img'
@@ -2576,6 +2580,7 @@ Implements:
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
     of an image to bootstrap onto the target
+  - verify (bool, default=True): optional, wether to verify the written image or not
 
 BDIMXUSBDriver
 ~~~~~~~~~~~~~~

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -55,6 +55,7 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
     }
 
     image = attr.ib(default=None)
+    verify = attr.ib(default=True, validator=attr.validators.instance_of(bool))
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -78,9 +79,13 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
         mf = ManagedFile(filename, self.loader)
         mf.sync_to_resource()
 
+        command = [self.tool, "-p", str(self.loader.path)]
+        if self.verify:
+            command.append("-c")
+        command.append(mf.get_remote_path())
+
         processwrapper.check_output(
-            self.loader.command_prefix +
-            [self.tool, "-p", str(self.loader.path), "-c", mf.get_remote_path()],
+            self.loader.command_prefix + command,
             print_on_silent_log=True
         )
 


### PR DESCRIPTION
**Description**

Some devices do not allow USB Serial Download read commands, which will result in a failure, when trying to verify the correctness of the image. Make the verify step optional but on by default.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] ~~Tests for the feature~~
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] ~~Add a section on how to use the feature to doc/usage.rst~~
<!---
A library feature which other developers can use:
--->
- [ ] ~~Add a section on how to use the feature to doc/development.rst~~
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] ~~Man pages have been regenerated~~

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->

Test has been done by creating a minimal place and setting verify to True, False and leaving it empty.

```
targets:
  main:
    resources:
    - RemotePlace:
        name: "myboard"
    drivers:
    - IMXUSBDriver:
        verify: False
```