### PR TITLE
strategy: add arguments wait_for_systemd and systemd_timeout

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3458,6 +3458,11 @@ the "shell" state:
 This command would transition from the bootloader into a Linux shell and
 activate the `ShellDriver`_.
 
+Arguments:
+  - wait_for_systemd (bool, default=True): If True, wait for all systemd services
+    to be up and running when transitioning to the "shell" state
+  - systemd_timeout (int, default=30): Timeout to wait for systemd services in seconds
+
 ShellStrategy
 ~~~~~~~~~~~~~
 A :any:`ShellStrategy` has three states:
@@ -3503,6 +3508,11 @@ the "shell" state:
 
 This command would transition directly into a Linux shell and
 activate the `ShellDriver`_.
+
+Arguments:
+  - wait_for_systemd (bool, default=True): If True, wait for all systemd services
+    to be up and running when transitioning to the "shell" state
+  - systemd_timeout (int, default=30): Timeout to wait for systemd services in seconds
 
 UBootStrategy
 ~~~~~~~~~~~~~
@@ -3552,6 +3562,11 @@ the "shell" state:
 
 This command would transition from the bootloader into a Linux shell and
 activate the `ShellDriver`_.
+
+Arguments:
+  - wait_for_systemd (bool, default=True): If True, wait for all systemd services
+    to be up and running when transitioning to the "shell" state
+  - systemd_timeout (int, default=30): Timeout to wait for systemd services in seconds
 
 DockerStrategy
 ~~~~~~~~~~~~~~

--- a/labgrid/strategy/shellstrategy.py
+++ b/labgrid/strategy/shellstrategy.py
@@ -24,6 +24,14 @@ class ShellStrategy(Strategy):
     }
 
     status = attr.ib(default=Status.unknown)
+    wait_for_systemd = attr.ib(
+        default=True,
+        validator=attr.validators.optional(attr.validators.instance_of(bool))
+    )
+    systemd_timeout = attr.ib(
+        default=30,
+        validator=attr.validators.optional(attr.validators.instance_of(int))
+    )
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -47,7 +55,8 @@ class ShellStrategy(Strategy):
             self.target.activate(self.console)
             self.power.cycle()
             self.target.activate(self.shell)
-            self.shell.run("systemctl is-system-running --wait")
+            if self.wait_for_systemd:
+                self.shell.run("systemctl is-system-running --wait", timeout=self.systemd_timeout)
         else:
             raise StrategyError(
                 f"no transition found from {self.status} to {status}"

--- a/labgrid/strategy/ubootstrategy.py
+++ b/labgrid/strategy/ubootstrategy.py
@@ -25,6 +25,14 @@ class UBootStrategy(Strategy):
     }
 
     status = attr.ib(default=Status.unknown)
+    wait_for_systemd = attr.ib(
+        default=True,
+        validator=attr.validators.optional(attr.validators.instance_of(bool))
+    )
+    systemd_timeout = attr.ib(
+        default=30,
+        validator=attr.validators.optional(attr.validators.instance_of(int))
+    )
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
@@ -54,7 +62,8 @@ class UBootStrategy(Strategy):
             self.uboot.boot("")
             self.uboot.await_boot()
             self.target.activate(self.shell)
-            self.shell.run("systemctl is-system-running --wait")
+            if self.wait_for_systemd:
+                self.shell.run("systemctl is-system-running --wait", timeout=self.systemd_timeout)
         else:
             raise StrategyError(f"no transition found from {self.status} to {status}")
         self.status = status


### PR DESCRIPTION
**Description**

```
Add the following arguments to the strategies BareboxStrategy, ShellStrategy and UBootStrategy:

- wait_for_systemd: If True, wait for all systemd services to be up and running when transitioning to the "shell" state default: True
- systemd_timeout: Timeout to wait for systemd services in seconds default: 30
```

Before the change, the `systemctl is-system-running --wait` command was called unconditionally with default timeout (30 seconds).

This does not cover the following scenarios:
1. Maybe the user does not want to execute the check at all (maybe systemd is not even used on the device)?
    - this is what the `wait_for_systemd` attribute is for
2. Or maybe the user wants to have a higher timeout because a certain service takes very long to start?
    - this is what the `systemd_timeout` attribute is for

**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages they have to be regenerated by calling make in the man subdirectory of the project
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
