### PR TITLE
doc: clarify udev string matching rules

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1571,6 +1571,10 @@ Finally ``sys_name`` allows matching against the name of the directory in
 sysfs.
 All match entries must succeed for the device to be accepted.
 
+Note that all udev property values are strings and are therefore case sensitive.
+Hex values such as ``ID_MODEL_ID`` must match the exact case reported by udev
+(e.g., ``"04d8"`` will not match ``"04D8"``).
+
 labgrid provides a small utility called ``labgrid-suggest`` which will
 output the proper YAML formatted snippets for you.
 These snippets can be added under the resource key in an environment


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
This adds documentation to clarify the fact that udev rules are treated as strings and must match the case that udev is expecting.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [X] Documentation for the feature
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [X] PR has been tested
<!---

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
Fixes #1733