### PR TITLE
driver/shelldriver: dereference symlinks when copying .ssh

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -277,7 +277,7 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
         self.logger.debug("Key not on target and not writeable, using bind mount...")
         self._run_check('mkdir -p -m 700 /tmp/labgrid-ssh/')
-        self._run("cp -a ~/.ssh/* /tmp/labgrid-ssh/")
+        self._run("cp -aL ~/.ssh/* /tmp/labgrid-ssh/")
         self._write_key(keyline, "/tmp/labgrid-ssh/authorized_keys")
         self._run_check('chmod 600 /tmp/labgrid-ssh/authorized_keys')
         out, err, exitcode = self._run('mount --bind /tmp/labgrid-ssh/ ~/.ssh/')


### PR DESCRIPTION
**Description**

cp -a implicitly preserves symlinks during copying. If the authorized_keys file is a symlink, the /tmp/labgrid-ssh/authorized_keys will still point to the read-only target of the symlink and adding the key will fail.

Add -L to cp to dereference the symlinks.