### PR TITLE
remote/common: allow ordering of ResourceMatches with/without name

### DIFF
--- a/labgrid/remote/common.py
+++ b/labgrid/remote/common.py
@@ -155,7 +155,7 @@ class ResourceMatch:
     exporter = attr.ib()
     group = attr.ib()
     cls = attr.ib()
-    name = attr.ib(default=None)
+    name = attr.ib(default=None, order=False)
     # rename is just metadata, so don't use it for comparing matches
     rename = attr.ib(default=None, eq=False)
 


### PR DESCRIPTION
**Description**
It is possible to create matches as:

```shell
$ export LG_PLACE=myplace
$ labgrid-client create
$ labgrid-client add-match myexporter/mygroup/mycls
$ labgrid-client add-named-match myexporter/mygroup/mycls/myname myrename
```

In this scenario, `labgrid-client show` throws an exception:

```python
$ labgrid-client show
Place 'myplace':
  matches:
Traceback (most recent call last):
  File "/usr/ptx-venvs/labgrid/lib/python3.13/site-packages/labgrid/remote/client.py", line 2171, in main
    session.loop.run_until_complete(coro)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/usr/ptx-venvs/labgrid/lib/python3.13/site-packages/labgrid/remote/client.py", line 500, in print_place
    place.show(level=1)
    ~~~~~~~~~~^^^^^^^^^
  File "/usr/ptx-venvs/labgrid/lib/python3.13/site-packages/labgrid/remote/common.py", line 280, in show
    for match in sorted(self.matches):
                 ~~~~~~^^^^^^^^^^^^^^
  File "/usr/ptx-venvs/labgrid/lib/python3.13/site-packages/attr/_make.py", line 1713, in __lt__
    return attrs_to_tuple(self) < attrs_to_tuple(other)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '<' not supported between instances of 'str' and 'NoneType'
```

The problem arises due to `ResourceMatch` objects being turned into tuples by attrs for ordering, such as:

```python
("myexporter", "mygroup", "mycls", None)
("myexporter", "mygroup", "mycls", "myname")
```

First, all elements with index 0 are compared, if these elements are equal, elements with index 1 are compared and so forth until an order can be determined. Normally, the comparison does not reach the "name" element of the match.

In the example above, the first three elements are equal, so `None` and `"myname"` are compared, which is unsupported and results in the `TypeError`.

Fix that by removing the `ResourceMatch`'s optional "name" attribute from ordering operations.

**Checklist**
- [x] PR has been tested

Fixes #1736
