### PR TITLE
exporter: limit ser2net port range

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -235,7 +235,7 @@ class SerialPortExport(ResourceExport):
         assert self.local.avail
         assert self.child is None
         assert start_params["path"].startswith("/dev/")
-        self.port = get_free_port()
+        self.port = get_free_port(os.environ.get("LG_PREFERRED_NETWORKSERIAL_PORT", None))
 
         # Ser2net has switched to using YAML format at version 4.0.0.
         result = subprocess.run([self.ser2net_bin, "-v"], capture_output=True, text=True)

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -15,10 +15,23 @@ from ..step import step
 
 re_vt100 = re.compile(r"(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]")
 
-def get_free_port():
+def get_free_port(prefered_port=None):
     """Helper function to always return an unused port."""
     with closing(socket(AF_INET, SOCK_STREAM)) as s:
-        s.bind(('', 0))
+        if prefered_port is not None:
+            port_range = [int(i) for i in prefered_port.split(':')]
+            port = port_range[0]
+            max_range = port_range[1] if len(port_range) > 1 else 10
+            max_no_of_ports = port + max_range
+            while port <= max_no_of_ports:
+                try:
+                    s.bind(('', port))
+                except:
+                    port += 1
+                else:
+                    break
+        else:
+            s.bind(('', 0))
         return s.getsockname()[1]
 
 

--- a/man/labgrid-exporter.1
+++ b/man/labgrid-exporter.1
@@ -104,6 +104,10 @@ The following environment variable can be used to configure labgrid\-exporter.
 .sp
 This variable can be used to set the default coordinator in the format
 \fBHOST[:PORT]\fP (instead of using the \fB\-x\fP option).
+.SS LG_PREFERRED_NETWORKSERIAL_PORT
+.sp
+Set a preferred port to be used with NetworkSerialPort resources.
+Specify a port and a optional range counting up using the format \fBPORT[:RANGE]\fP
 .SH EXAMPLES
 .sp
 Start the exporter with the configuration file \fImy\-config.yaml\fP:

--- a/man/labgrid-exporter.rst
+++ b/man/labgrid-exporter.rst
@@ -96,6 +96,13 @@ LG_COORDINATOR
 This variable can be used to set the default coordinator in the format
 ``HOST[:PORT]`` (instead of using the ``-x`` option).
 
+LG_PREFERRED_NETWORKSERIAL_PORT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Set a preferred port to be used with NetworkSerialPort resources.
+Specify a port and a optional range counting up using the format ``PORT[:RANGE]``
+
+
+
 EXAMPLES
 --------
 


### PR DESCRIPTION
This allows for specifying a start port and a range up from that to be used when looking for a free port to use with ser2net when creating a networkserialport resource. This can be helpful on networks where access to ports on the network is limited.

Currently this feature is planed for use in a labgrid setup where the exporter and duts are placed on a network separate from the main network the developers are on and there are restrictions on the tcp ports. Being able to specify what port(s) labgrid can use makes it easier to manage and keep track of what ports are open between the two networks.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
- [ ] PR has been tested
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
