### PR TITLE
driver/rawnetworkinterfacedriver: fix AttributeError in on_activate() due to typo

### DIFF
--- a/labgrid/driver/rawnetworkinterfacedriver.py
+++ b/labgrid/driver/rawnetworkinterfacedriver.py
@@ -37,7 +37,7 @@ class RawNetworkInterfaceDriver(Driver):
         self._replay_handle = None
 
     def on_activate(self):
-        if self.manage_inteface:
+        if self.manage_interface:
             self._set_interface("up")
             self._wait_state("up")
 


### PR DESCRIPTION
**Description**
Fixes a critical typo.

- [x] PR has been tested

Fixes #1737

/cc @JoshuaWatt 