### PR TITLE
driver/fastbootdriver: decode output to str before split

### DIFF
--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -59,7 +59,7 @@ class AndroidFastbootDriver(Driver):
         Splits output by '\n' and returns only elements starting with prefix. The prefix is
         removed.
         """
-        return [line[len(prefix):] for line in output.split('\n') if line.startswith(prefix)]
+        return [line[len(prefix):] for line in output.decode().split('\n') if line.startswith(prefix)]
 
     def on_activate(self):
         pass


### PR DESCRIPTION
processwrapper.check_output returns a byte-like object, which is not compatible with split() with an str. Decode the output to a str to fix this.

This fixes direct calls of the getvar function from a test suite. Calling `fastboot getvar` from the command line doesn't use the filtering mechanism and is successful without this fix.

The alternatives would have been to change the callers of _filter_fastboot_output to convert the byte-like object to a string, or to change '\n' to a byte-like object. The latter would also need a change of the startswith call.