### PR TITLE
qemudriver: Allow machine-specific options and pre-start QMP commands

### DIFF
--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
-        sudo apt-get install -yq libow-dev openssh-server openssh-client graphviz openocd
+        sudo apt-get install -yq libow-dev openssh-server openssh-client graphviz openocd qemu-system-arm
         sudo mkdir -p /var/cache/labgrid/runner && sudo chown runner /var/cache/labgrid/runner
     - name: Prepare local SSH
       run: |

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -33,7 +33,7 @@ jobs:
           ${{ runner.os }}-pip-
     - name: Install system dependencies
       run: |
-        sudo apt-get install -yq libow-dev openssh-server openssh-client graphviz openocd qemu-system-arm
+        sudo apt-get install -yq libow-dev openssh-server openssh-client graphviz openocd
         sudo mkdir -p /var/cache/labgrid/runner && sudo chown runner /var/cache/labgrid/runner
     - name: Prepare local SSH
       run: |

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2867,6 +2867,10 @@ The QEMUDriver also requires the specification of:
   specify the build device tree
 - a path key, this is the path to the rootfs
 
+To allow interactions with a prepared, not yet started QEMU instance, the ``prepare()`` method
+can be explicitly called, after which ``monitor_command(...)`` can be run before eventually
+releasing the CPU(s) via ``on()``.
+
 SigrokDriver
 ~~~~~~~~~~~~
 The :any:`SigrokDriver` uses a `SigrokDevice`_ resource to record samples and provides

--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -22,7 +22,7 @@ Example showing how to build labgrid-client image:
 
 .. code-block:: bash
 
-   $ docker build --target labgrid-client -t docker.io/labgrid/client -f dockerfiles/Dockerfile .
+   $ docker build --build-arg VERSION="$(python -m setuptools_scm)" --target labgrid-client -t docker.io/labgrid/client -f dockerfiles/Dockerfile .
 
 Using `BuildKit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_
 is recommended to reduce build times.

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -156,19 +156,20 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             disk_opts = ""
             if self.disk_opts:
                 disk_opts = f",{self.disk_opts}"
-            if self.machine == "vexpress-a9":
+            machine_base = self.machine.split(',')[0]
+            if machine_base == "vexpress-a9":
                 cmd.append("-drive")
                 cmd.append(
                     f"if=sd,format={disk_format},file={disk_path},id=mmc0{disk_opts}")
                 boot_args.append("root=/dev/mmcblk0p1 rootfstype=ext4 rootwait")
-            elif self.machine in ["pc", "q35", "virt"]:
+            elif machine_base in ["pc", "q35", "virt"]:
                 cmd.append("-drive")
                 cmd.append(
                     f"if=virtio,format={disk_format},file={disk_path}{disk_opts}")
                 boot_args.append("root=/dev/vda rootwait")
             else:
                 raise NotImplementedError(
-                    f"QEMU disk image support not implemented for machine '{self.machine}'"
+                    f"QEMU disk image support not implemented for machine '{machine_base}'"
                 )
         if self.rootfs is not None:
             cmd.append("-fsdev")

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -259,9 +259,9 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         shutil.rmtree(self._tempdir)
 
     @step()
-    def on(self):
-        """Start the QEMU subprocess, accept the unix socket connection and
-        afterwards start the emulator using a QMP Command"""
+    def prepare(self):
+        """Start the QEMU subprocess and accept the unix socket connection
+        if not already prepared."""
         if self.status:
             return
         self.logger.debug("Starting with: %s", self._cmd)
@@ -287,7 +287,14 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
 
         # Restore port forwards
         for v in self._forwarded_ports.values():
-            self._add_port_forward(*v)
+            self._add_port_forward(*v) 
+
+    @step()
+    def on(self):
+        """Prepare the instance (only if not done already) and start the emulator
+        using a QMP Command"""
+        if not self._child:
+            self.prepare()
 
         self.monitor_command("cont")
 

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -77,7 +77,7 @@ def qemu_version_mock(mocker):
 def test_qemu_instance(qemu_target, qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
 
-def test_qemu_get_qemu_base_args_disk(qemu_target, qemu_driver):
+def test_qemu_get_qemu_base_args_disk(qemu_target, qemu_driver, qemu_version_mock):
     qemu_driver.disk = 'disk'
     supported_machines = ['vexpress-a9', 'pc', 'q35', 'virt']
     for machine in supported_machines:

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -13,7 +13,8 @@ def qemu_env(tmpdir):
             role: foo
         images:
           kernel: "test.zImage"
-          dtb: test.dtb"
+          disk: "test.qcow2"
+          dtb: "test.dtb"
         tools:
           qemu: "qemu-system-arm"
         paths:
@@ -68,6 +69,15 @@ def qemu_version_mock(mocker):
 
 def test_qemu_instance(qemu_target, qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
+
+def test_qemu_get_qemu_base_args_disk(qemu_target, qemu_driver):
+    qemu_driver.disk = 'disk'
+    supported_machines = ['vexpress-a9', 'pc', 'q35', 'virt']
+    for machine in supported_machines:
+        qemu_driver.machine = machine
+        qemu_driver.get_qemu_base_args()
+        qemu_driver.machine = machine + ',option=value'
+        qemu_driver.get_qemu_base_args()
 
 def test_qemu_activate_deactivate(qemu_target, qemu_driver, qemu_version_mock):
     qemu_target.activate(qemu_driver)


### PR DESCRIPTION
**Description**

Two minor features are added to the `QemuDriver`:

_Support machine-specific options_ (e.g. `-machine virt,secure=on`)

> While raising an exception for unsupported machines/boards is reasonable, adding machine-specific options shall not break the parsing. Therefore, the check is adjusted to only account for the leading board name.

_Support interactions with the QEMU instance via QMP before releasing CPU(s)_

> Especially for bad case testing, it can be useful to be able to interact with the prepared but not yet spun off instance - e.g. to corrupt the boot medium without the need to build a corrupted image only for that purpose.

For both features, straight forward unit tests are provided.
Lastly, the changeset includes minor documentation updates and the introduction of type hints for the `qemudriver.py` file.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested