### PR TITLE
resource/udev: fix intermittent AttributeError in USBSDWireDevice

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -483,16 +483,13 @@ class USBSDWireDevice(USBResource):
     it is identified via USB using udev
     """
 
-    control_path = attr.ib(
-        default=None,
-        validator=attr.validators.optional(str)
-    )
     disk_path = attr.ib(
         default=None,
         validator=attr.validators.optional(str)
     )
 
     def __attrs_post_init__(self):
+        self.control_serial = None
         self.match['ID_VENDOR_ID'] = '04e8'
         self.match['ID_MODEL_ID'] = '6001'
         self.match['@ID_VENDOR_ID'] = '0424'
@@ -510,7 +507,7 @@ class USBSDWireDevice(USBResource):
         pass
 
     # Overwrite the poll function. Only mark the SDWire as available if both
-    # paths are available.
+    # control_serial and disk_path are available.
     def poll(self):
         super().poll()
         if self.device is not None and not self.avail:


### PR DESCRIPTION
The control_serial attribute is conditionally declared by assignment which causes a race where it may not be declared before being accessed in USBSDWireExport _get_params(). This causes an AttributeError when starting the exporter.

Remove the unused control_path attribute and explicitly declare control_serial to fix it.

Failure log:
```
Oct 08 12:25:14 sage labgrid-exporter[2757866]: add resource rpi3/USBSDWireDevice: USBSDWireDevice/OrderedDict([('match', OrderedDict([('@ID_SERIAL_SHORT', '202110140001')]))])
Oct 08 12:25:14 sage labgrid-exporter[2757866]: Traceback (most recent call last):
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/bin/labgrid-exporter", line 7, in <module>
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     sys.exit(main())
Oct 08 12:25:14 sage labgrid-exporter[2757866]:              ^^^^^^
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/lib/python3.11/site-packages/labgrid/remote/exporter.py", line 1109, in main
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     asyncio.run(amain(config), debug=bool(args.debug))
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     return runner.run(main)
Oct 08 12:25:14 sage labgrid-exporter[2757866]:            ^^^^^^^^^^^^^^^^
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     return self._loop.run_until_complete(task)
Oct 08 12:25:14 sage labgrid-exporter[2757866]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     return future.result()
Oct 08 12:25:14 sage labgrid-exporter[2757866]:            ^^^^^^^^^^^^^^^
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/lib/python3.11/site-packages/labgrid/remote/exporter.py", line 1032, in amain
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     await exporter.run()
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/lib/python3.11/site-packages/labgrid/remote/exporter.py", line 844, in run
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     await self.add_resource(group_name, resource_name, cls, params)
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/lib/python3.11/site-packages/labgrid/remote/exporter.py", line 1006, in add_resource
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     res.poll()
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/lib/python3.11/site-packages/labgrid/remote/exporter.py", line 161, in poll
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     params = self._get_params()
Oct 08 12:25:14 sage labgrid-exporter[2757866]:              ^^^^^^^^^^^^^^^^^^
Oct 08 12:25:14 sage labgrid-exporter[2757866]:   File "/opt/labgrid-venv/lib/python3.11/site-packages/labgrid/remote/exporter.py", line 424, in _get_params
Oct 08 12:25:14 sage labgrid-exporter[2757866]:     "control_serial": self.local.control_serial,
Oct 08 12:25:14 sage labgrid-exporter[2757866]:                       ^^^^^^^^^^^^^^^^^^^^^^^^^
Oct 08 12:25:14 sage labgrid-exporter[2757866]: AttributeError: 'USBSDWireDevice' object has no attribute 'control_serial'
```