### PR TITLE
github/workflows/scheduled-unit-tests: allow running via workflow_dispatch

### DIFF
--- a/.github/workflows/scheduled-unit-tests.yml
+++ b/.github/workflows/scheduled-unit-tests.yml
@@ -3,6 +3,7 @@ name: scheduled unit tests
 on:
   schedule:
     - cron: '10 8 * * *'
+  workflow_dispatch:
 
 jobs:
   scheduled-unit-tests:


### PR DESCRIPTION
This allows us to manually trigger the workflow via the web interface, the API or the GitHub cli tool:

    $ gh workflow run build --ref master

This does not benefit us too much right now, but it will once this change makes it into stable branches. Then we can trigger runs for these stable branches from a job on the master branch using e.g.:

    $ gh workflow run build --ref stable-25.0

This is required because scheduled runs are only executed for the main branch of a repository.

This is how we run scheduled tests for the different yocto version branches in [meta-labgrid](https://github.com/labgrid-project/meta-labgrid/).