### PR TITLE
remote/client: turn wrong match ValueError into UserError

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -302,7 +302,10 @@ class ClientSession:
 
     async def print_resources(self):
         """Print out the resources"""
-        match = ResourceMatch.fromstr(self.args.match) if self.args.match else None
+        try:
+            match = ResourceMatch.fromstr(self.args.match) if self.args.match else None
+        except ValueError as e:
+            raise UserError(str(e)) from e
 
         # filter self.resources according to the arguments
         nested = lambda: defaultdict(nested)


### PR DESCRIPTION
**Description**
When providing a wrong match pattern, a ValueError is raised, resulting in exception and traceback being printed.

To improve the user experience, turn it into a UserError. UserErrors are displayed more end-user friendly, but still allow traceback printing when called via `labgrid-client -d`.

**Checklist**
- [x] PR has been tested