### PR TITLE
Fix _check_prompt with interjected logs

### DIFF
--- a/labgrid/driver/shelldriver.py
+++ b/labgrid/driver/shelldriver.py
@@ -197,8 +197,12 @@ class ShellDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
         self.console.sendline(f"echo '{marker[:4]}''{marker[4:]}'")
         try:
             self.console.expect(
-                rf"{marker}\s+{self.prompt}",
+                rf"{marker}\s+",
                 timeout=30
+            )
+            self.console.expect(
+                rf"{self.prompt}",
+                timeout=1
             )
             self._status = 1
         except TIMEOUT:


### PR DESCRIPTION
**Description**
ShellDriver._check_prompt uses regexp that expects you get marker immediately followed by prompt, only separated by whitespace.
But sometimes, you can get some unrelated message on the shell console in between the marker and prompt, something like this:
```
root@user:~# echo 'SVVZ''SYBQPQ'
SVVZSYBQPQ
[   37.369462] systemd-journald[159]: Time jumped backwards, rotating.
root@user:~#

```
This is enough to break _check_prompt, it will timeout as the regexp never maches. This fixes the issue by waiting separately for the marker and prompt.
