### PR TITLE
Fix Shelly Gen 2 power_get()

### DIFF
--- a/labgrid/driver/power/shelly_gen2.py
+++ b/labgrid/driver/power/shelly_gen2.py
@@ -27,4 +27,4 @@ def power_get(host: str, port: int, index: int = 0):
     payload = {"id": 1, "method": "Switch.GetStatus", "params": {"id": index}}
     r = requests.post(f"{host}/rpc", json=payload)
     r.raise_for_status()
-    return r.json()["output"]
+    return r.json()["result"]["output"]


### PR DESCRIPTION
**Description**
Fix KeyError in shelly_gen2 power_get() function due to incorrect JSON response parsing.  The current implementation attempts to access `response["output"]` directly, but the Shelly Gen 2 RPC API returns the output field nested inside a `result` object.

API Response Structure:

```json
{
  "id": 1,
  "result": {
    "output": true,
    "apower": 0.0,
    "voltage": 245.3
  }
}
```

Fix:
Change r.json()["output"] to r.json()["result"]["output"] in line 30.

Testing:
* Verified with Shelly Plus Plug UK device
* All power operations (get/set/cycle) now work correctly
* Compatible with existing NetworkPowerPort configurations

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested