### PR TITLE
util/agents/usb_hid_relay: return value from get_output()

### DIFF
--- a/labgrid/util/agents/usb_hid_relay.py
+++ b/labgrid/util/agents/usb_hid_relay.py
@@ -100,7 +100,7 @@ class USBHIDRelay:
 
     def get_output(self, number):
         with self._claimed():
-            self._get_output(number)
+            return self._get_output(number)
 
 
 _relays = {}


### PR DESCRIPTION
Add missing return in get_output() to propagate value returned by a device specific function.

Fixes: 7ab62401 ("util/agents/usb_hid_relay: fix concurrent access")