### PR TITLE
Feature: client: Add scp multifile support

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1306,7 +1306,7 @@ class ClientSession:
     def scp(self):
         drv = self._get_ssh()
 
-        res = drv.scp(src=self.args.src, dst=self.args.dst)
+        res = drv.scp(src=self.args.src, dst=self.args.dst, recursive=self.args.recursive)
         if res:
             raise InteractiveCommandError("scp error", res)
 
@@ -2009,8 +2009,9 @@ def get_parser(auto_doc_mode=False) -> "argparse.ArgumentParser | AutoProgramArg
 
     subparser = subparsers.add_parser("scp", help="transfer file via scp")
     subparser.add_argument("--name", "-n", help="optional resource name")
-    subparser.add_argument("src", help="source path (use :dir/file for remote side)")
+    subparser.add_argument("src", nargs="+", help="source path (use :dir/file for remote side)")
     subparser.add_argument("dst", help="destination path (use :dir/file for remote side)")
+    subparser.add_argument("--recursive", "-r", action="store_true", help="copy recursive")
     subparser.set_defaults(func=ClientSession.scp)
 
     subparser = subparsers.add_parser(

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -678,7 +678,7 @@ transfer file via scp
 .INDENT 3.5
 .sp
 .EX
-usage: labgrid\-client scp [\-\-name NAME] src dst
+usage: labgrid\-client scp [\-\-name NAME] [\-\-recursive] src [src ...] dst
 .EE
 .UNINDENT
 .UNINDENT
@@ -696,6 +696,11 @@ destination path (use :dir/file for remote side)
 .TP
 .B \-\-name <name>, \-n <name>
 optional resource name
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-recursive, \-r
+copy recursive
 .UNINDENT
 .SS labgrid\-client sd\-mux
 .sp


### PR DESCRIPTION
**Description**

Implement `-r` and `[SOURCES...] [DESTINATION]` for `scp`
Collegues requested this feature since it matches the expectation on how to use the widely known `scp` command.

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested

### to Target
```
labgrid@phoebe:~/client$ lgc scp dummy/bar dummy/foo :/tmp
bar                                                                                                                                                                                100%    3     1.2KB/s 00:00
foo                                                                                                                                                                                100%    5     3.3KB/s   00:00
labgrid@phoebe:~/client$ lgc scp -r dummy :/tmp
foo                                                                                                                                                                                100%    5     2.6KB/s   00:00
bar                                                                                                                                                                                100%    3     1.7KB/s   00:00
labgrid@phoebe:~/client$ lgc ssh


BusyBox v1.34.1 () built-in shell (ash)

# cd /tmp
# ls
WebKitCache          bar                  env.yml              foo                  mesa_shader_cache    weston
avahi-daemon.socket  dummy                fontconfig           hsts-storage.sqlite  update-tool.lock
# cd dummy/
# ls
bar  foo
```
### from Target

```
labgrid@phoebe:~/client$ mkdir rev
labgrid@phoebe:~/client$ lgc scp :/tmp/dummy/foo :/tmp/dummy/bar rev/
foo                                                                                                                                                                                100%    5     1.0KB/s   00:00
bar                                                                                                                                                                                100%    3     0.8KB/s   00:00
labgrid@phoebe:~/client$ lgc scp -r :/tmp/dummy rev
bar                                                                                                                                                                                100%    3     0.4KB/s   00:00
foo    
labgrid@phoebe:~/client$ find rev
rev
rev/dummy
rev/dummy/foo
rev/dummy/bar
rev/foo
rev/bar
```

- [x] Man pages have been regenerated
