### PR TITLE
labgrid/qemudriver: tie QEMU and QMP monitor start/stop to on_activate()/on_deactivate()

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -225,19 +225,19 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         self._socket.bind(sockpath)
         self._socket.listen(0)
 
-        self._cmd = self.get_qemu_base_args()
+        qemu_cmd = self.get_qemu_base_args()
 
-        self._cmd.append("-S")
-        self._cmd.append("-qmp")
-        self._cmd.append("stdio")
+        qemu_cmd.append("-S")
+        qemu_cmd.append("-qmp")
+        qemu_cmd.append("stdio")
 
-        self._cmd.append("-chardev")
-        self._cmd.append(f"socket,id=serialsocket,path={sockpath}")
-        self._cmd.append("-serial")
-        self._cmd.append("chardev:serialsocket")
+        qemu_cmd.append("-chardev")
+        qemu_cmd.append(f"socket,id=serialsocket,path={sockpath}")
+        qemu_cmd.append("-serial")
+        qemu_cmd.append("chardev:serialsocket")
 
-        self.logger.debug("Starting with: %s", self._cmd)
-        self._child = subprocess.Popen(self._cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        self.logger.debug("Starting with: %s", qemu_cmd)
+        self._child = subprocess.Popen(qemu_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
         # prepare for timeout handing
         self._clientsocket, address = self._socket.accept()

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -237,7 +237,17 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         qemu_cmd.append("chardev:serialsocket")
 
         self.logger.debug("Starting with: %s", qemu_cmd)
-        self._child = subprocess.Popen(qemu_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        self._child = subprocess.Popen(qemu_cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+        try:
+            self._child.wait(timeout=0.5)
+            _, err = self._child.communicate()
+            raise IOError(
+                f"QEMU exited immediately: {err.decode().strip()} (exitcode={self._child.returncode})"
+            )
+        except subprocess.TimeoutExpired:
+            # good, QEMU did not exit immediately
+            pass
 
         # prepare for timeout handing
         self._clientsocket, address = self._socket.accept()

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -1,5 +1,4 @@
 """The QEMUDriver implements a driver to use a QEMU target"""
-import atexit
 import select
 import shlex
 import shutil
@@ -105,17 +104,6 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         self._socket = None
         self._clientsocket = None
         self._forwarded_ports = {}
-        atexit.register(self._atexit)
-
-    def _atexit(self):
-        if not self._child:
-            return
-        self._child.terminate()
-        try:
-            self._child.communicate(timeout=1)
-        except subprocess.TimeoutExpired:
-            self._child.kill()
-            self._child.communicate(timeout=1)
 
     def get_qemu_version(self, qemu_bin):
         p = subprocess.run([qemu_bin, "-version"], stdout=subprocess.PIPE, encoding="utf-8")
@@ -248,25 +236,8 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         self._cmd.append("-serial")
         self._cmd.append("chardev:serialsocket")
 
-    def on_deactivate(self):
-        if self.status:
-            self.off()
-        if self._clientsocket:
-            self._clientsocket.close()
-            self._clientsocket = None
-        self._socket.close()
-        self._socket = None
-        shutil.rmtree(self._tempdir)
-
-    @step()
-    def on(self):
-        """Start the QEMU subprocess, accept the unix socket connection and
-        afterwards start the emulator using a QMP Command"""
-        if self.status:
-            return
         self.logger.debug("Starting with: %s", self._cmd)
-        self._child = subprocess.Popen(
-            self._cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+        self._child = subprocess.Popen(self._cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 
         # prepare for timeout handing
         self._clientsocket, address = self._socket.accept()
@@ -283,37 +254,64 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
                 ) from exc
             raise
 
-        self.status = 1
+    def on_deactivate(self):
+        if self._child and self._child.poll() is None:
+            self.monitor_command("quit")
+            try:
+                self._child.communicate(timeout=1)
+            except subprocess.TimeoutExpired:
+                self._child.kill()
+                self._child.communicate(timeout=1)
+
+            self._child = None
+            self.qmp = None
+
+        if self._clientsocket:
+            self._clientsocket.close()
+            self._clientsocket = None
+
+        if self._socket:
+            self._socket.close()
+            self._socket = None
+        if self._tempdir:
+            shutil.rmtree(self._tempdir)
+            self._tempdir = None
+
+    @Driver.check_active
+    @step()
+    def on(self):
+        """Starts the emulation using a QMP command"""
+        if self.status:
+            return
 
         # Restore port forwards
         for v in self._forwarded_ports.values():
             self._add_port_forward(*v)
 
         self.monitor_command("cont")
+        self.status = 1
 
+    @Driver.check_active
     @step()
     def off(self):
-        """Stop the emulator using a monitor command and await the exitcode"""
+        """Stops and resets the emulation using monitor commands"""
         if not self.status:
             return
-        self.monitor_command('quit')
-        if self._child.wait() != 0:
-            self._child.communicate()
-            raise IOError
-        self._child = None
+        self.monitor_command('stop')
+        self.monitor_command('system_reset')
         self.status = 0
 
+    @Driver.check_active
+    @step()
     def cycle(self):
         """Cycle the emulator by restarting it"""
         self.off()
         self.on()
 
+    @Driver.check_active
     @step(result=True, args=['command', 'arguments'])
     def monitor_command(self, command, arguments={}):
         """Execute a monitor_command via the QMP"""
-        if not self.status:
-            raise ExecutionError(
-                "Can't use monitor command on non-running target")
         return self.qmp.execute(command, arguments)
 
     def _add_port_forward(self, proto, local_address, local_port, remote_address, remote_port, netdev):
@@ -324,10 +322,12 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             {"command-line": " ".join(command)},
         )
 
+    @Driver.check_active
     def add_port_forward(self, proto, local_address, local_port, remote_address, remote_port, netdev=""):
         self._add_port_forward(proto, local_address, local_port, remote_address, remote_port, netdev)
         self._forwarded_ports[(proto, local_address, local_port, netdev)] = (proto, local_address, local_port, remote_address, remote_port, netdev)
 
+    @Driver.check_active
     def remove_port_forward(self, proto, local_address, local_port, netdev=""):
         del self._forwarded_ports[(proto, local_address, local_port, netdev)]
         command = ("hostfwd_remove", netdev, f"{proto}:{local_address}:{local_port}")

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -64,11 +64,22 @@ def qemu_mock(mocker):
     version_mock.return_value.returncode = 0
     version_mock.return_value.stdout = "QEMU emulator version 4.2.1"
 
+@pytest.fixture
+def qemu_qmp_mock(mocker):
+    monitor_mock = mocker.patch('labgrid.driver.qemudriver.QMPMonitor')
+    monitor_mock.return_value.execute.return_value = {'return': {}}
+    return monitor_mock
+
 def test_qemu_instance(qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
 
-def test_qemu_activate_deactivate(qemu_target, qemu_driver):
+def test_qemu_activate_deactivate(qemu_target, qemu_driver, qemu_qmp_mock):
     qemu_target.activate(qemu_driver)
+
+    qemu_driver.monitor_command("info")
+    qemu_qmp_mock.assert_called_once()
+    qemu_qmp_mock.return_value.execute.assert_called_with("info", {})
+
     qemu_target.deactivate(qemu_driver)
 
 def test_qemu_on_off(qemu_target, qemu_driver):

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -1,3 +1,5 @@
+import subprocess
+
 import pytest
 
 from labgrid.driver import QEMUDriver
@@ -44,8 +46,8 @@ def qemu_driver(qemu_target, qemu_mock):
 @pytest.fixture
 def qemu_mock(mocker):
     popen_mock = mocker.patch('subprocess.Popen')
-    popen_mock.return_value.wait.return_value = 0
-    popen_mock.return_value.stdout.readline.return_value = b"""
+    instance_mock = mocker.MagicMock()
+    instance_mock.stdout.readline.return_value = b"""
     {
       "QMP": {
         "version": {}
@@ -53,6 +55,10 @@ def qemu_mock(mocker):
       "return": {}
     }
     """
+
+    instance_mock.wait = mocker.MagicMock(side_effect=subprocess.TimeoutExpired(cmd='qemu', timeout=0.5))
+    instance_mock.communicate = mocker.MagicMock(return_value=(b"", b""))
+    popen_mock.return_value = instance_mock
 
     select_mock = mocker.patch('select.select')
     select_mock.return_value = True, None, None

--- a/tests/test_qemudriver.py
+++ b/tests/test_qemudriver.py
@@ -27,7 +27,7 @@ def qemu_target(qemu_env):
     return qemu_env.get_target()
 
 @pytest.fixture
-def qemu_driver(qemu_target):
+def qemu_driver(qemu_target, qemu_mock):
     q = QEMUDriver(
         qemu_target,
         "qemu",
@@ -60,20 +60,18 @@ def qemu_mock(mocker):
     socket_mock = mocker.patch('socket.socket')
     socket_mock.return_value.accept.return_value = mocker.MagicMock(), ''
 
-@pytest.fixture
-def qemu_version_mock(mocker):
-    run_mock = mocker.patch('subprocess.run')
-    run_mock.return_value.returncode = 0
-    run_mock.return_value.stdout = "QEMU emulator version 4.2.1"
+    version_mock = mocker.patch('subprocess.run')
+    version_mock.return_value.returncode = 0
+    version_mock.return_value.stdout = "QEMU emulator version 4.2.1"
 
-def test_qemu_instance(qemu_target, qemu_driver):
+def test_qemu_instance(qemu_driver):
     assert (isinstance(qemu_driver, QEMUDriver))
 
-def test_qemu_activate_deactivate(qemu_target, qemu_driver, qemu_version_mock):
+def test_qemu_activate_deactivate(qemu_target, qemu_driver):
     qemu_target.activate(qemu_driver)
     qemu_target.deactivate(qemu_driver)
 
-def test_qemu_on_off(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
+def test_qemu_on_off(qemu_target, qemu_driver):
     qemu_target.activate(qemu_driver)
 
     qemu_driver.on()
@@ -81,7 +79,7 @@ def test_qemu_on_off(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
 
     qemu_target.deactivate(qemu_driver)
 
-def test_qemu_read_write(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
+def test_qemu_read_write(qemu_target, qemu_driver):
     qemu_target.activate(qemu_driver)
 
     qemu_driver.on()
@@ -91,7 +89,7 @@ def test_qemu_read_write(qemu_target, qemu_driver, qemu_mock, qemu_version_mock)
 
     qemu_target.deactivate(qemu_driver)
 
-def test_qemu_port_forwarding(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
+def test_qemu_port_forwarding(qemu_target, qemu_driver, qemu_mock):
     qemu_target.activate(qemu_driver)
 
     qemu_driver.on()
@@ -102,7 +100,7 @@ def test_qemu_port_forwarding(qemu_target, qemu_driver, qemu_mock, qemu_version_
 
     qemu_target.deactivate(qemu_driver)
 
-def test_qemu_port_forwarding_with_netdev(qemu_target, qemu_driver, qemu_mock, qemu_version_mock):
+def test_qemu_port_forwarding_with_netdev(qemu_target, qemu_driver, qemu_mock):
     qemu_target.activate(qemu_driver)
 
     qemu_driver.on()


### PR DESCRIPTION
**Description**
Until now the QEMU process and QMP monitor start was tied to the `on()`/`off()` methods. This feels unnatural, preventing the user from interacting with the QEMU process via monitor commands before the emulation starts and meant starting a new process on each power cycle.

Rework the driver to start QEMU and the QMP monitor in on_activate(), allowing interaction via `monitor_command()` after activation. The `on()` and `off()` methods interact only via QMP now.

All methods relying on a started QEMU and QMP monitor instance are decorated with `@Driver.check_active` now.

The atexit handling is no longer required since the target's atexit handler already calls the driver's `on_deactivate()`.

While at it, restructure the QEMU mock fixtures in the QEMUDriver tests.

**Checklist**
- [x] PR has been tested

Alternative to one aspect of #1753