### PR TITLE
remote/client: use non-deprecated iscoroutinefunction() from inspect module

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1759,6 +1759,8 @@ class ExportFormat(enum.Enum):
 
 
 def main():
+    import inspect
+
     basicConfig(
         level=logging.WARNING,
         stream=sys.stderr,
@@ -2214,7 +2216,7 @@ def main():
             logging.debug("Started session")
 
             try:
-                if asyncio.iscoroutinefunction(args.func):
+                if inspect.iscoroutinefunction(args.func):
                     if getattr(args.func, "needs_target", False):
                         place = session.get_acquired_place()
                         target = session._get_target(place)


### PR DESCRIPTION
**Description**
`asyncio.iscoroutinefunction()` is deprecated [1] since Python 3.14 [2]. Use `inspect.iscoroutinefunction()` instead.

This fixes the [latest CI errors](https://github.com/labgrid-project/labgrid/actions/runs/19362179200) happening since #1748 was merged. Python 3.14 checks did not run because #1723 was merged after #1748 was created. The DeprecationWarning breaks an assert in `tests/test_client.py::test_place_acquire_multiple`.

[1] https://docs.python.org/3/deprecations/index.html#pending-removal-in-python-3-16
[2] https://github.com/python/cpython/commit/bc9d92c67933917b474e61905451c6408c68e71d

**Checklist**
- [x] PR has been tested