### PR TITLE
util/agents/usb_hid_relay: Fix agent errors

### DIFF
--- a/labgrid/util/agents/usb_hid_relay.py
+++ b/labgrid/util/agents/usb_hid_relay.py
@@ -100,7 +100,11 @@ class USBHIDRelay:
 
     def get_output(self, number):
         with self._claimed():
-            self._get_output(number)
+            return self._get_output(number)
+
+    def __del__(self):
+        if not self._dev.is_kernel_driver_active(0):
+            self._dev.attach_kernel_driver(0)
 
 
 _relays = {}


### PR DESCRIPTION
**Description**

TL;DR

* get_output() should return some result;
* should attach kernel driver back in the destructor otherwise HIDRAW device will not appear if it has existed.

----

Hello there! I have a USB HID relay and tests for it and I face with the issue when after labgrid using the relay will not display in /dev system. Only replugging helps to fix it.

I notice that the device attachment is not performed at the USBHIDRelay destructor, and it seems to me ambiguous because the device doesn't return to the initial state.

I ran multiple pytest processes to test concurrent situations which were fixed in [1526](https://github.com/labgrid-project/labgrid/pull/1526). Tests are passed.

**Checklist**
- [x] PR has been tested