### PR TITLE
agentwrapper: Allow specyfing Python executable

### DIFF
--- a/doc/man/client.rst
+++ b/doc/man/client.rst
@@ -80,6 +80,12 @@ LG_AGENT_PREFIX
 Add a prefix to ``.labgrid_agent_{agent_hash}.py`` allowing specification for
 where on the exporter it should be uploaded to. 
 
+LG_AGENT_PYTHON
+~~~~~~~~~~~~~~~
+Specify python executable other the the default ``python3``. By pointing
+to an executable in a particular virtual environment, use this environment
+and its packages to run the agent and any agent-wrapped code.
+
 Matches
 -------
 Match patterns are used to assign a resource to a specific place. The format is:

--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -47,6 +47,7 @@ class AgentWrapper:
             os.path.abspath(os.path.dirname(__file__)),
             'agent.py')
         agent_prefix = os.environ.get("LG_AGENT_PREFIX", "")
+        python_exe = os.environ.get("LG_AGENT_PYTHON", "python3")
         if host:
             # copy agent.py and run via ssh
             with open(agent, 'rb') as agent_fd:
@@ -60,7 +61,7 @@ class AgentWrapper:
                  f'{host}:{agent_remote}'],
             )
             self.agent = subprocess.Popen(
-                ssh_opts + [host, '--', 'python3', agent_remote],
+                ssh_opts + [host, '--', python_exe, agent_remote],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 start_new_session=True,
@@ -68,7 +69,7 @@ class AgentWrapper:
         else:
             # run locally
             self.agent = subprocess.Popen(
-                ['python3', agent],
+                [python_exe, agent],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 start_new_session=True,

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -1132,6 +1132,11 @@ unspecified, defaults to 30 seconds.
 .sp
 Add a prefix to \fB\&.labgrid_agent_{agent_hash}.py\fP allowing specification for
 where on the exporter it should be uploaded to.
+.SS LG_AGENT_PYTHON
+.sp
+Specify python executable other the the default \fBpython3\fP\&. By pointing
+to an executable in a particular virtual environment, use this environment
+and its packages to run the agent and any agent\-wrapped code.
 .SH MATCHES
 .sp
 Match patterns are used to assign a resource to a specific place. The format is:


### PR DESCRIPTION
**Description**

Enable users to choose which Python executable to use to run the agent by setting LG_AGENT_PYTHON environment variable. This is necessary when a remote labgrid runs in a virtual environment which provide packages, or their versions, not available in the system installation of Python.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
- [x] Man pages have been regenerated
