### PR TITLE
remote/exporter: Export invert parameter on relays

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -503,6 +503,7 @@ class USBDeditecRelaisExport(USBGenericExport):
             "vendor_id": self.local.vendor_id,
             "model_id": self.local.model_id,
             "index": self.local.index,
+            "invert": self.local.invert,
         }
 
 
@@ -523,6 +524,7 @@ class USBHIDRelayExport(USBGenericExport):
             "vendor_id": self.local.vendor_id,
             "model_id": self.local.model_id,
             "index": self.local.index,
+            "invert": self.local.invert,
         }
 
 


### PR DESCRIPTION
The invert parameter is currently not being exported on Network HID and Deditec relays. Since the client is the one responsible for inverting the signal, and it does not recieve this information from the exporter (which causes it to default to False), the invert is only working on local setups and not on network exported devices.