### PR TITLE
util/helper: add stderr param to ProcessWrapper

### DIFF
--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -41,8 +41,14 @@ class ProcessWrapper:
     loglevel = logging.INFO
 
     @step(args=['command'], result=True, tag='process')
-    def check_output(self, command, *, print_on_silent_log=False, input=None, stdin=None, timeout=None): # pylint: disable=redefined-builtin
+    def check_output(
+        self, command, *, print_on_silent_log=False, input=None, stdin=None, stderr=subprocess.STDOUT, timeout=None
+    ):  # pylint: disable=redefined-builtin
         """Run a command and supply the output to callback functions"""
+
+        if stderr not in (None, subprocess.STDOUT, subprocess.DEVNULL):
+            raise NotImplementedError(f"{stderr=} not supported")
+
         logger = logging.getLogger("Process")
         res = []
         mfd, sfd = pty.openpty()
@@ -59,8 +65,7 @@ class ProcessWrapper:
         elif stdin is not None:
             kwargs['stdin'] = stdin
 
-        process = subprocess.Popen(command, stderr=sfd,
-                                   stdout=sfd, bufsize=0, **kwargs)
+        process = subprocess.Popen(command, stderr=stderr, stdout=sfd, bufsize=0, **kwargs)
 
         logger.log(ProcessWrapper.loglevel, "[%d] command: %s", process.pid, " ".join(command))
 

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -1,3 +1,4 @@
+import subprocess
 from urllib.parse import urlparse
 
 import pytest
@@ -81,7 +82,7 @@ class TestExternalPowerDriver:
         d.on()
 
         popen.assert_called_once_with(['set', '-1', 'foo-board'], bufsize=0,
-                                      stderr=2, stdout=2)
+                                      stderr=subprocess.STDOUT, stdout=2)
 
     def test_off(self, target, mocker):
         pty = mocker.patch('pty.openpty')
@@ -107,7 +108,7 @@ class TestExternalPowerDriver:
         d.off()
 
         popen.assert_called_once_with(['set', '-0', 'foo-board'], bufsize=0,
-                                      stderr=2, stdout=2)
+                                      stderr=subprocess.STDOUT, stdout=2)
 
     def test_cycle(self, target, mocker):
         pty = mocker.patch('pty.openpty')
@@ -135,10 +136,8 @@ class TestExternalPowerDriver:
         d.cycle()
 
         assert popen.call_args_list == [
-            mocker.call(['set', '-0', 'foo-board'], bufsize=0, stderr=2,
-                        stdout=2),
-            mocker.call(['set', '-1', 'foo-board'], bufsize=0, stderr=2,
-                        stdout=2),
+            mocker.call(['set', '-0', 'foo-board'], bufsize=0, stderr=subprocess.STDOUT, stdout=2),
+            mocker.call(['set', '-1', 'foo-board'], bufsize=0, stderr=subprocess.STDOUT, stdout=2),
         ]
         m_sleep.assert_called_once_with(2.0)
 
@@ -171,7 +170,7 @@ class TestExternalPowerDriver:
         d.cycle()
 
         popen.assert_called_once_with(['set', '-c', 'foo-board'], bufsize=0,
-                                      stderr=2, stdout=2)
+                                      stderr=subprocess.STDOUT, stdout=2)
         m_sleep.assert_not_called()
 
 class TestNetworkPowerDriver:


### PR DESCRIPTION
**Description**

Add a `stderr` parameter to the `ProcessWrapper`, allowing the separation of `stderr` from the output. In my driver, I use this feature to ignore `stderr` by redirecting it to `subprocess.DEVNULL`

**what do you use the feature for?**
  It allows calling `ProcessWrapper` without having `stderr` polluting the standard output.

**how does labgrid benefit as a testing library from the feature?**
  This feature is used in my custom `IpmiPowerDriver` to check the status without having debug messages mixed.

**how did you verify the feature works?**
  I tested the feature with a DUT in my labs.

**if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?**
  No specific hardware is required

---

**Checklist**

* [ ] Documentation for the feature
* [ ] Tests for the feature
* [ ] The arguments and descriptions in `doc/configuration.rst` have been updated
* [ ] Add a section in `doc/usage.rst` to explain how to use the feature
* [ ] Add a section in `doc/development.rst` to explain how developers can use the feature
* [x] PR has been tested locally
* [ ] Man pages have been regenerated
