### PR TITLE
util/agentwrapper: Implement _labgrid-agent

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,6 +102,7 @@ labgrid-client = "labgrid.remote.client:main"
 labgrid-exporter = "labgrid.remote.exporter:main"
 labgrid-suggest = "labgrid.resource.suggest:main"
 labgrid-coordinator = "labgrid.remote.coordinator:main"
+_labgrid-agent = "labgrid.util.agent:main"
 
 # the following makes a plugin available to pytest
 [project.entry-points.pytest11]


### PR DESCRIPTION
> a helper to execute agents on the exporter host.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

This hasn't been tested yet, but is a mere discussion point.

The thesis: On a host where labgrid has been installed and the exporter is supposed to run 
we already have all the dependencies installed (at least in an environment, not necessarily an isolated one).

This means it should not only not be necessary to copy over the agent file, as its already present on the exporter host,
but not necessary to install dependencies globally on it either.

This introduces a new command `_labgrid-agent`, which due to the leading underscore should not confuse users using autocompletion.

**Considerations**

The approach has a considered drawback:
Currently the client uses the `agentwrapper` and the `agents/` shipped with the client matching its version perfectly.
With this change it would only use the latter and potential upcoming incompatibilities in the wrapper could show up, in case somebody installed different versions of labgrid on the client- and the exporterhost.

I think the risk is low though, as the wrapper does not change much anymore and a version check could be introduced, once its behaviour is changed in a breaking way.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- ~Add a section on how to use the feature to doc/usage.rst~
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->

Fixes #1790 
