### PR TITLE
doc/conf: use stable year for man page generation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -223,7 +223,7 @@ def setup(app):
     # Make version and date stable when generating manpages as they will be tracked in git
     if app.outdir.parts[-1] == "man":
         app.config.version = ""
-        app.config.today_fmt = "%Y"
+        app.config.today = "2025"
     app.connect('builder-inited', run_apidoc)
     app.connect('doctree-read', write_literal_blocks)
 


### PR DESCRIPTION
**Description**
Updating the man pages should always be an explicit action. We rely on stable output and keep the generated man pages tracked in git for easy packaging. The CI jobs generate the man pages and check for diffs.

Using the current year obviously breaks this process, so set the year to an explicit value that can be updated when required.

See failing CI jobs since 2026-01-01: https://github.com/labgrid-project/labgrid/actions?query=branch%3Amaster

**Checklist**
- [x] PR has been tested
- [ ] Man pages have been regenerated (not needed)

Fixes #1767
