### PR TITLE
doc/getting_started: Document distro packages

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -451,3 +451,14 @@ See the section about the various :ref:`shipped strategies <conf-strategies>`
 for examples on this.
 
 An example using the pytest plugin is provided under ``examples/strategy``.
+
+Distribution installation
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Labgrid is packaged for the following Linux distributions:
+
+- [Debian Sid](https://packages.debian.org/sid/python3-labgrid)
+- [Debian Forky](https://packages.debian.org/forky/python3-labgrid)
+- Unofficial support for Fedora 42 and 43 by
+  [philipmolloy/labgrid](https://copr.fedorainfracloud.org/coprs/philipmolloy/labgrid/)
+  on Fedora Copr


### PR DESCRIPTION
Distro packages are can create users/groups, install systemd service files, and install udev rules. They also can deal with distro specifics like uaccess vs. plugdev. Despite those benefits they present challenges related to dependency management.

As the author of the Fedora Copr package I have done some basic testing. I was able to run both services, acquire a place and access a console. I tried the Debian package as well, but did not test it extensively.

Note that in both cases dependencies ([most importantly gRPC](https://gitlab.com/pamolloy/copr-dist-labgrid#grpc)) are older than required by `pyproject.toml`.