### PR TITLE
doc/man/pytest: fix inline interpreted text without a role

### DIFF
--- a/doc/man/pytest.rst
+++ b/doc/man/pytest.rst
@@ -15,7 +15,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 Labgrid ships a pytest plugin to integrate with the pytest infrastructure. It is
-activated if the `--lg-env` parameter is supplied to the pytest command.
+activated if the ``--lg-env`` parameter is supplied to the pytest command.
 
 The labgrid plugin parses the supplied configuration yaml file as described in
 ``labgrid-device-config``\(5) and allows the usage of the target and environment

--- a/man/labgrid-pytest.7
+++ b/man/labgrid-pytest.7
@@ -37,7 +37,7 @@ labgrid-pytest \- labgrid integration for pytest
 .SS DESCRIPTION
 .sp
 Labgrid ships a pytest plugin to integrate with the pytest infrastructure. It is
-activated if the \fI\-\-lg\-env\fP parameter is supplied to the pytest command.
+activated if the \fB\-\-lg\-env\fP parameter is supplied to the pytest command.
 .sp
 The labgrid plugin parses the supplied configuration yaml file as described in
 \fBlabgrid\-device\-config\fP(5) and allows the usage of the target and environment


### PR DESCRIPTION
**Description**
sphinx became stricter when handling interpreted text without a role, e.g. "`foo`" since [1], see [2]. This results in errors such as:

```
  sphinx.errors.SphinxError: cannot determine default role!
```

In the past, heuristics were used to determine how to format the text (inline code, italic, ..).

Fix another occurrence that should have been marked as inline code instead.

[1] https://github.com/sphinx-doc/sphinx/commit/114093cff01562a6a50f8c88b59c7b2fed52a39a
[2] https://github.com/sphinx-doc/sphinx/issues/13904



<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

See also #1755 
