### PR TITLE
Pin Sphinx version to fix failing builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ dynamic = ["version"]  # via setuptools_scm
 [project.optional-dependencies]
 doc = [
     "sphinx_rtd_theme>=1.0.0",
-    "Sphinx>=2.0.0",
+    "Sphinx>=2.0.0,<9.0.0",
     "sphinxcontrib-autoprogram>=0.1.9",
 ]
 docker = ["docker>=5.0.2"]


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
New version of Sphinx and docutils make the builds fail.
`Sphinx>=9.0.0` is requiring the definition of `default_role` in `config.py` and the `docutils>=22.0.0` generate different than expected man pages from existing `*.rst` files causing the tests of documentation to fail.

Problem happens for Python >= 3.11 so updating the man pages would in turn break the builds/tests for Python 3.9 and 3.10 that are currently passing.

My proposition is to pin Sphinx package version to one that works with all labgrid-supported Python versions. Doing that also (indirectly) pins version of `docutils` package to one that doesn't alter generation of man pages.

The solution is temporary until we're able to drop support for python 3.9 and 3.10.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
Fixes #1801 
