### PR TITLE
Add externally_managed property for NetworkInterfaces

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -887,6 +887,9 @@ Ethernet or WiFi)
 
 Arguments:
   - ifname (str): name of the interface
+  - externally_managed (bool): if True, the interface configuration is managed
+    by the administrator and should not be changed by labgrid. Default is
+    False.
 
 Used by:
   - `NetworkInterfaceDriver`_

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -325,6 +325,7 @@ class NetworkInterfaceExport(ResourceExport):
         params = {
             "host": self.host,
             "ifname": self.local.ifname,
+            "externally_managed": self.local.externally_managed,
         }
         if self.cls == "USBNetworkInterface":
             params["extra"] = {

--- a/labgrid/resource/base.py
+++ b/labgrid/resource/base.py
@@ -21,8 +21,13 @@ class NetworkInterface(Resource):
     """The basic NetworkInterface contains an interface name
 
     Args:
-        ifname (str): name of the interface"""
+        ifname (str): name of the interface
+        externally_managed (bool): if True, the interface configuration is managed
+            by the administrator and should not be changed by labgrid. Default is
+            False.
+    """
     ifname = attr.ib(default=None)
+    externally_managed = attr.ib(default=False, validator.attr.validators.instance_of(bool))
 
 @target_factory.reg_resource
 @attr.s

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -391,6 +391,7 @@ class RemoteNetworkInterface(NetworkResource, ManagedResource):
     manager_cls = RemotePlaceManager
 
     ifname = attr.ib(default=None)
+    externally_managed = attr.ib(default=False, validator.attr.validators.instance_of(bool))
 
 @attr.s(eq=False)
 class RemoteBaseProvider(NetworkResource):


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Adds a property to NetworkInterface to indicate that the interface is externally managed by the system administrator, and cannot be manipulated by labgrid. While RawNetworkInterfaceDriver has a similar flag, setting a flag at the driver level is suboptimal since not all instances of RawNetworkInterfaceDriver are guarenteed to correctly set that flag. As an example, if labgrid-client or a test script creates a RawNetworkInterfaceDriver ephemerally, it will reset the network interface configuration, much to the consternation of the system administrator.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
