### PR TITLE
man/labgrid-client: mention LG_PROXY requirements for exporter resources

### DIFF
--- a/doc/man/client.rst
+++ b/doc/man/client.rst
@@ -60,6 +60,12 @@ This variable can be used to specify a SSH proxy hostname which should be used
 to connect to the coordinator and any resources which are normally accessed
 directly.
 
+Note: this proxy is only used to connect to the coordinator.
+Additional steps may be required to connect to ressources.
+See <https://labgrid.readthedocs.io/en/latest/overview.html#proxy-mechanism>
+(or the file ``doc/overview.rst`` in the labgrid source tree)
+for more information.
+
 LG_HOSTNAME
 ~~~~~~~~~~~
 Override the hostname used when accessing a resource. Typically only useful for

--- a/dockerfiles/staging/dut/Dockerfile
+++ b/dockerfiles/staging/dut/Dockerfile
@@ -14,7 +14,7 @@ RUN apt update -q=2 && \
 
 COPY --chown=root:root ./authorized_keys /root/.ssh/authorized_keys
 
-# As sshd scrubs ENV variables if they are set by the ENV varibale ensure to put the into /etc/profile as shown below
+# As sshd scrubs ENV variables if they are set by the ENV variable ensure to put the into /etc/profile as shown below
 ENV NOTVISIBLE="in users profile"
 RUN echo "export VISIBLE=now" >> /etc/profile
 

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1826,7 +1826,7 @@ def get_parser(auto_doc_mode=False) -> "argparse.ArgumentParser | AutoProgramArg
         "-s",
         "--state",
         type=str,
-        help="strategy state to switch into before command (default: value from env varibale LG_STATE)",
+        help="strategy state to switch into before command (default: value from env variable LG_STATE)",
     )
     parser.add_argument(
         "-i",

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -1116,6 +1116,12 @@ This variable can be used to set the default coordinator in the format
 This variable can be used to specify a SSH proxy hostname which should be used
 to connect to the coordinator and any resources which are normally accessed
 directly.
+.sp
+Note: this proxy is only used to connect to the coordinator.
+Additional steps may be required to connect to ressources.
+See <\%<https://\:labgrid\:.readthedocs\:.io/\:en/\:latest/\:overview\:.html#\:proxy-mechanism>>
+(or the file \fBdoc/overview.rst\fP in the labgrid source tree)
+for more information.
 .SS LG_HOSTNAME
 .sp
 Override the hostname used when accessing a resource. Typically only useful for

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -63,7 +63,7 @@ place name/alias (default: value from env variable LG_PLACE)
 .INDENT 0.0
 .TP
 .B \-s <state>, \-\-state <state>
-strategy state to switch into before command (default: value from env varibale LG_STATE)
+strategy state to switch into before command (default: value from env variable LG_STATE)
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
Small consistency patch for readers of the man page that wonder about how to reach ressources on remote exporters when using `LG_PROXY`. While at it, correct a few typos.

**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested
- [x] Man pages have been regenerated