### PR TITLE
fix: quoting of QEMU driver boot args

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -225,7 +225,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             boot_args.append(self.boot_args)
         if self.kernel is not None and boot_args:
             cmd.append("-append")
-            cmd.append(" ".join(boot_args))
+            cmd.append("\'" + " ".join(boot_args) + "\'")
 
         return cmd
 

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -225,7 +225,7 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
             boot_args.append(self.boot_args)
         if self.kernel is not None and boot_args:
             cmd.append("-append")
-            cmd.append("\'" + " ".join(boot_args) + "\'")
+            cmd.append(shlex.quote(" ".join(boot_args)))
 
         return cmd
 


### PR DESCRIPTION
**Description**
This fixes the issue that boot arguments were passed unquoted to QEMU.

- [x] PR has been tested

