### PR TITLE
fix: handling of empty password in SSHDriver and NetworkService

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -683,7 +683,7 @@ These and the sudo configuration needs to be prepared by the administrator.
 Arguments:
   - address (str): hostname of the remote system
   - username (str): username used by SSH
-  - password (str, default=""): password used by SSH
+  - password (str, default=None): optional, password used by SSH
   - port (int, default=22): port used by SSH
 
 Used by:

--- a/labgrid/resource/networkservice.py
+++ b/labgrid/resource/networkservice.py
@@ -9,5 +9,5 @@ from .common import Resource
 class NetworkService(Resource):
     address = attr.ib(validator=attr.validators.instance_of(str))
     username = attr.ib(validator=attr.validators.instance_of(str))
-    password = attr.ib(default='', validator=attr.validators.instance_of(str))
+    password = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     port = attr.ib(default=22, validator=attr.validators.instance_of(int))


### PR DESCRIPTION
**Description**
SSHDriver and NetworkService currently does not differentiate between no password set and password set to an empty string. Both cases resulted in that the SSH option `-o PasswordAuthentication=no` is passed.
There are cases where a password should be used, but it is set to an empty string.
This merge request fixes this.

**Checklist**
- [x] PR has been tested

