### PR TITLE
doc/development: remove --lg-env option from pytest

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -36,7 +36,7 @@ Tests can now be run via:
 
 .. code-block:: bash
 
-   python -m pytest --lg-env <config>
+   python -m pytest
 
 Writing a Driver
 ----------------


### PR DESCRIPTION

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Remove the `--lg-env` option from the pytest invocation in the development documentation. The labgrid plugin isn't loaded automatically when running pytest from the labgrid repository, so the option isn't recognized and causes the tests to fail
