### PR TITLE
tests/test_agent.py: parametrize test_all_modules

### DIFF
--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -96,20 +96,18 @@ def test_local():
     dummy = aw.load('dummy')
     assert dummy.neg(1) == -1
 
-def test_all_modules():
+@pytest.mark.parametrize('module_name', [
+    'deditec_relais8',
+    'sysfsgpio',
+    'usb_hid_relay'
+])
+def test_all_modules(module_name: str) -> None:
     aw = AgentWrapper(None)
-    aw.load('deditec_relais8')
+
+    aw.load(module_name)
     methods = aw.list()
-    assert 'deditec_relais8.set' in methods
-    assert 'deditec_relais8.get' in methods
-    aw.load('sysfsgpio')
-    methods = aw.list()
-    assert 'sysfsgpio.set' in methods
-    assert 'sysfsgpio.get' in methods
-    aw.load('usb_hid_relay')
-    methods = aw.list()
-    assert 'usb_hid_relay.set' in methods
-    assert 'usb_hid_relay.get' in methods
+    assert f'{module_name}.set' in methods
+    assert f'{module_name}.get' in methods
 
 def test_import_modules():
     import labgrid.util.agents


### PR DESCRIPTION


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Use pytest.mark.parametrize to avoid code duplication in test_all_modules. This will also allow us to see if only one module is failing or if all modules are failing which could be helpful for debugging.

(I was poking around with the agent code and saw there was some room for improvement here.)
