### PR TITLE
driver/pyvisa: extend Test and Measurement equipment support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -1330,19 +1330,42 @@ Such device could be a signal generator.
 
 .. code-block:: yaml
 
-   PyVISADevice:
-     type: 'TCPIP'
-     url: '192.168.110.11'
+   - PyVISADevice:
+       name: lxi_instrument
+       type: 'TCPIP'
+       url: '192.168.110.11'
+       backend: '@py'
+   - PyVISADevice:
+       name: raw_socket_instrument
+       type: 'TCPIP'
+       resource: 'SOCKET'
+       url: '192.168.110.12'
+       backend: '@py'
+   - PyVISADevice:
+       name: usbtmc_instrument
+       type: 'USB0'
+       url: '6833::3220::DM3O224500792::0'
+       backend: '@py'
+   - PyVISADevice:
+       name: serial_instrument
+       type: 'ASRL/dev/ttyACM0'
+       backend: '@py'
 
 Arguments:
   - type (str): device resource type following the PyVISA resource syntax, e.g.
     ASRL, TCPIP...
   - url (str): device identifier on selected resource, e.g. <ip> for TCPIP
     resource
+  - resource (str): VISA resource type (default is ``INSTR``), ``INSTR``, ``SOCKET`` or ``RAW``.
   - backend (str): optional, Visa library backend, e.g. '@sim' for pyvisa-sim backend
 
 Used by:
   - `PyVISADriver`_
+
+NetworkPyVISADevice
+~~~~~~~~~~~~~~~~~~~~~~
+A :any:`NetworkPyVISADevice` describes a `PyVISADevice`_ resource
+available on a remote computer.
 
 HTTPVideoStream
 ~~~~~~~~~~~~~~~
@@ -3388,12 +3411,62 @@ equipment manageable by PyVISA.
 Binds to:
   pyvisa_resource:
     - `PyVISADevice`_
+    - `NetworkPyVISADevice`_
+
+.. code-block:: yaml
+
+   PyVISADriver: {}
 
 Implements:
   - None yet
 
 Arguments:
   - None
+
+TMInstrumentDriver
+~~~~~~~~~~~~~~~~~~
+The :any:`TMInstrument` uses a low-level drivers to control SCPI compatible test and measurement instruments.
+
+Binds to:
+  pyvisa_resource:
+    - `PyVISADriver`_
+    - `USBTMCDriver`_
+
+.. code-block:: yaml
+
+   TMInstrument: {}
+
+Implements:
+  - None yet
+
+Arguments:
+  - None
+
+TMInstrumentPowerDriver
+~~~~~~~~~~~~~~~~~~~~~~~
+The :any:`TMInstrumentPower` uses a `PyVISADevice`_ resource to
+control a programmable power supply.
+
+Binds to:
+  sigrok:
+    - `PyVISADevice`_
+    - `NetworkPyVISADevice`_
+
+Implements:
+  - :any:`PowerProtocol`
+  - :any:`ResetProtocol`
+
+.. code-block:: yaml
+
+   TMInstrumentPower:
+     delay: 3.0
+
+Arguments:
+  - delay (float, default=3.0): delay in seconds between off and on
+  - max_voltage (float): optional, maximum allowed voltage for protection against
+    accidental damage (in volts)
+  - max_current (float): optional, maximum allowed current for protection against
+    accidental damage (in ampere)
 
 NetworkInterfaceDriver
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/pyvisa/pyvisa_example.py
+++ b/examples/pyvisa/pyvisa_example.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture()
 def signal_generator(target):
-    return target.get_driver("PyVISADriver").get_session()
+    return target.get_driver("PyVISADriver")
 
 
 def test_with_signal_generator_example(signal_generator):

--- a/examples/tminstrument/env.yaml
+++ b/examples/tminstrument/env.yaml
@@ -1,0 +1,26 @@
+targets:
+  main:
+    resources:
+    - PyVISADevice:
+        name: dmm-rigol
+        type: 'USB0'
+        url: '6833::3220::DM3O224500792::0'
+        backend: '@py'
+    - PyVISADevice:
+        name: ps-rigol
+        type: 'USB0'
+        url: '6833::3601::DP8C223703711::0'
+        backend: '@py'
+    drivers:
+    - PyVISADriver:
+        name: 'PyVisa_device_dmm-rigol'
+        bindings: { pyvisa_resource : 'dmm-rigol'}
+    - PyVISADriver:
+        name: 'PyVisa_device_ps-rigol'
+        bindings: { pyvisa_resource : 'ps-rigol'}
+    - TMInstrument:
+        name: 'TM_instrument_visa-rigol-dmm'
+        bindings: { inst : 'PyVisa_device_dmm-rigol' }
+    - TMInstrument:
+        name: 'TM_instrument_visa-rigol-ps'
+        bindings: { inst : 'PyVisa_device_ps-rigol' }

--- a/examples/tminstrument/tminstrument_example.py
+++ b/examples/tminstrument/tminstrument_example.py
@@ -1,0 +1,29 @@
+import pytest
+
+
+@pytest.fixture()
+def digital_multimeter(target):
+    return target.get_driver("TMInstrument", name="TM_instrument_visa-rigol-dmm")
+
+
+@pytest.fixture()
+def laboratory_power_supply(target):
+    return target.get_driver("TMInstrument", name="TM_instrument_visa-rigol-ps")
+
+
+def test_with_digital_multimeter_example(digital_multimeter):
+    # Identify the device
+    digital_multimeter.identify()
+
+    # Get DC voltage reading
+    assert 0.0 <= digital_multimeter.query_iterable(":MEASure:VOLTage:DC?")[0] <= 33.0
+    assert 0.0 <= float(digital_multimeter.query(":MEASure:VOLTage:DC?")) <= 33.0
+
+
+def test_with_laboratory_power_supply_example(laboratory_power_supply):
+    # Identify the device
+    laboratory_power_supply.identify()
+
+    # Get voltage reading of channel 1
+    assert 0.0 <= laboratory_power_supply.query_iterable(":MEAS:VOLT? CH1")[0] <= 33.0
+    assert 0.0 <= float(laboratory_power_supply.query(":MEAS:VOLT? CH1")) <= 33.0

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -49,3 +49,4 @@ from .usbtmcdriver import USBTMCDriver
 from .deditecrelaisdriver import DeditecRelaisDriver
 from .dediprogflashdriver import DediprogFlashDriver
 from .httpdigitaloutput import HttpDigitalOutputDriver
+from .tminstrument import TMInstrument, TMInstrumentPower

--- a/labgrid/driver/pyvisadriver.py
+++ b/labgrid/driver/pyvisadriver.py
@@ -21,7 +21,7 @@ class PyVISADriver(Driver):
 
     def on_activate(self):
         url = "" if self.pyvisa_resource.url == "" else f"::{self.pyvisa_resource.url}"
-        self.device_identifier = f"{self.pyvisa_resource.type}{url}::INSTR"
+        self.device_identifier = f"{self.pyvisa_resource.type}{url}::{self.pyvisa_resource.resource}"
         if isinstance(self.pyvisa_resource, NetworkPyVISADevice):
             host = self.pyvisa_resource.host
         else:

--- a/labgrid/driver/pyvisadriver.py
+++ b/labgrid/driver/pyvisadriver.py
@@ -63,6 +63,28 @@ class PyVISADriver(Driver):
         return self.proxy.query(self.device_identifier, self.pyvisa_resource.backend, cmd, timeout).rstrip()
 
     @Driver.check_active
+    def query_iterable(self, cmd, timeout=2000, **kwargs):
+        """
+        Sent the specified command to the instrument and read the response.
+
+        Args:
+            cmd (str): command to be executed
+            timeout (int): optional, I/O operation timeout in ms, default is 2000ms
+
+        Returns:
+            List[float]: response from the instrument, retunring list of float values (readings).
+        """
+        return self.proxy.query(
+            self.device_identifier,
+            self.pyvisa_resource.backend,
+            cmd,
+            timeout,
+            iterable=True,
+            is_ascii=True,
+            **kwargs
+        )
+
+    @Driver.check_active
     def identify(self):
         """
         Sent the identify command to the instrument and read the response.

--- a/labgrid/driver/pyvisadriver.py
+++ b/labgrid/driver/pyvisadriver.py
@@ -2,6 +2,8 @@ from importlib import import_module
 import attr
 
 from ..factory import target_factory
+from ..resource.pyvisa import NetworkPyVISADevice
+from ..util.agentwrapper import AgentWrapper
 from .common import Driver
 
 
@@ -13,22 +15,38 @@ class PyVISADriver(Driver):
     Args:
         bindings (dict): driver to use with PyVISA
     """
-
-    bindings = {"pyvisa_resource": "PyVISADevice"}
+    bindings = {"pyvisa_resource": {"PyVISADevice", "NetworkPyVISADevice"}}
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        _py_pyvisa_module = import_module("pyvisa")
-        self._pyvisa_resource_manager = _py_pyvisa_module.ResourceManager(self.pyvisa_resource.backend)
-        self.pyvisa_device = None
+        self.wrapper = None
 
     def on_activate(self):
-        device_identifier = f"{self.pyvisa_resource.type}::{self.pyvisa_resource.url}::INSTR"
-        self.pyvisa_device = self._pyvisa_resource_manager.open_resource(device_identifier)
+        url = "" if self.pyvisa_resource.url == "" else f"::{self.pyvisa_resource.url}"
+        self.device_identifier = f"{self.pyvisa_resource.type}{url}::INSTR"
+        if isinstance(self.pyvisa_resource, NetworkPyVISADevice):
+            host = self.pyvisa_resource.host
+        else:
+            host = None
+        self.wrapper = AgentWrapper(host)
+        self.proxy = self.wrapper.load("visa_instrument")
 
     def on_deactivate(self):
-        self.pyvisa_device = None
+        self.wrapper.close()
+        self.wrapper = None
 
     @Driver.check_active
     def get_session(self):
-        return self.pyvisa_device
+        raise NotImplementedError('Deprecated, use command or query instead')
+
+    @Driver.check_active
+    def command(self, cmd):
+        self.proxy.write(self.device_identifier, self.pyvisa_resource.backend, cmd)
+
+    @Driver.check_active
+    def query(self, cmd):
+        return self.proxy.query(self.device_identifier, self.pyvisa_resource.backend, cmd)
+
+    @Driver.check_active
+    def identify(self):
+        return self.query("*IDN?")

--- a/labgrid/driver/pyvisadriver.py
+++ b/labgrid/driver/pyvisadriver.py
@@ -1,11 +1,9 @@
-from importlib import import_module
 import attr
 
 from ..factory import target_factory
 from ..resource.pyvisa import NetworkPyVISADevice
 from ..util.agentwrapper import AgentWrapper
 from .common import Driver
-
 
 @target_factory.reg_driver
 @attr.s(eq=False)
@@ -40,13 +38,36 @@ class PyVISADriver(Driver):
         raise NotImplementedError('Deprecated, use command or query instead')
 
     @Driver.check_active
-    def command(self, cmd):
-        self.proxy.write(self.device_identifier, self.pyvisa_resource.backend, cmd)
+    def command(self, cmd, timeout=2000):
+        """
+        Sent the specified command to the instrument.
+
+        Args:
+            cmd (str): command to be executed
+            timeout (int): optional, I/O operation timeout in ms, default is 2000ms
+        """
+        self.proxy.write(self.device_identifier, self.pyvisa_resource.backend, cmd, timeout)
 
     @Driver.check_active
-    def query(self, cmd):
-        return self.proxy.query(self.device_identifier, self.pyvisa_resource.backend, cmd)
+    def query(self, cmd, timeout=2000):
+        """
+        Sent the specified command to the instrument and read the response.
+
+        Args:
+            cmd (str): command to be executed
+            timeout (int): optional, I/O operation timeout in ms, default is 2000ms
+
+        Returns:
+            str: response from the instrument, with possible termination removed.
+        """
+        return self.proxy.query(self.device_identifier, self.pyvisa_resource.backend, cmd, timeout).rstrip()
 
     @Driver.check_active
     def identify(self):
+        """
+        Sent the identify command to the instrument and read the response.
+
+        Returns:
+            str: returns a comma-separated string with the information about the instrument (manufacturer, model, serial number, firmware version).
+        """
         return self.query("*IDN?")

--- a/labgrid/driver/tminstr/it_m3632.py
+++ b/labgrid/driver/tminstr/it_m3632.py
@@ -1,0 +1,705 @@
+from labgrid.driver.tminstr.scpi_arg import *
+from labgrid.driver.tminstrument import TMInstrument
+
+ALLOWED_CHANNELS = list(range(1, 17))
+
+# Chapter 4 CHANNELS
+
+
+def check_channel(channel: int):
+    if channel not in ALLOWED_CHANNELS:
+        raise ValueError(f"Channel number {channel} is out of range. Valid range: 1–16 (see Chapter 4 of the manual).")
+
+
+def channel_output_set(driver: TMInstrument, channel):
+    """
+    Selects the active output channel using CHANnel command.
+    """
+    channel = get_int(channel)
+    check_channel(channel)
+    driver.command(f"CHAN {channel}")
+
+
+def channel_instrument_set(driver: TMInstrument, channel):
+    """
+    Selects the active output channel using INSTrument[:SELect] command.
+    """
+    channel = get_int(channel)
+    check_channel(channel)
+    driver.command(f"INST {channel}")
+
+
+# Chapter 5 SYST COMMANDS
+
+
+def system_beeper_immediate(driver: TMInstrument):
+    """
+    Immediate test of the beeper (issues a beep if functional).
+    """
+    driver.command("SYSTem:BEEPer:IMMediate")
+
+
+def system_beeper_state_set(driver: TMInstrument, state):
+    """
+    Enables or disables the beeper. Allowed values: True/False
+    """
+    state = get_bool(state)
+    driver.command(f"SYSTem:BEEPer:STATe {state}")
+
+
+def system_beeper_state_get(driver: TMInstrument):
+    """
+    Queries the current beeper state.
+    Returns: "0" or "1"
+    """
+    return driver.query("SYSTem:BEEPer:STATe?")
+
+
+def system_error_get(driver: TMInstrument):
+    """
+    Returns error code and error description.
+    Format: e.g., 0,"NO_ERR"
+    """
+    return driver.query("SYSTem:ERRor?")
+
+
+def system_clear(driver: TMInstrument):
+    """
+    Clears the system status register.
+    """
+    driver.command("SYSTem:CLEar")
+
+
+def system_remote_set(driver: TMInstrument):
+    """
+    Switches to remote control mode.
+    """
+    driver.command("SYSTem:REMote")
+
+
+def system_local_set(driver: TMInstrument):
+    """
+    Switches to front panel local control mode.
+    """
+    driver.command("SYSTem:LOCal")
+
+
+def system_remote_lock(driver: TMInstrument):
+    """
+    Locks the device in remote control mode (prevents LOCAL button from switching).
+    """
+    driver.command("SYSTem:RWLock")
+
+
+def lan_ip_address_get(driver: TMInstrument) -> str:
+    """
+    Get current IP address of the device.
+    """
+    return driver.query(":SYST:COMM:LAN:CURR:ADDR?")
+
+
+def lan_ip_address_set(driver: TMInstrument, ip_address: str):
+    """
+    Set current IP address.
+    """
+    ip_address = get_ip(ip_address)
+    driver.command(f':SYST:COMM:LAN:CURR:ADDR "{ip_address}"')
+
+
+def lan_subnet_mask_get(driver: TMInstrument) -> str:
+    """
+    Get current subnet mask.
+    """
+    return driver.query(":SYSTem:COMMunicate:LAN:CURRent:SMASk?")
+
+
+def lan_subnet_mask_set(driver: TMInstrument, mask: str):
+    """
+    Set current subnet mask.
+    """
+    mask = get_ip(mask)
+    driver.command(f':SYSTem:COMMunicate:LAN:CURRent:SMASk "{mask}"')
+
+
+def lan_gateway_get(driver: TMInstrument) -> str:
+    """
+    Get current gateway address.
+    """
+    return driver.query("SYSTem:COMMunicate:LAN:CURRent:DGATeway?")
+
+
+def lan_gateway_set(driver: TMInstrument, gateway: str):
+    """
+    Set current gateway address.
+    """
+    gateway = get_ip(gateway)
+    driver.command(f'SYSTem:COMMunicate:LAN:CURRent:DGATeway "{gateway}"')
+
+
+def lan_mac_address_get(driver: TMInstrument) -> str:
+    """
+    Get current MAC address.
+    """
+    return driver.query(":SYSTem:COMMunicate:LAN:MACaddress?")
+
+
+def lan_dhcp_state_get(driver: TMInstrument) -> str:
+    """
+    Get current DHCP setting (ON or OFF).
+    """
+    return driver.query(":SYSTem:COMMunicate:LAN:DHCP?")
+
+
+def lan_dhcp_state_set(driver: TMInstrument, enable):
+    """
+    Set DHCP ON (True) or OFF (False).
+    """
+    enable = get_bool(enable)
+    driver.command(f":SYSTem:COMMunicate:LAN:DHCP {'ON' if enable else 'OFF'}")
+
+
+def lan_settings_valid(driver: TMInstrument):
+    """
+    This command makes the LAN settings valid.
+    """
+    driver.command(f"SYSTem:COMMunicate:LAN:SAVE")
+
+
+# Chapter 6 MEAS
+
+
+def measure_current_dc_get(driver: TMInstrument):
+    """
+    MEASure[:SCALar]:CURRent[:DC]?
+    """
+    return driver.query("MEAS:CURR?")
+
+
+def measure_power_dc_get(driver: TMInstrument):
+    """
+    MEASure[:SCALar]:POWer[:DC]?
+    """
+    return driver.query("MEAS:POW?")
+
+
+def measure_voltage_dc_get(driver: TMInstrument):
+    """
+    MEASure[:SCALar]:VOLTage[:DC]?
+    """
+    return driver.query("MEAS:VOLT?")
+
+
+def measure_temperature_get(driver: TMInstrument):
+    """
+    MEASure[:SCALar][:EXTernal]:TEMPerature?
+    """
+    return driver.query("MEAS:TEMP?")
+
+
+# Chapter 7 OUTPUT
+
+
+def source_state_set(driver: TMInstrument, state):
+    """
+    This command sets the output state of the power supply.
+    """
+    state = get_bool(state)
+    driver.command(f"OUTP {state}")
+
+
+def source_state_get(driver: TMInstrument):
+    """
+    This command sets the output state of the power supply.
+    """
+    return driver.query(f"OUTP?")
+
+
+# Chapter 8 INPUT
+
+
+def load_state_set(driver: TMInstrument, state):
+    """
+    This command sets the input state of the electronic load.
+    """
+    state = get_bool(state)
+    driver.command(f"INP {state}")
+
+
+def load_state_get(driver: TMInstrument):
+    """
+    This command sets the input state of the electronic load.
+    """
+    return driver.query(f"INP?")
+
+
+def load_short_set(driver: TMInstrument, state):
+    """
+    This command sets the electronic load to short mode.
+    """
+    state = get_bool(state)
+    driver.command(f"INP:SHOR {state}")
+
+
+def load_reversed_get(driver: TMInstrument):
+    """
+    This command is used to query the connection of input terminals.
+    """
+    return driver.query(f"INP:REV?")
+
+
+# Chapter 9 Trigger Commands
+# TBD
+
+# Chapter 10 Sense Commands
+
+
+def sense_enable_set(driver: TMInstrument, state):
+    """
+    This command enables or disables the sense function.
+    """
+    state = get_bool(state)
+    driver.command(f"SENS {state}")
+
+
+def sense_enable_get(driver: TMInstrument):
+    """
+    This command check the state of the sense function.
+    """
+    return driver.query(f"SENS?")
+
+
+def sense_filter_set(driver: TMInstrument, level):
+    """
+    This command sets the sense filter level.
+    """
+    level = get_filter_level(level)
+    driver.command(f"SENS:FILT:LEV {level}")
+
+
+# Chapter 11 Source Commands
+
+
+def source_load_mode_set(driver: TMInstrument, mode):
+    """
+    This command is used to switch the source mode and load mode.
+    Please switch the instrument to source mode before sending source commands.
+    """
+    mode = get_function_mode(mode)
+    driver.command(f"SYSTem:FUNCtion {mode}")
+
+
+def source_load_mode_get(driver: TMInstrument):
+    """
+    This command is used to query the source mode and load mode.
+    """
+    return driver.query(f"SYSTem:FUNCtion?")
+
+
+def source_load_current_set(driver: TMInstrument, current):
+    """
+    This command sets the current value of the power supply/load.
+    """
+    # TODO: range check
+    current = get_float(current)
+    driver.command(f"CURR {current}")
+
+
+def source_load_current_get(driver: TMInstrument):
+    """
+    The query form of this command gets the set current value of the power supply/load.
+    """
+    return driver.query(f"CURR?")
+
+
+def source_current_limit_pos_set(driver: TMInstrument, limit):
+    """
+    This command sets the positive current limit value of the power supply.
+    """
+    # TODO: range check
+    limit = get_float(limit)
+    driver.command(f"CURR:LIM:POS {limit}")
+
+
+def source_current_limit_pos_get(driver: TMInstrument):
+    """
+    This command gets the positive current limit value of the power supply.
+    """
+    return driver.query(f"CURR:LIM:POS?")
+
+
+def source_current_limit_neg_set(driver: TMInstrument, limit):
+    """
+    This command sets negative current limit value of power supply.
+    """
+    # TODO: range check
+    limit = get_float(limit)
+    driver.command(f"CURR:LIM:NEG {limit}")
+
+
+def source_current_limit_neg_get(driver: TMInstrument):
+    """
+    This command Gets negative current limit value of power supply.
+    """
+    return driver.query(f"CURR:LIM:NEG?")
+
+
+def source_load_oc_protection_set(driver: TMInstrument, level):
+    """
+    This command sets the over-current limit of the power supply/load.
+    """
+    # TODO: range check
+    level = get_float(level)
+    driver.command(f"CURR:PROT {level}")
+
+
+def source_load_oc_protection_get(driver: TMInstrument):
+    """
+    This command gets the over-current limit of the power supply/load.
+    """
+    return driver.query(f"CURR:PROT?")
+
+
+def source_load_oc_protection_delay_set(driver: TMInstrument, delay):
+    """
+    This command sets the over-current delay time of the power supply/load.
+    """
+    # TODO: range check
+    delay = get_float(delay)
+    driver.command(f"CURR:PROT:DEL {delay}")
+
+
+def source_load_oc_protection_delay_get(driver: TMInstrument):
+    """
+    This command gets the over-current delay time of the power supply/load.
+    """
+    return driver.query(f"CURR:PROT:DEL?")
+
+
+def source_load_oc_protection_state_set(driver: TMInstrument, state):
+    """
+    This command enables or disables the over-current function.
+    """
+    state = get_bool(state)
+    driver.command(f"CURR:PROT:STAT {'ON' if state else 'OFF'}")
+
+
+def source_load_oc_protection_state_get(driver: TMInstrument):
+    """
+    This command returns the state the over-current function.
+    """
+    return driver.query(f"CURR:PROT:STAT?")
+
+
+def source_voltage_set(driver: TMInstrument, voltage):
+    """
+    This command sets the voltage value of the power supply.
+    """
+    voltage = get_float(voltage)
+    driver.command(f"VOLT {voltage}")
+
+
+def source_voltage_get(driver: TMInstrument):
+    """
+    This command gets the voltage value of the power supply.
+    """
+    return driver.query(f"VOLT?")
+
+
+# Chapter 12 Load Commands
+# some commands are shared with the source subsystem
+
+
+def load_resistance_set(driver: TMInstrument, resistance):
+    """
+    This command sets the resistance value under CR mode.
+    """
+    resistance = get_float(resistance)
+    driver.command(f"RES {resistance}")
+
+
+def load_resistance_get(driver: TMInstrument):
+    """
+    This command gets the resistance value under CR mode.
+    """
+    return driver.query(f"RES?")
+
+
+def load_volt_set(driver: TMInstrument, voltage):
+    """
+    This command sets the input voltage value under CV mode.
+    """
+    voltage = get_float(voltage)
+    driver.command(f"VOLT {voltage}")
+
+
+def load_volt_get(driver: TMInstrument):
+    """
+    This command gets the input voltage value under CV mode.
+    """
+    return driver.query(f"VOLT?")
+
+
+# Chapter 15 Battery Commands
+
+
+def battery_mode_set(driver: TMInstrument, mode: str):
+    """
+    This command is used to set the mode of battery test: charging or discharging.
+    Syntax
+        BATTery:MODE <CHARge|DISCharge>
+    Arguments
+        CHARge|DISCharge
+    """
+    mode = get_battery_mode(mode)
+    driver.command(f"BATTery:MODE {mode}")
+
+
+def battery_mode_get(driver: TMInstrument):
+    """
+    This command is used to get the mode of battery test: charging or discharging.
+    Syntax
+        BATTery:MODE?
+    """
+    return driver.query(f"BATTery:MODE?")
+
+
+def battery_charge_voltage_set(driver: TMInstrument, voltage):
+    """
+    This command is used to set the battery charging voltage value.
+    Syntax
+                BATTery:CHARge:VOLTage <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    """
+    voltage = get_float(voltage)
+    driver.command(f"BATTery:CHARge:VOLTage {voltage}")
+
+
+def battery_charge_voltage_get(driver: TMInstrument):
+    """
+    This command is used to set the battery charging voltage value.
+    Query syntax
+                BATTery:CHARge:VOLTage? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:CHARge:VOLTage?")
+
+
+def battery_charge_current_set(driver: TMInstrument, current):
+    """
+    This command is used to set the battery charging current value.
+    Syntax
+                BATTery:CHARge:CURRent <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    Example
+                BATT:CHAR:CURR 3.0
+    """
+    current = get_float(current)
+    driver.command(f"BATTery:CHARge:CURRent {current}")
+
+
+def battery_charge_current_get(driver: TMInstrument):
+    """
+    This command is used to set the battery charging current value.
+    Query syntax
+                BATTery:CHARge:CURRent? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:CHARge:CURRent?")
+
+
+def battery_discharge_voltage_set(driver: TMInstrument, voltage):
+    """
+    This command is used to set the battery discharge voltage value.
+    Syntax
+                BATTery:DISCharge:VOLTage <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    """
+    voltage = get_float(voltage)
+    driver.command(f"BATTery:DISCharge:VOLTage {voltage}")
+
+
+def battery_discharge_voltage_get(driver: TMInstrument):
+    """
+    This command is used to set the battery discharge voltage value.
+    Query syntax
+                BATTery:DISCharge:VOLTage? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:DISCharge:VOLTage?")
+
+
+def battery_discharge_current_set(driver: TMInstrument, current):
+    """
+    This command is used to set the battery discharge current value.
+    Syntax
+                BATTery:DISCharge:CURRent <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    Example
+                BATT:DISC:CURR 3.0
+    """
+    current = get_float(current)
+    driver.command(f"BATTery:DISCharge:CURRent {current}")
+
+
+def battery_discharge_current_get(driver: TMInstrument):
+    """
+    This command is used to set the battery discharge current value.
+    Query syntax
+                BATTery:DISCharge:CURRent? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:DISCharge:CURRent?")
+
+
+def battery_stop_voltage_set(driver: TMInstrument, voltage):
+    """
+    This command is used to set the voltage value for the battery test cutoff.
+    Syntax
+                BATTery:STOP:VOLTage <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    """
+    voltage = get_float(voltage)
+    driver.command(f"BATTery:STOP:VOLTage {voltage}")
+
+
+def battery_stop_voltage_get(driver: TMInstrument):
+    """
+    This command is used to set the voltage value for the battery test cutoff.
+    Query syntax
+                BATTery:STOP:VOLTage? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:STOP:VOLTage?")
+
+
+def battery_stop_current_set(driver: TMInstrument, current):
+    """
+    This command is used to set the current value of the battery test cutoff.
+    Syntax
+                BATTery:STOP:CURRent <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    """
+    current = get_float(current)
+    driver.command(f"BATTery:STOP:CURRent {current}")
+
+
+def battery_stop_current_get(driver: TMInstrument):
+    """
+    This command is used to set the current value of the battery test cutoff.
+    Query syntax
+                BATTery:STOP:CURRent? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:STOP:CURRent?")
+
+
+def battery_stop_capacity_set(driver: TMInstrument, capacity):
+    """
+    This command is used to set the capacitance value of the battery test cutoff.
+    Syntax
+                BATTery:STOP:CAPacity <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    """
+    capacity = get_float(capacity)
+    driver.command(f"BATTery:STOP:CAPacity {capacity}")
+
+
+def battery_stop_capacity_get(driver: TMInstrument):
+    """
+    This command is used to set the capacitance value of the battery test cutoff.
+    Query syntax
+                BATTery:STOP:CAPacity? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:STOP:CAPacity?")
+
+
+def battery_stop_time_set(driver: TMInstrument, time):
+    """
+    This command is used to set the battery test cutoff time.
+    Syntax
+                BATTery:STOP:TIME <NRf+>
+    Arguments
+                <MINimum-MAXimum|MINimum|MAXimum>
+    Example
+                BATT:SHUT:TIME 3.0
+    Query syntax
+                BATTery:STOP:TIME? [MINimum|MAXimum]
+    """
+    time = get_float(time)
+    driver.command(f"BATTery:STOP:TIME {time}")
+
+
+def battery_stop_time_get(driver: TMInstrument):
+    """
+    This command is used to set the battery test cutoff time.
+    Query syntax
+                BATTery:STOP:TIME? [MINimum|MAXimum]
+    """
+    return driver.query(f"BATTery:STOP:TIME?")
+
+
+def battery_state_set(driver: TMInstrument, state):
+    """
+    This command enables or disables the battery function.
+    Syntax
+                BATTery[:STATe]
+    Arguments
+                <0|1|OFF|ON>
+    """
+    state = get_bool(state)
+    driver.command(f"BATT {'ON' if state else 'OFF'}")
+
+
+def battery_state_get(driver: TMInstrument):
+    """
+    This command enables or disables the battery function.
+    Query syntax
+                BATTery[:STATe]?
+    """
+    return driver.query(f"BATT?")
+
+
+def battery_save_to_memory(driver: TMInstrument, memory):
+    """
+    This command saves the present battery test file into the specified memory.
+    Syntax
+                BATTery:SAVE <BANK>
+    Arguments
+                <1-10>
+    Example
+                BATT:SAV 1
+    """
+    memory = get_int(memory)
+    if 1 <= memory and memory <= 10:
+        driver.command(f"BATT:SAV {memory}")
+    else:
+        raise ValueError(f"Invalid memory ID {memory}. Valid syntax memory ID is form 1 to 10.")
+
+
+def battery_load_from_memory(driver: TMInstrument, memory):
+    """
+    This command recalls the battery test file you saved in the specified memory location.
+    Syntax
+                BATTery:REC <BANK>
+    Arguments
+                <1-10>
+    Example
+                BATT:REC 1
+    """
+    memory = get_int(memory)
+    if 1 <= memory and memory <= 10:
+        driver.command(f"BATT:REC {memory}")
+    else:
+        raise ValueError(f"Invalid memory ID {memory}. Valid syntax memory ID is form 1 to 10.")
+
+
+def battery_reset(driver: TMInstrument):
+    """
+    This command resets the running state of the list program to initial state.
+    Syntax
+                [SOURce:]BATTery:RESet
+    Arguments
+                None
+    """
+    driver.command(f"BATT:RES")

--- a/labgrid/driver/tminstr/rigol_dp832.py
+++ b/labgrid/driver/tminstr/rigol_dp832.py
@@ -1,0 +1,70 @@
+from labgrid.driver.tminstrument import TMInstrument
+
+CHANNEL_LIST = [1, 2, 3]
+VOLTAGE_UPPER_LIM = 32  # V
+VOLTAGE_LOWER_LIM = 0  # V
+CURRENT_UPPER_LIM = 3.2  # A
+CURRENT_LOWER_LIM = 0  # A
+
+
+def check_channel_number(channel):
+    if not int(channel) in CHANNEL_LIST:
+        raise ValueError(
+            f"Channel index {channel} is out of expected range. For Rigol DP832 must be from list {CHANNEL_LIST}!"
+        )
+
+
+def check_voltage_range(value):
+    if not (VOLTAGE_LOWER_LIM <= int(value) and int(value) <= VOLTAGE_UPPER_LIM):
+        raise ValueError(
+            f"Voltage is out of expected range. For Rigol DP832 must between {VOLTAGE_LOWER_LIM} V and {VOLTAGE_UPPER_LIM} V!"
+        )
+
+
+def check_current_range(value):
+    if not (CURRENT_LOWER_LIM <= int(value) and int(value) <= CURRENT_UPPER_LIM):
+        raise ValueError(
+            f"Current is out of expected range. For Rigol DP832 must between {CURRENT_LOWER_LIM} V and {VOLTAGE_UPPER_LIM} V!"
+        )
+
+
+def activate(driver: TMInstrument, state, channel):
+    check_channel_number(channel)
+    driver.command(":OUTP CH{},{}".format(channel, "ON" if state else "OFF"))
+
+
+def voltage_set(driver: TMInstrument, value, channel):
+    check_channel_number(channel)
+    check_voltage_range(value)
+    driver.command(f":SOUR{channel}:VOLT {value}")
+
+
+def voltage_get(driver: TMInstrument, channel):
+    check_channel_number(channel)
+    return driver.query(f":MEAS:VOLT? CH{channel}")
+
+
+def voltage_preset_get(driver: TMInstrument, channel):
+    check_channel_number(channel)
+    return driver.query(f":SOUR{channel}:VOLT?")
+
+
+def current_set(driver: TMInstrument, value, channel):
+    check_channel_number(channel)
+    check_current_range(value)
+    driver.command(f":SOUR{channel}:CURR {value}")
+
+
+def current_get(driver: TMInstrument, channel):
+    check_channel_number(channel)
+    return driver.query(f":MEAS:CURR? CH{channel}")
+
+
+def current_preset_get(driver: TMInstrument, channel):
+    check_channel_number(channel)
+    return driver.query(f":SOUR{channel}:CURR?")
+
+
+def state_get(driver: TMInstrument, channel):
+    check_channel_number(channel)
+    return driver.query(f":OUTP? CH{channel}")

--- a/labgrid/driver/tminstr/rnd320kd3305P.py
+++ b/labgrid/driver/tminstr/rnd320kd3305P.py
@@ -1,0 +1,79 @@
+from labgrid.driver.tminstrument import TMInstrument
+
+CHANNEL_LIST = [1, 2]
+VOLTAGE_UPPER_LIM = 30  # V
+VOLTAGE_LOWER_LIM = 0  # V
+CURRENT_UPPER_LIM = 5  # A
+CURRENT_LOWER_LIM = 0  # A
+
+
+def check_channel_number(channel):
+    if not int(channel) in CHANNEL_LIST:
+        raise ValueError(
+            f"Channel index {channel} is out of expected range. For RND320-KD3305P must be from list {CHANNEL_LIST}!"
+        )
+
+
+def check_voltage_range(value):
+    if not (VOLTAGE_LOWER_LIM <= value and value <= VOLTAGE_UPPER_LIM):
+        raise ValueError(
+            f"Voltage is out of expected range. For RND320-KD3305P must between {VOLTAGE_LOWER_LIM} V and {VOLTAGE_UPPER_LIM} V!"
+        )
+
+
+def check_current_range(value):
+    if not (CURRENT_LOWER_LIM <= value and value <= CURRENT_UPPER_LIM):
+        raise ValueError(
+            f"Current is out of expected range. For RND320-KD3305P must between {CURRENT_LOWER_LIM} V and {VOLTAGE_UPPER_LIM} V!"
+        )
+
+
+def lock_front_panel(driver: TMInstrument, state: bool):
+    driver.command(f"LOCK{1 if state else 0}")
+
+
+def current_set(driver: TMInstrument, value: float, channel: int):
+    check_channel_number(channel)
+    check_current_range(value)
+    driver.command(f"ISET{channel}:{value}")
+
+
+def current_preset_get(driver: TMInstrument, channel: int):
+    check_channel_number(channel)
+    return driver.command(f"ISET{channel}?")
+
+
+def current_get(driver: TMInstrument, channel: int):
+    check_channel_number(channel)
+    return driver.command(f"IOUT{channel}?")
+
+
+def voltage_set(driver: TMInstrument, value: float, channel: int):
+    check_channel_number(channel)
+    check_voltage_range(value)
+    driver.command(f"VSET{channel}:{value}")
+
+
+def voltage_preset_get(driver: TMInstrument, channel: int):
+    check_channel_number(channel)
+    return driver.command(f"VSET{channel}?")
+
+
+def voltage_get(driver: TMInstrument, channel: int):
+    check_channel_number(channel)
+    return driver.query(f"VOUT{channel}?")
+
+
+def activate(driver: TMInstrument, state: bool, channel: int):
+    check_channel_number(channel)
+    driver.command(f":OUT{channel}:{1 if state else 0}")
+
+
+def state_get(driver: TMInstrument, channel: int):
+    check_channel_number(channel)
+    status = driver.query("STATUS?")
+    value = int(status.encode().hex())
+    if int(channel) == 1:
+        return (value >> 6) & 0x01
+    elif int(channel) == 2:
+        return (value >> 7) & 0x01

--- a/labgrid/driver/tminstr/scpi_arg.py
+++ b/labgrid/driver/tminstr/scpi_arg.py
@@ -1,0 +1,73 @@
+import ipaddress
+
+
+def get_bool(arg: str) -> int:
+    if "0" in arg or "False" in arg or "OFF" in arg:
+        return 0
+    elif "1" in arg or "True" in arg or "ON" in arg:
+        return 1
+    else:
+        raise ValueError(f"Wrong argument {arg}! 0/OFF/False or 1/ON/True is expected.")
+
+
+def get_int(arg: str) -> int:
+    try:
+        i = int(arg)
+    except ValueError as e:
+        raise ValueError(f"Wrong argument {arg}! Integer is expected.") from e
+    return i
+
+
+def get_float(arg: str) -> float | str:
+    value = arg.strip().upper()
+
+    if value in ("MIN", "MINIMUM"):
+        return "MIN"
+    elif value in ("MAX", "MAXIMUM"):
+        return "MAX"
+
+    normalized = arg.strip().replace(",", ".")
+    try:
+        return float(normalized)
+    except ValueError as e:
+        raise ValueError(f"Wrong argument {arg}! Float or MIN/MAX is expected.") from e
+
+
+def get_ip(arg: str) -> str:
+    try:
+        ip = ipaddress.ip_address(arg)
+    except ValueError as e:
+        raise ValueError(f"Wrong argument {arg}! Valid IP address is expected.") from e
+    return str(ip)
+
+
+def get_filter_level(arg: str) -> str:
+    value = arg.strip().upper()
+    if value in ("SLOW",):
+        return "SLOW"
+    elif value in ("MED", "MEDIUM"):
+        return "MED"
+    elif value in ("FAST",):
+        return "FAST"
+    else:
+        raise ValueError(f"Invalid filter level '{arg}'. Valid syntax is <SLOW|MEDium|FAST>.")
+
+
+def get_function_mode(arg: str) -> str:
+    value = arg.strip().upper()
+    if value in ("SOUR", "SOURCE"):
+        return "SOUR"
+    elif value in ("LOAD",):
+        return "LOAD"
+    else:
+        raise ValueError(f"Invalid mode '{arg}'. Valid syntax is SYSTem:FUNCtion <SOURce|LOAD>")
+
+
+def get_battery_mode(arg: str) -> str:
+    value = arg.strip().upper()
+    if value in ("CHAR", "CHARGE"):
+        return "CHAR"
+    elif value in ("DISC", "DISCHARGE"):
+        return "DISC"
+    else:
+        raise ValueError(f"Invalid battery mode '{arg}'. Valid syntax is BATTery:MODE <CHARge|DISCharge>")

--- a/labgrid/driver/tminstr/sdm3065x.py
+++ b/labgrid/driver/tminstr/sdm3065x.py
@@ -1,0 +1,112 @@
+from labgrid.driver.tminstrument import TMInstrument
+
+VOLTAGE_RANGES = ["AUTO", "MIN", "MAX", "200mV", "2V", "20V", "200V", "1000V", "750V"]
+CURRENT_RANGES = ["AUTO", "MIN", "MAX", "200uA", "2mA", "20mA", "2A", "10A"]
+RESISTANCE_RANGES = ["AUTO", "MIN", "MAX"]
+CAPACITANCE_RANGES = ["AUTO", "MIN", "MAX", "2nF", "20nF", "200nF", "2uF ", "20uF", "200uF", "2mF", "20mF", "100mF"]
+PROBE_TYPES = ["RTD", "THER"]
+RTD_TYPES = ["PT100"]
+THC_TYPES = ["BITS90", "EITS90", "JITS90", "KITS90", "NITS90", "RITS90", "SITS90", "TITS90", "DEFault", "DEF"]
+
+
+def check_voltage_range(value: str):
+    if value not in VOLTAGE_RANGES:
+        raise ValueError(f"Invalid range '{value}'. Must be one of: {VOLTAGE_RANGES}")
+
+
+def check_current_range(value: str):
+    if value not in CURRENT_RANGES:
+        raise ValueError(f"Invalid range '{value}'. Must be one of: {CURRENT_RANGES}")
+
+
+def check_resistance_range(value: str):
+    if value not in RESISTANCE_RANGES:
+        raise ValueError(f"Invalid range '{value}'. Must be one of: {RESISTANCE_RANGES}")
+
+
+def check_capacitance_range(value: str):
+    if value not in CAPACITANCE_RANGES:
+        raise ValueError(f"Invalid range '{value}'. Must be one of: {CAPACITANCE_RANGES}")
+
+
+def check_temperature(probe_type: str, type: str):
+    if probe_type not in PROBE_TYPES:
+        raise ValueError(f"Invalid range '{probe_type}'. Must be one of: {PROBE_TYPES}")
+    if probe_type == "RTD":
+        if type not in RTD_TYPES:
+            raise ValueError(f"Invalid sensor type '{type}'. Must be one of: {RTD_TYPES}")
+    if probe_type == "THER":
+        if type not in THC_TYPES:
+            raise ValueError(f"Invalid sensor type '{type}'. Must be one of: {THC_TYPES}")
+
+
+def measure_voltage_dc(dmm: TMInstrument, range: str = "AUTO"):
+    check_voltage_range(range)
+    return dmm.query(f":MEASure:VOLTage:DC? {range}")
+
+
+def measure_voltage_ac(dmm: TMInstrument, range: str = "AUTO"):
+    check_voltage_range(range)
+    return dmm.query(f":MEASure:VOLTage:AC? {range}")
+
+
+def measure_current_dc(dmm: TMInstrument, range: str = "AUTO"):
+    check_current_range(range)
+    return dmm.query(f":MEASure:CURRent:DC? {range}")
+
+
+def measure_current_ac(dmm: TMInstrument, range: str = "AUTO"):
+    check_current_range(range)
+    return dmm.query(f":MEASure:CURRent:AC? {range}")
+
+
+def measure_resistance(dmm: TMInstrument, range: str = "AUTO"):
+    check_resistance_range(range)
+    return dmm.query(f":MEASure:RESistance? {range}")
+
+
+def measure_resistance_4wire(dmm: TMInstrument, range: str = "AUTO"):
+    check_resistance_range(range)
+    return dmm.query(f":MEASure:FRESistance? {range}")
+
+
+def measure_frequency(dmm: TMInstrument):
+    return dmm.query(":MEASure:FREQuency?")
+
+
+def measure_period(dmm: TMInstrument):
+    return dmm.query(":MEASure:PERiod?")
+
+
+def measure_capacitance(dmm: TMInstrument, range: str = "AUTO"):
+    check_capacitance_range(range)
+    return dmm.query(f":MEASure:CAPacitance? {range}")
+
+
+def measure_diode(dmm: TMInstrument):
+    return dmm.query(":MEASure:DIODe?")
+
+
+def measure_continuity(dmm: TMInstrument):
+    return dmm.query(":MEASure:CONTinuity?")
+
+
+def measure_temperature(dmm: TMInstrument, probe_type: str = "RTD", sensor_type: str = "PT100"):
+    check_temperature(probe_type, sensor_type)
+    return dmm.query(f":MEASure:TEMPerature? {probe_type},{sensor_type}")
+
+
+def lan_get_ip_address(dmm: TMInstrument):
+    return dmm.query(":SYSTem:COMMunicate:LAN:IPADdress?")
+
+
+def lan_set_ip_address(dmm: TMInstrument, ip_address: str):
+    dmm.command(f':SYSTem:COMMunicate:LAN:IPADdress "{ip_address}"')
+
+
+def lan_get_subnet_mask(dmm: TMInstrument):
+    return dmm.query(":SYSTem:COMMunicate:LAN:SMASk?")
+
+
+def lan_set_subnet_mask(dmm: TMInstrument, mask: str):
+    dmm.command(f':SYSTem:COMMunicate:LAN:SMASk "{mask}"')

--- a/labgrid/driver/tminstrument.py
+++ b/labgrid/driver/tminstrument.py
@@ -1,0 +1,190 @@
+import inspect
+import logging
+from importlib import import_module
+from time import sleep
+
+import attr
+
+from ..factory import target_factory
+from ..protocol import PowerProtocol
+from ..step import step
+from .common import Driver
+from .powerdriver import PowerResetMixin
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class TMInstrument(Driver):
+    """
+    This driver provides a common interface for TMC SCPI compatible instruments.
+
+    Args:
+        bindings (dict): driver to use with test and measurement instrument
+
+    TODO: Create a common base abstract (aka protocol) class for VISA based instruments
+    """
+
+    bindings = {"inst": {"PyVISADriver", "USBTMCDriver"}}
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self._backend = None
+        # Mapping of known instruments to their backend module
+        self.instruments_backend = {
+        }
+
+    @Driver.check_active
+    def command(self, cmd):
+        self.inst.command(cmd)
+
+    @Driver.check_active
+    def query(self, cmd):
+        return self.inst.query(cmd)
+
+    @Driver.check_active
+    def identify(self):
+        return self.inst.identify()
+
+    @Driver.check_active
+    def clear_status(self):
+        self.inst.command("*CLS")
+
+    @Driver.check_active
+    def reset_device(self):
+        self.inst.command("*RST")
+
+    @Driver.check_active
+    def operation_complete(self):
+        self.inst.command("*OPC")
+
+    @Driver.check_active
+    def is_operation_complete(self):
+        return self.inst.query("*OPC?")
+
+    @Driver.check_active
+    def wait_to_continue(self):
+        self.inst.command("*WAI")
+
+    @property
+    def _backend_get(self):
+        if self._backend is None:
+            model = self.identify()
+            for key, value in self.instruments_backend.items():
+                if key in model:
+                    self._backend = import_module(value, __package__)
+                    break
+        return self._backend
+
+    @Driver.check_active
+    @step(args=["cmd", "args"])
+    def backend(self, cmd=None, args=[]):
+        _backend = self._backend_get
+        if _backend is None:  # Backend is not specified
+            return []
+        elif cmd is None:  # No command = return the list of implemented
+            functions = []
+            for name, func in inspect.getmembers(_backend, inspect.isfunction):
+                if inspect.getmodule(func) == _backend:
+                    functions.append([name, str(inspect.signature(func))])
+            return functions
+        else:  # Execute command from backend
+            if hasattr(_backend, cmd):
+                func = getattr(_backend, cmd)
+                return func(self, *args)
+            else:
+                raise ValueError(f"Unknown backend command: {cmd}")
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class TMInstrumentPower(TMInstrument, PowerResetMixin, PowerProtocol):
+    """
+    This driver provides a common interface for TMC SCPI compatible instruments with PowerProtocol API.
+
+    Args:
+        bindings (dict): driver to use with test and measurement instrument
+    """
+
+    bindings = TMInstrument.bindings
+
+    delay = attr.ib(
+        default=3.0, converter=attr.converters.optional(float), validator=attr.validators.instance_of(float)
+    )
+    max_voltage = attr.ib(
+        default=None,
+        converter=attr.converters.optional(float),
+        validator=attr.validators.optional(attr.validators.instance_of(float)),
+    )
+    max_current = attr.ib(
+        default=None,
+        converter=attr.converters.optional(float),
+        validator=attr.validators.optional(attr.validators.instance_of(float)),
+    )
+
+    @Driver.check_active
+    @step()
+    def on(self):
+        self.backend("activate", args=[1, self.inst.index])
+
+    @Driver.check_active
+    @step()
+    def off(self):
+        self.backend("activate", args=[0, self.inst.index])
+
+    @Driver.check_active
+    @step()
+    def cycle(self):
+        self.off()
+        sleep(self.delay)
+        self.on()
+
+    @Driver.check_active
+    @step(args=["value"])  # only for StrategyExecutor
+    def set_voltage_target(self, value=None):
+        if self.max_voltage is not None and value > self.max_voltage:
+            raise ValueError(
+                "Requested voltage target({}) is higher than configured maximum ({})".format(value, self.max_voltage)
+            )  # pylint: disable=line-too-long
+        self.backend("voltage_set", args=[value, self.inst.index])
+        logging.info(f"Target voltage set to {value} V")
+
+    @Driver.check_active
+    @step()
+    def get_voltage_target(self):
+        v = self.backend("voltage_get", args=[self.inst.index])
+        return v
+
+    @Driver.check_active
+    @step(args=["value"])
+    def set_current_limit(self, value):
+        if self.max_current is not None and value > self.max_current:
+            raise ValueError(
+                "Requested current limit ({}) is higher than configured maximum ({})".format(value, self.max_current)
+            )  # pylint: disable=line-too-long
+        self.backend("current_set", args=[value, self.inst.index])
+        logging.info(f"Current limit set to {value} A")
+
+    @Driver.check_active
+    @step()
+    def get_current_target(self):
+        c = self.backend("current_get", args=[self.inst.index])
+        return c
+
+    @Driver.check_active
+    @step()
+    def get_voltage_preset(self):
+        v = self.backend("voltage_preset_get", args=[self.inst.index])
+        return v
+
+    @Driver.check_active
+    @step()
+    def get_current_preset(self):
+        c = self.backend("current_preset_get", args=[self.inst.index])
+        return c
+
+    @Driver.check_active
+    @step()
+    def get(self):
+        state = self.backend("state_get", args=[self.inst.index])
+        state = True if "ON" in state else False
+        return state

--- a/labgrid/driver/tminstrument.py
+++ b/labgrid/driver/tminstrument.py
@@ -42,6 +42,13 @@ class TMInstrument(Driver):
         return self.inst.query(cmd)
 
     @Driver.check_active
+    def query_iterable(self, cmd, **kwargs):
+        if hasattr(self.inst, "query_iterable"):
+            return self.inst.query_iterable(cmd, **kwargs)
+        else:
+            raise NotImplementedError("query_iterable not implemented in underlying driver")
+
+    @Driver.check_active
     def identify(self):
         return self.inst.identify()
 

--- a/labgrid/driver/tminstrument.py
+++ b/labgrid/driver/tminstrument.py
@@ -31,6 +31,10 @@ class TMInstrument(Driver):
         self._backend = None
         # Mapping of known instruments to their backend module
         self.instruments_backend = {
+            "ITECH Electronics,IT-M3632": ".tminstr.it_m3632",
+            "RIGOL TECHNOLOGIES,DP832": ".tminstr.rigol_dp832",
+            "RND 320-KD3305P": ".tminstr.rnd320kd3305P",
+            "Siglent Technologies,SDM3065X-SC": ".tminstr.sdm3065x",
         }
 
     @Driver.check_active

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -974,6 +974,36 @@ class ClientSession:
         if action == "get":
             print(f"power{' ' + name if name else ''} for place {place.name} is {'on' if res else 'off'}")
 
+    def instrument(self):
+        place = self.get_acquired_place()
+        action = self.args.action
+        name = self.args.name
+        value = self.args.value
+        args = self.args.args
+        target = self._get_target(place)
+
+        drv = None
+        try:
+            drv = target.get_driver("TMInstrument", name=name)
+        except NoDriverFoundError:
+            raise UserError("target has no compatible resource available")
+
+        if action in ['query', 'command', 'query_iterable'] and value is None:
+            raise UserError(f"Action '{action}' requires a paramter value!")
+
+        if hasattr(drv, action):
+            method = getattr(drv, action)
+            if value is not None:
+                res = method(value) if not args else method(value, args)
+            else:
+                res = method()
+
+        if not isinstance(res, list):
+            res = [res]
+        for r in res:
+            print(r)
+
+
     def digital_io(self):
         place = self.get_acquired_place()
         action = self.args.action
@@ -1947,6 +1977,14 @@ def get_parser(auto_doc_mode=False) -> "argparse.ArgumentParser | AutoProgramArg
     )
     subparser.add_argument("--name", "-n", help="optional resource name")
     subparser.set_defaults(func=ClientSession.power)
+
+    subparser = subparsers.add_parser("instrument", aliases=("inst",), help="control a SCPI instrument via selected driver.")
+    subparser.add_argument("action", choices=["query", "query_iterable", "command", "identify", "clear_status", "reset", "operation_complete", "is_operation_complete", "wait_to_continue", "backend"])
+    subparser.add_argument("value", nargs="?", help="target command for set actions (query <scpi cmd>, command <scpi cmd>, backend <function> [args]).", type=str)
+    subparser.add_argument("args", nargs="*", help="optional arguments for backend command, type 'backend' for list of backend functions if available.")
+
+    subparser.add_argument("--name", "-n", help="optional resource name")
+    subparser.set_defaults(func=ClientSession.instrument)
 
     subparser = subparsers.add_parser("io", help="change (or get) a digital IO status")
     subparser.add_argument("action", choices=["high", "low", "get"], help="action")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -803,6 +803,25 @@ class YKUSHPowerPortExport(ResourceExport):
 exports["YKUSHPowerPort"] = YKUSHPowerPortExport
 
 
+@attr.s(eq=False)
+class PyVISADeviceExport(ResourceExport):
+    """ResourceExport for PyVISA devices"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        local_cls_name = self.cls
+        self.data["cls"] = f"Network{local_cls_name}"
+        from ..resource import pyvisa
+
+        local_cls = getattr(pyvisa, local_cls_name)
+        self.local = local_cls(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        return {"host": self.host, **self.local_params}
+
+
+exports["PyVISADevice"] = PyVISADeviceExport
+
 class Exporter:
     def __init__(self, config) -> None:
         """Set up internal datastructures on successful connection:

--- a/labgrid/resource/pyvisa.py
+++ b/labgrid/resource/pyvisa.py
@@ -1,7 +1,7 @@
 import attr
 
 from ..factory import target_factory
-from .common import Resource
+from .common import Resource, NetworkResource
 
 
 @target_factory.reg_resource
@@ -11,10 +11,24 @@ class PyVISADevice(Resource):
 
     Args:
         type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
-        url (str): device identifier on selected resource, e.g. <ip> for TCPIP resource
+        url (str, default=''): optional device identifier on selected resource, e.g. <ip> for TCPIP resource
         backend (str, default=''): Visa library backend, e.g. '@sim' for pyvisa-sim backend
     """
 
     type = attr.ib(validator=attr.validators.instance_of(str))
-    url = attr.ib(validator=attr.validators.instance_of(str))
+    url = attr.ib(default="", validator=attr.validators.instance_of(str))
+    backend = attr.ib(default="", validator=attr.validators.instance_of(str))
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkPyVISADevice(NetworkResource):
+    """The NetworkPyVISADevice describes a remote test stimuli device controlled  with PyVISA
+
+    Args:
+        type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
+        url (str, default=''): optional device identifier on selected resource, e.g. <ip> for TCPIP resource
+        backend (str, default=''): Visa library backend, e.g. '@sim' for pyvisa-sim backend
+    """
+    type = attr.ib(validator=attr.validators.instance_of(str))
+    url = attr.ib(default="", validator=attr.validators.instance_of(str))
     backend = attr.ib(default="", validator=attr.validators.instance_of(str))

--- a/labgrid/resource/pyvisa.py
+++ b/labgrid/resource/pyvisa.py
@@ -12,11 +12,13 @@ class PyVISADevice(Resource):
     Args:
         type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
         url (str, default=''): optional device identifier on selected resource, e.g. <ip> for TCPIP resource
+        resource (str, default='INSTR'): resource type, INSTR, SOCKET and RAW are currently supported
         backend (str, default=''): Visa library backend, e.g. '@sim' for pyvisa-sim backend
     """
 
     type = attr.ib(validator=attr.validators.instance_of(str))
     url = attr.ib(default="", validator=attr.validators.instance_of(str))
+    resource = attr.ib(default="INSTR", validator=attr.validators.in_(("INSTR", "SOCKET", "RAW")))
     backend = attr.ib(default="", validator=attr.validators.instance_of(str))
 
 @target_factory.reg_resource
@@ -27,8 +29,10 @@ class NetworkPyVISADevice(NetworkResource):
     Args:
         type (str): device resource type following the pyVISA resource syntax, e.g. ASRL, TCPIP...
         url (str, default=''): optional device identifier on selected resource, e.g. <ip> for TCPIP resource
+        resource (str, default='INSTR'): resource type, e.g. INSTR, SOCKET and RAW are currently supported
         backend (str, default=''): Visa library backend, e.g. '@sim' for pyvisa-sim backend
     """
     type = attr.ib(validator=attr.validators.instance_of(str))
     url = attr.ib(default="", validator=attr.validators.instance_of(str))
+    resource = attr.ib(default="INSTR", validator=attr.validators.in_(("INSTR", "SOCKET", "RAW"))) 
     backend = attr.ib(default="", validator=attr.validators.instance_of(str))

--- a/labgrid/util/agents/visa_instrument.py
+++ b/labgrid/util/agents/visa_instrument.py
@@ -1,0 +1,53 @@
+"""
+This module implements the communication with TMC SCPI compatible instrument using py-visa driver.
+
+Supported modules:
+
+- All VISA compatible instruments supported by py-visa
+
+Supported Functionality:
+
+- Command, Query, Identify
+"""
+
+from importlib import import_module
+
+
+class VISAInstrument:
+    def __init__(self, device_identifier, backend):
+        try:
+            _py_pyvisa_module = import_module('pyvisa')
+        except ModuleNotFoundError as e:
+            raise ModuleNotFoundError("pyvisa module not found, please install it") from e
+        else:
+            _pyvisa_resource_manager = _py_pyvisa_module.ResourceManager(backend)
+            if _pyvisa_resource_manager is None:
+                raise ValueError("pyVISA backend not found")
+            self._pyvisa_device = _pyvisa_resource_manager.open_resource(device_identifier)
+            if self._pyvisa_device is None:
+                raise ValueError("pyVISA device not found")
+
+    def write(self, cmd):
+        self._pyvisa_device.write(cmd)
+
+    def query(self, cmd):
+        return self._pyvisa_device.query(cmd)
+
+    def __del__(self):
+        if hasattr(self, '_pyvisa_device') and self._pyvisa_device is not None:
+            self._pyvisa_device.close()
+            self._pyvisa_device = None
+
+
+def handle_write(device_identifier, backend, cmd):
+    visa_inst = VISAInstrument(device_identifier, backend)
+    visa_inst.write(cmd)
+
+def handle_query(device_identifier, backend, cmd):
+    visa_inst = VISAInstrument(device_identifier, backend)
+    return visa_inst.query(cmd)
+
+methods = {
+    "write": handle_write,
+    "query": handle_query,
+}

--- a/labgrid/util/agents/visa_instrument.py
+++ b/labgrid/util/agents/visa_instrument.py
@@ -11,24 +11,21 @@ Supported Functionality:
 """
 
 from importlib import import_module
+from importlib.util import find_spec
 
 
 class VISAInstrument:
     def __init__(self, device_identifier, backend, timeout):
-        try:
-            _py_pyvisa_module = import_module('pyvisa')
-        except ModuleNotFoundError as e:
-            raise ModuleNotFoundError("pyvisa module not found, please install it") from e
-        else:
-            _pyvisa_resource_manager = _py_pyvisa_module.ResourceManager(backend)
-            if _pyvisa_resource_manager is None:
-                raise ValueError("pyVISA backend not found")
-            self._pyvisa_device = _pyvisa_resource_manager.open_resource(device_identifier)
-            if 'SOCKET' in device_identifier:
-                self._pyvisa_device.read_termination = '\n'
-                self._pyvisa_device.write_termination = '\n'
-            if self._pyvisa_device is None:
-                raise ValueError("pyVISA device not found")
+        if not find_spec("pyvisa"):
+            raise ModuleNotFoundError("pyvisa module not found, please install it")
+		
+        _py_pyvisa_module = import_module('pyvisa')
+        _pyvisa_resource_manager = _py_pyvisa_module.ResourceManager(backend)
+        if _pyvisa_resource_manager is None:
+            raise ValueError("pyVISA backend not found")
+        self._pyvisa_device = _pyvisa_resource_manager.open_resource(device_identifier)
+        if self._pyvisa_device is None:
+            raise ValueError("pyVISA device not found")
             try:
                 self._pyvisa_device.clear()
             except _py_pyvisa_module.errors.VisaIOError as e:

--- a/labgrid/util/agents/visa_instrument.py
+++ b/labgrid/util/agents/visa_instrument.py
@@ -14,7 +14,7 @@ from importlib import import_module
 
 
 class VISAInstrument:
-    def __init__(self, device_identifier, backend):
+    def __init__(self, device_identifier, backend, timeout):
         try:
             _py_pyvisa_module = import_module('pyvisa')
         except ModuleNotFoundError as e:
@@ -26,6 +26,7 @@ class VISAInstrument:
             self._pyvisa_device = _pyvisa_resource_manager.open_resource(device_identifier)
             if self._pyvisa_device is None:
                 raise ValueError("pyVISA device not found")
+            self._pyvisa_device.timeout = timeout
 
     def write(self, cmd):
         self._pyvisa_device.write(cmd)
@@ -39,12 +40,12 @@ class VISAInstrument:
             self._pyvisa_device = None
 
 
-def handle_write(device_identifier, backend, cmd):
-    visa_inst = VISAInstrument(device_identifier, backend)
+def handle_write(device_identifier, backend, cmd, timeout):
+    visa_inst = VISAInstrument(device_identifier, backend, timeout)
     visa_inst.write(cmd)
 
-def handle_query(device_identifier, backend, cmd):
-    visa_inst = VISAInstrument(device_identifier, backend)
+def handle_query(device_identifier, backend, cmd, timeout):
+    visa_inst = VISAInstrument(device_identifier, backend, timeout)
     return visa_inst.query(cmd)
 
 methods = {

--- a/labgrid/util/agents/visa_instrument.py
+++ b/labgrid/util/agents/visa_instrument.py
@@ -24,8 +24,19 @@ class VISAInstrument:
             if _pyvisa_resource_manager is None:
                 raise ValueError("pyVISA backend not found")
             self._pyvisa_device = _pyvisa_resource_manager.open_resource(device_identifier)
+            if 'SOCKET' in device_identifier:
+                self._pyvisa_device.read_termination = '\n'
+                self._pyvisa_device.write_termination = '\n'
             if self._pyvisa_device is None:
                 raise ValueError("pyVISA device not found")
+            try:
+                self._pyvisa_device.clear()
+            except _py_pyvisa_module.errors.VisaIOError as e:
+                if 'VI_ERROR_NSUP_OPER' in e.abbreviation:
+                    # Unsupported, just skip it.
+                    pass
+                else:
+                    raise e
             self._pyvisa_device.timeout = timeout
 
     def write(self, cmd):

--- a/labgrid/util/agents/visa_instrument.py
+++ b/labgrid/util/agents/visa_instrument.py
@@ -45,6 +45,13 @@ class VISAInstrument:
     def query(self, cmd):
         return self._pyvisa_device.query(cmd)
 
+    def query_iterable(self, cmd, is_ascii=True, **kwargs):
+        return (
+            self._pyvisa_device.query_ascii_values(cmd, **kwargs)
+            if is_ascii
+            else self._pyvisa_device.query_binary_values(cmd, **kwargs)
+        )
+
     def __del__(self):
         if hasattr(self, '_pyvisa_device') and self._pyvisa_device is not None:
             self._pyvisa_device.close()
@@ -55,9 +62,9 @@ def handle_write(device_identifier, backend, cmd, timeout):
     visa_inst = VISAInstrument(device_identifier, backend, timeout)
     visa_inst.write(cmd)
 
-def handle_query(device_identifier, backend, cmd, timeout):
+def handle_query(device_identifier, backend, cmd, timeout, iterable=False, is_ascii=True, **kwargs):
     visa_inst = VISAInstrument(device_identifier, backend, timeout)
-    return visa_inst.query(cmd)
+    return visa_inst.query(cmd) if not iterable else visa_inst.query_iterable(cmd, is_ascii, **kwargs)
 
 methods = {
     "write": handle_write,


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

Main purpose:

- Extend generic support for T&M instruments (SCPI based test & measurement equipment) using already existing pyvisa driver with appropriate backend (e.g. pyvisa-py)
- Add pyvisa remote access by introducing an agent wrapper module.
- Extend pyvisa driver with the option to select specific resource type (e.g. INSTR/SOCKET).
- Add remote client support.
- Introduce the tminstrument driver as high-level wrapper for low-level drivers, (pyvisa, usbtmc), with PowerProtocol support. Potentially replacing the standalone usbtmc driver.
- Add backend support for various laboratory instruments, e.g. convenient command wrapper for SCPI commands.

The implementation was tested only by using it with devices on our lab environment, both locally and remotely for following interfaces:

- TCPIP INSTR
- TCPIP SOCKET
- ASRL INSTR
- USB INSTR

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
