### PR TITLE
driver/power/poe_netgear_plus: Respect dynamic ports

### DIFF
--- a/labgrid/driver/power/poe_netgear_plus.py
+++ b/labgrid/driver/power/poe_netgear_plus.py
@@ -26,7 +26,7 @@ from py_netgear_plus import NetgearSwitchConnector
 from ..exception import ExecutionError
 
 
-def _get_hostname_and_password(url: str) -> tuple[str, str]:
+def _get_hostname_port_and_password(url: str) -> tuple[str, int, str]:
     """Obtain credentials from url or default and return hostname and password.
 
     If no password is in the URL return "P4ssword", which fulfills  the minimal requirements from Netgear:
@@ -35,20 +35,23 @@ def _get_hostname_and_password(url: str) -> tuple[str, str]:
     - at least one lower case character
     - at least one number
 
+    If no port is in the URL, return 80.
+
     Args:
         url: A URL with an optional basic auth prefix.
 
     Returns:
-        A tuple of the hostname, and the extracted or default password
+        A tuple of the hostname, port and the extracted or default password
 
     """
     parse_result = urlparse(url)
     if parse_result.scheme != "http":
         raise ExecutionError(f"URL must start with http://, found {parse_result.scheme} for {url}.")
 
-    password = "P4ssword" if parse_result.password is None else parse_result.password
+    password = parse_result.password or "P4ssword"
+    port = parse_result.port or 80
 
-    return parse_result.hostname, password
+    return parse_result.hostname, port, password
 
 
 def power_set(host: str, _port: int, index: int, value: bool) -> None:
@@ -64,9 +67,11 @@ def power_set(host: str, _port: int, index: int, value: bool) -> None:
     index = int(index)
     netgear_port_number = index + 1
 
-    (hostname, password) = _get_hostname_and_password(host)
+    (hostname, port, password) = _get_hostname_port_and_password(host)
 
-    sw = NetgearSwitchConnector(hostname, password)
+    network_address = f"{hostname}:{port}"
+
+    sw = NetgearSwitchConnector(network_address, password)
     sw.autodetect_model()
     try:
         sw.get_login_cookie()
@@ -97,9 +102,10 @@ def power_get(host: str, _port: int, index: int) -> bool:
     index = int(index)
     netgear_port_number = index + 1
 
-    (hostname, password) = _get_hostname_and_password(host)
+    (hostname, port, password) = _get_hostname_port_and_password(host)
+    network_address = f"{hostname}:{port}"
 
-    sw = NetgearSwitchConnector(hostname, password)
+    sw = NetgearSwitchConnector(network_address, password)
     sw.autodetect_model()
     try:
         sw.get_login_cookie()

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -3,7 +3,7 @@ from urllib.parse import urlparse
 import pytest
 
 from labgrid.driver import ExecutionError
-from labgrid.driver.power.poe_netgear_plus import _get_hostname_and_password
+from labgrid.driver.power.poe_netgear_plus import _get_hostname_port_and_password
 from labgrid.resource import NetworkPowerPort, YKUSHPowerPort
 from labgrid.driver.powerdriver import (
     ExternalPowerDriver,
@@ -393,10 +393,11 @@ class TestPoeNetgearPlusPowerDriver:
         ]
     )
     def test_get_hostname_and_password(self, url: str, expected_host: str, expected_pw: str):
-        returned_host, returned_pw = _get_hostname_and_password(url)
+        returned_host, returned_port, returned_pw = _get_hostname_port_and_password(url)
         assert returned_host == expected_host
+        assert returned_port == 80
         assert returned_pw == expected_pw
 
     def test_get_hostname_and_pw_non_http_raises(self):
         with pytest.raises(ExecutionError, match="URL must start with http://"):
-            _get_hostname_and_password("no_http_protocol")
+            _get_hostname_port_and_password("no_http_protocol")


### PR DESCRIPTION
in isolated mode.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
