### PR TITLE
dockerfiles: Add statsd docker image

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -57,3 +57,13 @@ RUN apt update -q=2 && \
 VOLUME /opt/conf
 
 CMD ["/entrypoint.sh"]
+
+#
+# Coordinator statsd
+#
+FROM labgrid-base AS labgrid-coordinator-statsd
+ARG VERSION
+
+RUN pip3 install "statsd>=4.0.1"
+
+ENTRYPOINT ["/opt/labgrid/contrib/coordinator-statsd.py"]

--- a/dockerfiles/README.rst
+++ b/dockerfiles/README.rst
@@ -7,6 +7,8 @@ for the 3 different components of a Labgrid distributed infrastructure.
 - **labgrid-coordinator**
   An image with the Labgrid coordinator.
   a Labgrid coordinator instance.
+- **labgrid-coordinator-statsd**
+  An image with a statsd reporter for the Labgrid coordinator.
 - **labgrid-client**
   An image with the Labgrid client tools and pytest integration.
 - **labgrid-exporter**
@@ -27,7 +29,7 @@ Example showing how to build labgrid-client image:
 Using `BuildKit <https://docs.docker.com/develop/develop-images/build_enhancements/>`_
 is recommended to reduce build times.
 
-You can also choose to build all 3 images with the included script. The script
+You can also choose to build all images with the included script. The script
 will automatically use `docker buildx
 <https://docs.docker.com/engine/reference/commandline/buildx/>`` if available.
 
@@ -39,7 +41,6 @@ will automatically use `docker buildx
 The script supports ``podman`` as well.
 
 .. code-block:: bash
-  
    $ export DOCKER=podman
    $ ./dockerfiles/build.sh
 
@@ -77,6 +78,20 @@ so you can restart the service without losing state.
 
    $ docker run -t -p 20408:20408 -v $HOME/coordinator:/opt/coordinator \
 	 docker.io/labgrid/coordinator
+
+
+labgrid-coordinator-statsd usage
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The labgrid-coordinator-statsd image can be used to run a statsd reporter for the coordinator.
+
+The address of the statsd server and other options can be configured using parameters as passed to the ``contrib/coordinator-statsd.py`` script.
+For example, to run the statsd reporter with a coordinator at 192.168.1.42:20408:
+
+.. code-block:: bash
+
+   $ docker run -e LG_COORDINATOR=192.168.1.42:20408 docker.io/labgrid/coordinator-statsd \
+    --statsd-server=192.168.1.50
 
 
 labgrid-client usage
@@ -141,7 +156,7 @@ client:
 .. code-block:: bash
 
    $ cd dockerfiles/staging
-   $ CURRENT_UID=$(id -u):$(id -g) docker compose up -d coordinator exporter dut
+   $ CURRENT_UID=$(id -u):$(id -g) docker compose up -d coordinator coordinator-statsd exporter dut
 
 To run the smoke test just run the client:
 

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -59,7 +59,7 @@ perform_regular_build() {
 
     log_info "building for native platform only."
 
-    for t in client exporter coordinator; do
+    for t in client exporter coordinator coordinator-statsd; do
         "${docker_cmd}" build --build-arg VERSION="${version}" \
             --target labgrid-${t} -t "${IMAGE_PREFIX}${t}:${IMAGE_TAG}" -f "${script_dir}/Dockerfile" \
             "${extra_args[@]}" .
@@ -73,7 +73,7 @@ perform_docker_buildx_build() {
     version="${3}"
     extra_args=("${@:4}")
 
-    for t in client exporter coordinator; do
+    for t in client exporter coordinator coordinator-statsd; do
         "${docker_cmd}" buildx build --build-arg VERSION="${version}" \
             --target labgrid-${t} -t "${IMAGE_PREFIX}${t}:${IMAGE_TAG}" -f "${script_dir}/Dockerfile" \
             "${extra_args[@]}" .

--- a/dockerfiles/staging/docker-compose.yml
+++ b/dockerfiles/staging/docker-compose.yml
@@ -7,6 +7,11 @@ services:
     network_mode: "host"
     command: bash -c "cp /home/root/coordinator/places_example.yaml /opt/coordinator/places.yaml &&
       /usr/local/bin/labgrid-coordinator"
+  coordinator-statsd:
+    image: "${IMAGE_PREFIX:-docker.io/labgrid/}coordinator-statsd"
+    network_mode: "host"
+    depends_on:
+      - coordinator
   client:
     image: "${IMAGE_PREFIX:-docker.io/labgrid/}client"
     volumes:


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Adds a new docker image for a coordinator-statsd service, which can be used to easily run a statsd reporter for the coordinator leveraging the `contrib/coordinator-statsd.py` script.


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested

Testing included running the example in the `dockerfiles/staging` directory as well as running a locally built image in our production environment and verifying that statsd reporting still functioned as expected.