### PR TITLE
sigrokdriver: fix TypeError in stop() by passing bytes to communicate()

### DIFF
--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -175,7 +175,7 @@ class SigrokDriver(SigrokCommon):
         csv_filename = f'{os.path.splitext(self._basename)[0]}.csv'
 
         # sigrok-cli can be quit through any keypress
-        stdout, stderr = self._process.communicate(input="q")
+        stdout, stderr = self._process.communicate(input=b"q")
         self.logger.debug("stdout: %s", stdout)
         self.logger.debug("stderr: %s", stderr)
 


### PR DESCRIPTION
Popen is opened without text=True so stdin is in binary mode. communicate(input=...) must receive bytes, not str. Fixes Python 3.11+ TypeError: memoryview requires bytes, not str.

Fixes #1847

`SigrokDriver.stop()` calls `self._process.communicate(input="q")`, but
`Popen` is created without `text=True`, so stdin is in binary mode.
On Python 3.11+, this raises:
    TypeError: memoryview: a bytes-like object is required, not 'str'
Fix: pass `b"q"` instead of `"q"`.