### PR TITLE
driver: shelly_gen1: fix for Shelly Plug US Gen4

### DIFF
--- a/labgrid/driver/power/shelly_gen1.py
+++ b/labgrid/driver/power/shelly_gen1.py
@@ -6,8 +6,7 @@ NetworkPowerPort:
     index: 0
 
 Will do a GET request to http://192.168.0.42/relay/0 to get the current
-relay state, and a POST request to http://192.168.0.42/relay/0 with request
-data of 'turn=off' or 'turn=on' to change the relay state.
+relay state or set it with parameters of 'turn=off' or 'turn=on'.
 
 Also, see the official Gen 1 Device API documentation:
 https://shelly-api-docs.shelly.cloud/gen1/
@@ -22,7 +21,7 @@ import requests
 def power_set(host: str, port: int, index: int = 0, value: bool = True):
     assert not port
     turn = "on" if value else "off"
-    r = requests.post(f"{host}/relay/{index}", data={"turn": turn})
+    r = requests.get(f"{host}/relay/{index}", params={"turn": turn})
     r.raise_for_status()
 
 


### PR DESCRIPTION
POST is not supported by Shelly Plug US Gen4. Use GET instead.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
I tried shelly_gen1 driver on a Shelly Plug US Gen4 and found that this Shelly plug does not support POST. Replacing POST with GET seems working. But I don't have other Shelly plugs to test for.

<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
