### PR TITLE
flashscriptdriver: Add optional timeout

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3405,6 +3405,7 @@ Arguments:
   - script (str): optional, key in :ref:`images <labgrid-device-config-images>`
     containing the script to execute for writing of the flashable device
   - args (list of str): optional, list of arguments for flash script execution
+  - timeout (float): optional, timeout for script execution in seconds
 
 The FlashScriptDriver allows running arbitrary programs to flash a device.
 Some SoC or devices may require custom, one-off, or proprietary programs to

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -3411,6 +3411,7 @@ Arguments:
   - script (str): optional, key in :ref:`images <labgrid-device-config-images>`
     containing the script to execute for writing of the flashable device
   - args (list of str): optional, list of arguments for flash script execution
+  - timeout (float): optional, timeout for script execution in seconds
 
 The FlashScriptDriver allows running arbitrary programs to flash a device.
 Some SoC or devices may require custom, one-off, or proprietary programs to

--- a/labgrid/driver/flashscriptdriver.py
+++ b/labgrid/driver/flashscriptdriver.py
@@ -34,7 +34,7 @@ class FlashScriptDriver(Driver):
 
     @Driver.check_active
     @step(args=["script"])
-    def flash(self, script=None, args=None):
+    def flash(self, script=None, args=None, timeout=None):
         """
         Transfers and remotely executes the script
 
@@ -55,5 +55,5 @@ class FlashScriptDriver(Driver):
 
         self.logger.debug("Running command '%s'", " ".join(cmd))
         processwrapper.check_output(
-            self.device.command_prefix + cmd, print_on_silent_log=True
+            self.device.command_prefix + cmd, print_on_silent_log=True, timeout=timeout
         )

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -1,17 +1,18 @@
+import errno
 import fcntl
-import os
 import logging
+import os
 import pty
 import re
 import select
 import subprocess
-import errno
-from socket import socket, AF_INET, SOCK_STREAM
 from contextlib import closing
+from socket import AF_INET, SOCK_STREAM, socket
 
 import attr
 
 from ..step import step
+from .timeout import Timeout
 
 re_vt100 = re.compile(r"(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]")
 
@@ -40,7 +41,7 @@ class ProcessWrapper:
     loglevel = logging.INFO
 
     @step(args=['command'], result=True, tag='process')
-    def check_output(self, command, *, print_on_silent_log=False, input=None, stdin=None): # pylint: disable=redefined-builtin
+    def check_output(self, command, *, print_on_silent_log=False, input=None, stdin=None, timeout=None): # pylint: disable=redefined-builtin
         """Run a command and supply the output to callback functions"""
         logger = logging.getLogger("Process")
         res = []
@@ -81,6 +82,9 @@ class ProcessWrapper:
         write_fds = []
         if stdin_w is not None:
             write_fds.append(stdin_w)
+
+        if timeout is not None:
+            timeout = Timeout(timeout)
 
         while True:
             ready_r, ready_w, _ = select.select(read_fds, write_fds, [], 0.1)
@@ -127,6 +131,9 @@ class ProcessWrapper:
             if process.returncode is not None:
                 break
 
+            if timeout is not None and timeout.expired:
+                break
+
         if stdin_w is not None:
             os.close(stdin_w)
 
@@ -142,6 +149,11 @@ class ProcessWrapper:
 
         if print_on_silent_log and logger.getEffectiveLevel() > ProcessWrapper.loglevel:
             self.disable_print()
+
+        if timeout is not None and timeout.expired:
+            raise TimeoutError(
+                f"Timeout of {timeout.timeout} seconds exceeded while waiting for process: [{process.pid}] command: {command}"
+            )
 
         if process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode,

--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -1,17 +1,18 @@
+import errno
 import fcntl
-import os
 import logging
+import os
 import pty
 import re
 import select
 import subprocess
-import errno
-from socket import socket, AF_INET, SOCK_STREAM
 from contextlib import closing
+from socket import AF_INET, SOCK_STREAM, socket
 
 import attr
 
 from ..step import step
+from .timeout import Timeout
 
 re_vt100 = re.compile(r"(\x1b\[|\x9b)[^@-_a-z]*[@-_a-z]|\x1b[@-_a-z]")
 
@@ -40,7 +41,7 @@ class ProcessWrapper:
     loglevel = logging.INFO
 
     @step(args=['command'], result=True, tag='process')
-    def check_output(self, command, *, print_on_silent_log=False, input=None, stdin=None): # pylint: disable=redefined-builtin
+    def check_output(self, command, *, print_on_silent_log=False, input=None, stdin=None, timeout=None): # pylint: disable=redefined-builtin
         """Run a command and supply the output to callback functions"""
         logger = logging.getLogger("Process")
         res = []
@@ -81,6 +82,9 @@ class ProcessWrapper:
         write_fds = []
         if stdin_w is not None:
             write_fds.append(stdin_w)
+
+        if timeout is not None:
+            timeout = Timeout(timeout)
 
         while True:
             ready_r, ready_w, _ = select.select(read_fds, write_fds, [], 0.1)
@@ -127,6 +131,9 @@ class ProcessWrapper:
             if process.returncode is not None and len(ready_r) == 0:
                 break
 
+            if timeout is not None and timeout.expired:
+                break
+
         if stdin_w is not None:
             os.close(stdin_w)
 
@@ -142,6 +149,11 @@ class ProcessWrapper:
 
         if print_on_silent_log and logger.getEffectiveLevel() > ProcessWrapper.loglevel:
             self.disable_print()
+
+        if timeout is not None and timeout.expired:
+            raise TimeoutError(
+                f"Timeout of {timeout.timeout} seconds exceeded while waiting for process: [{process.pid}] command: {command}"
+            )
 
         if process.returncode != 0:
             raise subprocess.CalledProcessError(process.returncode,


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Adds an optional timeout for flashscriptdriver to be passed to ProcessWrapper.check_output().  This can be used to prevent processes from hanging and requiring external input to stop the session.  Testing included running flashscriptdriver on our local setup and DUT with various timeouts, including no timeout.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
