### PR TITLE
resource/udev: add ADI USB debugger IDs to USBDebugger

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -817,6 +817,14 @@ class USBDebugger(USBResource):
                          ("1366", "1024"),  # SEGGER J-Link
                          ("1366", "1051"),  # SEGGER J-Link
                          ("1366", "1061"),  # SEGGER J-Link
+                         ("064b", "0617"),  # Analog Devices ICE-1000 Emulator
+                         ("064b", "2500"),  # Analog Devices ICE-1500 Emulator
+                         ("064b", "0283"),  # Analog Devices ICE-2000 Emulator
+                         ("064b", "2503"),  # Analog Devices Onboard Debug Agent
+                         ("064b", "2504"),  # Analog Devices Onboard Debug Agent
+                         ("064b", "2507"),  # Analog Devices Onboard Debug Agent
+                         ("064b", "2508"),  # Analog Devices Onboard Debug Agent
+                         ("064b", "250A"),  # Analog Devices Onboard Debug Agent
                          ]:
             return False
 


### PR DESCRIPTION
**Description**

Recognize additional Analog Devices USB debug probes as USBDebugger resources.

Add VID/PID entries for ICE-1000, ICE-1500, ICE-2000, and Onboard Debug Agent variants so they are matched by the existing USBDebugger resource path without requiring custom local changes.

This makes ADI debugger hardware available to drivers such as OpenOCDDriver through the standard labgrid USB debugger flow.

**Checklist**
- [x] PR has been tested