### PR TITLE
HTTPVideo: Allow to specify port in URL

### DIFF
--- a/labgrid/driver/httpvideodriver.py
+++ b/labgrid/driver/httpvideodriver.py
@@ -21,9 +21,11 @@ class HTTPVideoDriver(Driver, VideoProtocol):
         return ("high", [("high", None)])
 
     @Driver.check_active
-    def stream(self, quality_hint=None):
+    def stream(self, quality_hint=None, controls=None):
         s = urlsplit(self.video.url)
-        if s.scheme == "http":
+        if s.port:
+            default_port = s.port
+        elif s.scheme == "http":
             default_port = 80
         elif s.scheme == "https":
             default_port = 443

--- a/tests/test_httpvideo.py
+++ b/tests/test_httpvideo.py
@@ -2,7 +2,17 @@ from labgrid.resource.httpvideostream import HTTPVideoStream
 from labgrid.driver.httpvideodriver import HTTPVideoDriver
 
 
-def test_ipvideo_create(target):
+def test_ipvideo_create_http(target):
     r = HTTPVideoStream(target, name=None, url="http://localhost/")
+    d = HTTPVideoDriver(target, name=None)
+    assert isinstance(d, HTTPVideoDriver)
+
+def test_ipvideo_create_https(target):
+    r = HTTPVideoStream(target, name=None, url="https://localhost/")
+    d = HTTPVideoDriver(target, name=None)
+    assert isinstance(d, HTTPVideoDriver)
+
+def test_ipvideo_create_with_port(target):
+    r = HTTPVideoStream(target, name=None, url="http://localhost:8080/")
     d = HTTPVideoDriver(target, name=None)
     assert isinstance(d, HTTPVideoDriver)


### PR DESCRIPTION
This PR fixes and improves HTTPVideoStream usage:

Fix:
- Adds dummy `controls` parameter to be compatible with other streams (used by remote/client.py in drv.stream() call)

Improvement:
- Use declared port in URL if present (e.g. `http://lab.local:8080/stream.mjpg`)