### PR TITLE
Allow `NetworkService` to be used without an explicit SSH username

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -698,6 +698,8 @@ A :any:`NetworkService` describes a remote SSH connection.
 
 The example describes a remote SSH connection to the computer
 ``example.computer`` with the username ``root``.
+If ``username`` is omitted, labgrid will let SSH resolve the username through
+the local SSH configuration or the default SSH user selection.
 Set the optional password password property to make SSH login with a password
 instead of the key file.
 
@@ -710,7 +712,7 @@ These and the sudo configuration needs to be prepared by the administrator.
 
 Arguments:
   - address (str): hostname of the remote system
-  - username (str): username used by SSH
+  - username (str, default=None): optional, username used by SSH
   - password (str, default=None): optional, password used by SSH
   - port (int, default=22): port used by SSH
 
@@ -2091,7 +2093,9 @@ Arguments:
     will explicitly use the SFTP protocol for file transfers instead of scp's default protocol
   - explicit_scp_mode (bool, default=False): if set to True, ``put()``, ``get()``, and ``scp()``
     will explicitly use the SCP protocol for file transfers instead of scp's default protocol
-  - username (str, default=username from `NetworkService`_): username used by SSH
+  - username (str, default=username from `NetworkService`_): optional, username used by SSH
+    If neither `SSHDriver`_ nor `NetworkService`_ specifies a username, SSH's
+    own username resolution is used.
   - password (str, default=password from `NetworkService`_): password used by SSH
 
 UBootDriver

--- a/labgrid/driver/sshdriver.py
+++ b/labgrid/driver/sshdriver.py
@@ -118,8 +118,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
                  "-o", "ControlPersist=300", "-o",
                  "UserKnownHostsFile=/dev/null", "-o", "StrictHostKeyChecking=no",
                  "-o", "ServerAliveInterval=15", "-MN", "-S", control.replace('%', '%%'), "-p",
-                 str(self.networkservice.port), "-l", self._get_username(),
-                 self.networkservice.address]
+                 str(self.networkservice.port)]
+        if username := self._get_username():
+            args += ["-l", username]
+        args += [self.networkservice.address]
 
         # proxy via the exporter if we have an ifname suffix
         address = self.networkservice.address
@@ -214,9 +216,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             raise ExecutionError("Keepalive no longer running")
 
         complete_cmd = [self._ssh, "-x", *self.ssh_prefix,
-                        "-p", str(self.networkservice.port), "-l", self._get_username(),
-                        self.networkservice.address
-                        ] + cmd.split(" ")
+                        "-p", str(self.networkservice.port)]
+        if username := self._get_username():
+            complete_cmd += ["-l", username]
+        complete_cmd += [self.networkservice.address] + cmd.split(" ")
         self.logger.debug("Sending command: %s", complete_cmd)
         if self.stderr_merge:
             stderr_pipe = subprocess.STDOUT
@@ -482,6 +485,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     @Driver.check_active
     @step(args=['filename', 'remotepath'])
     def put(self, filename, remotepath=''):
+        destination = f"{self.networkservice.address}:{remotepath}"
+        if username := self._get_username():
+            destination = f"{username}@{destination}"
+
         transfer_cmd = [
             self._scp,
             "-S", self._ssh,
@@ -489,7 +496,7 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
             "-P", str(self.networkservice.port),
             "-r",
             filename,
-            f"{self._get_username()}@{self.networkservice.address}:{remotepath}"
+            destination
             ]
 
         if self.explicit_sftp_mode and self._scp_supports_explicit_sftp_mode():
@@ -513,13 +520,17 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
     @Driver.check_active
     @step(args=['filename', 'destination'])
     def get(self, filename, destination="."):
+        source = f"{self.networkservice.address}:{filename}"
+        if username := self._get_username():
+            source = f"{username}@{source}"
+
         transfer_cmd = [
             self._scp,
             "-S", self._ssh,
             *self.ssh_prefix,
             "-P", str(self.networkservice.port),
             "-r",
-            f"{self._get_username()}@{self.networkservice.address}:{filename}",
+            source,
             destination
             ]
 
@@ -543,7 +554,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def _cleanup_own_master(self):
         """Exit the controlmaster and delete the tmpdir"""
-        complete_cmd = f"{self._ssh} -x -o ControlPath={self.control.replace('%', '%%')} -O exit -p {self.networkservice.port} -l {self._get_username()} {self.networkservice.address}".split(' ')  # pylint: disable=line-too-long
+        complete_cmd = [self._ssh, "-x", "-o", f"ControlPath={self.control.replace('%', '%%')}", "-O", "exit", "-p", str(self.networkservice.port)]  # pylint: disable=line-too-long
+        if username := self._get_username():
+            complete_cmd += ["-l", username]
+        complete_cmd += [self.networkservice.address]
         res = subprocess.call(
             complete_cmd,
             stdin=subprocess.DEVNULL,
@@ -560,7 +574,10 @@ class SSHDriver(CommandMixin, Driver, CommandProtocol, FileTransferProtocol):
 
     def _start_keepalive(self):
         """Starts a keepalive connection via the own or external master."""
-        args = [self._ssh, *self.ssh_prefix, self.networkservice.address, "cat"]
+        args = [self._ssh, *self.ssh_prefix]
+        if username := self._get_username():
+            args += ["-l", username]
+        args += [self.networkservice.address, "cat"]
 
         assert self._keepalive is None
         self._keepalive = subprocess.Popen(

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1302,7 +1302,7 @@ class ClientSession:
                 ip = self._get_ip(place)
                 if not ip:
                     return
-                resource = NetworkService(target, address=str(ip), username="root")
+                resource = NetworkService(target, name=None, address=str(ip))
 
             drv = self._get_driver_or_new(target, "SSHDriver", name=resource.name)
             return drv

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -723,9 +723,14 @@ class NetworkServiceExport(ResourceExport):
 
     def _get_params(self):
         """Helper function to return parameters"""
-        return {
+        params = {
             **self.local_params,
         }
+        # Keep username string-typed on the wire so older clients can still
+        # reconstruct the resource.
+        if params.get("username") is None:
+            params["username"] = ""
+        return params
 
 
 exports["NetworkService"] = NetworkServiceExport

--- a/labgrid/resource/networkservice.py
+++ b/labgrid/resource/networkservice.py
@@ -8,6 +8,6 @@ from .common import Resource
 @attr.s(eq=False)
 class NetworkService(Resource):
     address = attr.ib(validator=attr.validators.instance_of(str))
-    username = attr.ib(validator=attr.validators.instance_of(str))
+    username = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     password = attr.ib(default=None, validator=attr.validators.optional(attr.validators.instance_of(str)))
     port = attr.ib(default=22, validator=attr.validators.instance_of(int))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -76,6 +76,27 @@ def test_connect_timeout(coordinator):
         coordinator.resume_tree()
         pass
 
+def test_get_ssh_no_username(target, mocker):
+    from labgrid.remote.client import ClientSession
+    from labgrid.resource import NetworkService
+
+    driver = object()
+
+    session = object.__new__(ClientSession)
+    session.args = type("Args", (), {"name": None})()
+    session.get_acquired_place = lambda: "test-place"
+    session._get_target = lambda place: target
+    session._get_ip = lambda place: "192.0.2.10"
+    session._get_driver_or_new = mocker.MagicMock(return_value=driver)
+
+    result = session._get_ssh()
+    resource = target.get_resource(NetworkService)
+
+    assert resource.address == "192.0.2.10"
+    assert resource.username is None
+    session._get_driver_or_new.assert_called_once_with(target, "SSHDriver", name=None)
+    assert result is driver
+
 def test_place_show(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test show') as spawn:
         spawn.expect("Place 'test':")

--- a/tests/test_sshdriver.py
+++ b/tests/test_sshdriver.py
@@ -80,6 +80,82 @@ def test_custom_tools(target, tmpdir):
     s = SSHDriver(target, "ssh")
     assert [s._ssh, s._scp, s._sshfs, s._rsync] == [f"/path/to/{t}" for t in ("ssh", "scp", "sshfs", "rsync")]
 
+def test_run_no_username(target, mocker):
+    NetworkService(target, "service", "1.2.3.4")
+    mocker.patch('os.path.exists', return_value=True)
+    mocker.patch('subprocess.call', return_value=0)
+    popen = mocker.patch('subprocess.Popen', autospec=True)
+    master = mocker.MagicMock()
+    master.wait = mocker.MagicMock(return_value=0)
+    master.communicate = mocker.MagicMock(return_value=(b"", b""))
+    keepalive = mocker.MagicMock()
+    keepalive.poll = mocker.MagicMock(return_value=None)
+    keepalive.communicate = mocker.MagicMock(return_value=("", ""))
+    run = mocker.MagicMock()
+    run.communicate = mocker.MagicMock(return_value=(b"Hello\n", b""))
+    run.returncode = 0
+    popen.side_effect = [
+        master,
+        keepalive,
+        run,
+    ]
+
+    SSHDriver(target, "ssh")
+    s = target.get_driver("SSHDriver")
+
+    assert s.networkservice.username is None
+    assert s.run("echo Hello") == (["Hello"], [], 0)
+    for call in popen.call_args_list:
+        assert "-l" not in call.args[0]
+
+    target.deactivate(s)
+
+def test_put_get_no_username(target, mocker):
+    NetworkService(target, "service", "1.2.3.4")
+    popen = mocker.patch('subprocess.Popen', autospec=True)
+    mocker.patch('os.path.exists', return_value=True)
+    call = mocker.patch('subprocess.call', return_value=0)
+    master = mocker.MagicMock()
+    master.wait = mocker.MagicMock(return_value=0)
+    master.communicate = mocker.MagicMock(return_value=(b"", b""))
+    keepalive = mocker.MagicMock()
+    keepalive.poll = mocker.MagicMock(return_value=None)
+    keepalive.communicate = mocker.MagicMock(return_value=("", ""))
+    popen.side_effect = [master, keepalive]
+
+    SSHDriver(target, "ssh")
+    s = target.get_driver("SSHDriver")
+
+    s.put("/tmp/local-file", "/tmp/remote-file")
+    s.get("/tmp/remote-file", "/tmp/local-file")
+
+    assert call.call_args_list[0].args[0][-1] == "1.2.3.4:/tmp/remote-file"
+    assert "@" not in call.call_args_list[0].args[0][-1]
+    assert call.call_args_list[1].args[0][-2] == "1.2.3.4:/tmp/remote-file"
+    assert "@" not in call.call_args_list[1].args[0][-2]
+
+    target.deactivate(s)
+
+def test_networkservice_export_keeps_empty_username_for_compat():
+    from labgrid.remote.exporter import NetworkServiceExport
+
+    export = NetworkServiceExport(
+        {
+            "avail": True,
+            "cls": "NetworkService",
+            "params": {
+                "address": "1.2.3.4",
+                "port": 22,
+            },
+        },
+        host="testhost",
+        proxy="testproxy",
+        proxy_required=False,
+    )
+
+    assert export.local.username is None
+    assert export._get_params()["username"] == ""
+
 @pytest.fixture(scope='function')
 def ssh_localhost(target, pytestconfig):
     name = pytestconfig.getoption("--ssh-username")


### PR DESCRIPTION
Allow `NetworkService` to be used without an explicit SSH username.

Until now, `NetworkService.username` was required and `SSHDriver` always passed
it through to `ssh`, `scp`, etc. That prevented setups where the SSH user should
come from the local SSH configuration or the default SSH user resolution.

This change makes `NetworkService.username` optional and updates `SSHDriver` to
only pass `-l <username>` or `user@host` when a username is explicitly set.

The client-side fallback path in `labgrid.remote.client` also no longer forces
`username="root"`. While adding regression coverage for that path, this also
surfaced that the fallback resource creation needs `name=None`, which is now
passed explicitly.

I verified the change with some tests called `test_run_no_username`, `test_put_get_no_username` and  `test_get_ssh_no_username` for the no-username paths.

**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
- [x] PR has been tested