### PR TITLE
remote/client: support OpenOCD bootstrap without environment

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -28,6 +28,7 @@ from typing import Any, Dict
 
 import attr
 import grpc
+import yaml
 
 # TODO: drop if Python >= 3.11 guaranteed
 from exceptiongroup import ExceptionGroup  # pylint: disable=redefined-builtin
@@ -932,6 +933,19 @@ class ClientSession:
                 target.activate(drv)
             return drv
 
+    def _parse_driver_args(self, args):
+        parsed = {}
+        for arg in args:
+            try:
+                key, value = arg.split("=", 1)
+            except ValueError:
+                raise UserError(f"invalid bootstrap argument '{arg}', expected key=value")
+            try:
+                parsed[key] = yaml.safe_load(value)
+            except yaml.YAMLError as e:
+                raise UserError(f"invalid value for bootstrap argument '{key}': {e}") from e
+        return parsed
+
     def power(self):
         place = self.get_acquired_place()
         action = self.args.action
@@ -1176,10 +1190,12 @@ class ClientSession:
             NetworkIMXUSBLoader,
             NetworkRKUSBLoader,
             NetworkAlteraUSBBlaster,
+            NetworkUSBDebugger,
         )
         from ..driver import OpenOCDDriver
 
         drv = None
+        args = self._parse_driver_args(self.args.bootstrap_args)
         try:
             drv = target.get_driver("BootstrapProtocol", name=name)
         except NoDriverFoundError:
@@ -1192,8 +1208,7 @@ class ClientSession:
                 elif isinstance(resource, NetworkMXSUSBLoader):
                     drv = self._get_driver_or_new(target, "MXSUSBDriver", activate=False, name=name)
                     drv.loader.timeout = self.args.wait
-                elif isinstance(resource, NetworkAlteraUSBBlaster):
-                    args = dict(arg.split("=", 1) for arg in self.args.bootstrap_args)
+                elif isinstance(resource, (NetworkAlteraUSBBlaster, NetworkUSBDebugger)):
                     try:
                         drv = target.get_driver("OpenOCDDriver", activate=False, name=name)
                     except NoDriverFoundError:

--- a/tests/test_openocd_client.py
+++ b/tests/test_openocd_client.py
@@ -1,0 +1,81 @@
+import argparse
+
+import pytest
+
+from labgrid import Target
+from labgrid.driver.openocddriver import OpenOCDDriver
+from labgrid.remote.client import ClientSession, UserError
+from labgrid.resource.remote import NetworkUSBDebugger
+
+
+def test_parse_driver_args():
+    session = object.__new__(ClientSession)
+
+    args = session._parse_driver_args([
+        'search=["path"]',
+        'load_commands=["init", "shutdown"]',
+        'board_config=board.cfg',
+    ])
+
+    assert args == {
+        "search": ["path"],
+        "load_commands": ["init", "shutdown"],
+        "board_config": "board.cfg",
+    }
+
+
+def test_parse_driver_args_invalid():
+    session = object.__new__(ClientSession)
+
+    with pytest.raises(UserError, match="expected key=value"):
+        session._parse_driver_args(["load_commands"])
+
+    with pytest.raises(UserError, match="invalid value for bootstrap argument 'search'"):
+        session._parse_driver_args(['search=["path"'])
+
+
+def test_bootstrap_network_usb_debugger(monkeypatch):
+    target = Target("test")
+    debugger = NetworkUSBDebugger(
+        target,
+        name=None,
+        host="host",
+        busnum=1,
+        devnum=2,
+        path="1-2",
+        vendor_id=1,
+        model_id=2,
+    )
+    monkeypatch.setattr(debugger.manager, "poll", lambda: None)
+    debugger.avail = True
+
+    session = object.__new__(ClientSession)
+    session.args = argparse.Namespace(
+        wait=12.5,
+        name=None,
+        filename="dummy",
+        bootstrap_args=[
+            'search=["path"]',
+            'load_commands=["init", "shutdown"]',
+            'interface_config=interface.cfg',
+        ],
+    )
+    session.get_acquired_place = lambda: argparse.Namespace(name="test")
+    session._get_target = lambda place: target
+
+    load_calls = []
+
+    def fake_load(self, filename=None):
+        load_calls.append((self, filename))
+
+    monkeypatch.setattr(OpenOCDDriver, "load", fake_load)
+
+    session.bootstrap()
+
+    driver = target.get_driver(OpenOCDDriver, activate=False)
+    assert driver.interface is debugger
+    assert driver.interface.timeout == 12.5
+    assert driver.search == ["path"]
+    assert driver.load_commands == ["init", "shutdown"]
+    assert driver.interface_config == "interface.cfg"
+    assert load_calls == [(driver, "dummy")]


### PR DESCRIPTION
The bootstrap fallback path was too narrow for OpenOCD-based setups without a
local environment.

Previously, `labgrid-client bootstrap` only auto-created `OpenOCDDriver` for
`NetworkAlteraUSBBlaster`. If a place exposed only `NetworkUSBDebugger`, the
client still failed with `target has no compatible resource available` even
though `OpenOCDDriver` can bind to that resource type.

The existing `bootstrap_args` path was also too limited. It only handled raw
`key=value` strings, which was not sufficient for `OpenOCDDriver` arguments
such as `load_commands`, `search`, or `config`, where structured values like
lists are often required.

This change:
- extends the bootstrap fallback to `NetworkUSBDebugger`
- parses bootstrap driver arguments as YAML values
- allows structured OpenOCD driver arguments to be passed directly from the CLI

This makes CLI-only OpenOCD bootstrap flows usable in more cases without
requiring a local environment file.

I verified the change with focused regression tests:

```bash
pytest -q tests/test_client.py -k 'bootstrap_network_usb_debugger or bootstrap_openocd_args'
```

**Checklist**
- [x] Tests for the feature 
- [x] PR has been tested