### PR TITLE
tests: Omit generated protobuf code from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+[run]
+omit =
+    labgrid/remote/generated/*
+
 [report]
 exclude_lines =
     pragma: no cover


### PR DESCRIPTION
When a field is added to a .proto file, protoc's regen of labgrid_coordinator_pb2.py shifts the opaque descriptor-bytes literal across dozens of lines.  Codecov counts every shifted line as 'modified code that isn't tested', so a tiny 6-line proto change can produce 80+ patch misses and drag the patch coverage down, tripping the per-PR threshold for what is otherwise a routine protocol addition.

Add labgrid/remote/generated/* to .coveragerc's omit list so the generated files no longer count toward coverage.  They are machine-produced and exercised implicitly by every test that talks to the coordinator protocol; there is no value in asking unit tests to cover descriptor metadata.