### PR TITLE
Allow using coordinator and exporter programatically

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -1143,7 +1143,7 @@ async def serve(listen, cleanup) -> None:
     except ImportError:
         logging.info("Module grpcio-channelz not available")
 
-    server.add_insecure_port(listen)
+    bound = server.add_insecure_port(listen)
     logging.debug("Starting server")
     await server.start()
 
@@ -1159,6 +1159,10 @@ async def serve(listen, cleanup) -> None:
 
     cleanup.append(server_graceful_shutdown())
     logging.info("Coordinator ready")
+    host, sep, port = listen.rpartition(":")
+    if not sep or not port.isdigit():
+        host = listen
+    print(f"listening on {host}:{bound}", flush=True)
     await server.wait_for_termination()
 
 

--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -9,6 +9,7 @@ import time
 from contextlib import contextmanager
 import copy
 import random
+import signal
 
 import attr
 import grpc
@@ -1157,7 +1158,13 @@ async def serve(listen, cleanup) -> None:
         # existing RPCs to continue within the grace period.
         await server.stop(5)
 
+    def callback():
+        asyncio.ensure_future(server_graceful_shutdown())
+
     cleanup.append(server_graceful_shutdown())
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, callback)
+    loop.add_signal_handler(signal.SIGTERM, callback)
     logging.info("Coordinator ready")
     host, sep, port = listen.rpartition(":")
     if not sep or not port.isdigit():

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -901,6 +901,7 @@ class Exporter:
                 logging.debug("received message %s", out_message)
                 kind = out_message.WhichOneof("kind")
                 if kind == "hello":
+                    print("Exporter ready", flush=True)
                     logging.info("connected to coordinator version %s", out_message.hello.version)
                 elif kind == "set_acquired_request":
                     logging.debug("acquire request")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -8,6 +8,7 @@ import sys
 import os
 import os.path
 import traceback
+import signal
 import shutil
 import subprocess
 from urllib.parse import urlsplit
@@ -884,8 +885,11 @@ class Exporter:
         for task in pending:
             task.cancel()
 
-        await self.pump_task
-        await self.poll_task
+        try:
+            await self.pump_task
+            await self.poll_task
+        except asyncio.CancelledError:
+            return
 
     def send_started(self):
         msg = labgrid_coordinator_pb2.ExporterInMessage()
@@ -1010,6 +1014,10 @@ class Exporter:
             except Exception:  # pylint: disable=broad-except
                 traceback.print_exc(file=sys.stderr)
 
+    async def stop(self):
+        if self.poll_task is not None:
+            self.poll_task.cancel()
+
     async def add_resource(self, group_name, resource_name, cls, params):
         """Add a resource to the exporter and update status on the coordinator"""
         print(f"add resource {group_name}/{resource_name}: {cls}/{params}")
@@ -1051,6 +1059,13 @@ async def amain(config) -> bool:
 
     if inspect:
         inspect.exporter = exporter
+
+    def _stop():
+        asyncio.ensure_future(exporter.stop())
+
+    loop = asyncio.get_event_loop()
+    loop.add_signal_handler(signal.SIGINT, _stop)
+    loop.add_signal_handler(signal.SIGTERM, _stop)
 
     await exporter.run()
 


### PR DESCRIPTION
**Description**
We spin up a local coordinator and exporter for automated testing, and we want to be able to tell whether they're ready before running our tests. Also, we use port `0` with the coordinator to let the kernel allocate a free port, so we need to know which port was actually used. So now you can do:

```
labgrid-coordinator --listen 127.0.0.1:0
```

And it will print to `stdout`:
```
listening on 127.0.0.1:46269
```

We also fixed an issue when interrupting the coordinator/exporter (e.g. `Ctrl`+`c`):

```
^CINFO:root:Starting graceful shutdown...
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "path/to/labgrid/labgrid/remote/coordinator.py", line 1211, in <module>
    main()
  File "path/to/labgrid/labgrid/remote/coordinator.py", line 1204, in main
    loop.run_until_complete(serve(args.listen, cleanup))
  File "/usr/lib/python3.10/asyncio/base_events.py", line 636, in run_until_complete
    self.run_forever()
  File "/usr/lib/python3.10/asyncio/base_events.py", line 603, in run_forever
    self._run_once()
  File "/usr/lib/python3.10/asyncio/base_events.py", line 1871, in _run_once
    event_list = self._selector.select(timeout)
  File "/usr/lib/python3.10/selectors.py", line 469, in select
    fd_event_list = self._selector.poll(timeout, max_ev)
KeyboardInterrupt
```

**Checklist**
- [x] PR has been tested