### PR TITLE
remote/coordinator: publish correct place after reservation re-scheduling

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -1053,7 +1053,7 @@ class Coordinator(labgrid_coordinator_pb2_grpc.CoordinatorServicer):
                     place.reservation = res.token
         for name in old_map.keys() | new_map.keys():
             if old_map.get(name) != new_map.get(name):
-                self._publish_place(place)
+                self._publish_place(self.places[name])
 
     @locked
     async def CreateReservation(self, request: labgrid_coordinator_pb2.CreateReservationRequest, context):


### PR DESCRIPTION
**Description**
Small bug fix in `schedule_reservations()` where the update notification could publish a stale/incorrect place due to reuse of a loop variable. Now it publishes the place corresponding to the name whose reservation mapping actually changed.

**Checklist**
- [x] PR has been tested