### PR TITLE
Fix USB SD wire control_serial export

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -421,6 +421,7 @@ class USBSDWireExport(USBGenericExport):
             "path": self.local.path,
             "vendor_id": self.local.vendor_id,
             "model_id": self.local.model_id,
+            "control_serial": self.local.control_serial,
         }
 
 


### PR DESCRIPTION
Re-add control_serial export to USB SD wire export that was accidentally dropped by 52dc8a8d49ccda0d8d3ccd10ee6044b82357509c.  Without this, the exporter no longer transmits control_serial over the network for USBSDWireDevice resources, so on the client side, control_serial remains `None`, which prevents interaction with the mux.