### PR TITLE
resource&driver: add mtd resource, flashcp driver

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -682,6 +682,27 @@ Arguments:
 Used by:
   - `GpioDigitalOutputDriver`_
 
+DevfsMTDPartition
++++++++++++++++++
+
+A :any:`DevfsMTDPartition` resource describes a MTD partition accessible through the devFS.
+
+.. code-block:: yaml
+
+   DevfsMTDPartition:
+     index: 0
+
+Arguments:
+  - index (int): index of the MTD partition
+
+Used by:
+  - `FlashcpDriver`_
+
+NetworkDevfsMTDPartition
++++++++++++++++++
+
+A :any:`NetworkDevfsMTDPartition` resource describes a `DevfsMTDPartition`_ resource available on a remote computer.
+
 NetworkService
 ~~~~~~~~~~~~~~
 A :any:`NetworkService` describes a remote SSH connection.

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -54,3 +54,4 @@ from .laadriver import LAASerialDriver, LAAPowerDriver, \
                        LAAUSBGadgetMassStorageDriver, LAAUSBDriver, \
                        LAAButtonDriver, LAALedDriver, LAATempDriver, LAAWattDriver, \
                        LAAProviderDriver
+from .flashcpdriver import FlashcpDriver

--- a/labgrid/driver/flashcpdriver.py
+++ b/labgrid/driver/flashcpdriver.py
@@ -1,0 +1,78 @@
+import os
+from uuid import uuid4
+from pathlib import Path
+
+import attr
+from .common import check_file
+from .exception import ExecutionError
+from ..factory import target_factory
+from ..step import step
+from ..driver import Driver
+from ..protocol import BootstrapProtocol, FileTransferProtocol, CommandProtocol
+from ..util.helper import processwrapper
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class FlashcpDriver(Driver, BootstrapProtocol):
+    _devfs: Path = Path("/dev")
+
+    bindings = {
+        "mtdpartition": {"DevfsMTDPartition", "NetworkDevfsMTDPartition"},
+        "filetransfer": FileTransferProtocol,
+        "command": CommandProtocol
+    }
+
+    image = attr.ib(
+        default=None,
+        validator=attr.validators.optional(attr.validators.instance_of(str)),
+    )
+    tool = attr.ib(
+        default="flashcp",
+        validator=attr.validators.instance_of(str),
+    )
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+
+    def _get_flashcp_prefix(self):
+        return self.mtdpartition.command_prefix + [self.tool]
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    @Driver.check_active
+    @step(title="call", args=["args"])
+    def __call__(self, *args):
+        arg_list = list(args)
+        arg_list.append("-v")
+        processwrapper.check_output(
+            self._get_flashcp_prefix() + arg_list, print_on_silent_log=True
+        )
+
+    @Driver.check_active
+    @step(result=True, args=["filename"])
+    def load(self, filename=None):
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        elif filename is None and self.image is None:
+            raise ExecutionError(
+                "At least one of 'filename' argument or driver 'image' attribute must supplied."
+            )
+        filename = os.path.abspath(filename)
+        check_file(filename)
+        remote_folder = Path(f"/tmp/image-{uuid4()}")
+        remote_file = remote_folder.joinpath(Path(filename).name)
+
+        self.command.run_check(f"mkdir -p {remote_folder.as_posix()}")
+        self.filetransfer.put(filename, remote_file.as_posix())
+        self.logger.info("Local File %s put to remote path %s", filename, remote_file)
+        self.logger.info("Now flashing to mtd partition '%i'", self.mtdpartition.index)
+        self(
+            remote_file.as_posix(),
+            self._devfs.joinpath(f"mtd{self.mtdpartition.index}").as_posix(),
+        )
+        self.logger.info("Flashing finished.")

--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -700,6 +700,23 @@ class GPIOSysFSExport(ResourceExport):
 exports["SysfsGPIO"] = GPIOSysFSExport
 exports["MatchedSysfsGPIO"] = GPIOSysFSExport
 
+@attr.s(eq=False)
+class DevfsMTDPartitionExport(ResourceExport):
+    """ResourceExport for a DevfsMTDPartition"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        from ..resource.base import DevfsMTDPartition
+        self.data['cls'] = "NetworkDevfsMTDPartition"
+        self.local = DevfsMTDPartition(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        return {
+            'host': self.host,
+            **self.local_params
+        }
+
+exports["DevfsMTDPartition"] = DevfsMTDPartitionExport
 
 @attr.s
 class NetworkServiceExport(ResourceExport):

--- a/labgrid/resource/__init__.py
+++ b/labgrid/resource/__init__.py
@@ -1,4 +1,4 @@
-from .base import SerialPort, NetworkInterface, EthernetPort, SysfsGPIO
+from .base import SerialPort, NetworkInterface, EthernetPort, SysfsGPIO, DevfsMTDPartition
 from .ethernetport import SNMPEthernetPort
 from .serialport import RawSerialPort, NetworkSerialPort
 from .modbus import ModbusTCPCoil, WaveshareModbusTCPCoil

--- a/labgrid/resource/base.py
+++ b/labgrid/resource/base.py
@@ -44,3 +44,12 @@ class SysfsGPIO(Resource):
     Args:
         index (int): index of target gpio line."""
     index = attr.ib(default=None, validator=attr.validators.instance_of(int))
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class DevfsMTDPartition(Resource):
+    """The basic DevfsMTDPartition contains an index
+
+    Args:
+        index (int): index of target MTD partition."""
+    index = attr.ib(default=None, validator=attr.validators.instance_of(int))

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -356,6 +356,17 @@ class NetworkSysfsGPIO(NetworkResource, ManagedResource):
         self.timeout = 10.0
         super().__attrs_post_init__()
 
+
+@target_factory.reg_resource
+@attr.s(eq=False)
+class NetworkDevfsMTDPartition(NetworkResource):
+    """The NetworkDevfsMTDPartition describes a remotely accessible mtd partition"""
+    index = attr.ib(validator=attr.validators.instance_of(int))
+
+    def __attrs_post_init__(self):
+        self.timeout = 10.0
+        super().__attrs_post_init__()
+
 @attr.s(eq=False)
 class NetworkLXAIOBusNode(ManagedResource):
     manager_cls = RemotePlaceManager


### PR DESCRIPTION
**Description**

This change adds a resource&driver pair for MTD partitions, commonly found in embedded board utilizing flash storage.

A resource is added that identifies MTD partitions by their number as they appear in the devfs,
and a driver that flashes these partitions using the `flashscp` tool, which is part of `mtdutils` on popular distributions.


**Checklist**

- [x] Documentation for the feature
- [x] The arguments and description in doc/configuration.rst have been updated
- [x] PR has been tested

