### PR TITLE
driver: usbsdmuxdriver: add GPIO get and set support

### DIFF
--- a/labgrid/driver/usbsdmuxdriver.py
+++ b/labgrid/driver/usbsdmuxdriver.py
@@ -45,3 +45,22 @@ class USBSDMuxDriver(Driver):
         cmd = self.mux.command_prefix + [self.tool, self.mux.control_path, "get"]
         proc = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
         return proc.stdout.strip().decode()
+
+    @Driver.check_active
+    @step(title="sdmux_gpio_get", args=["gpio"])
+    def get_gpio(self, gpio):
+        if gpio not in [0, 1]:
+            raise ExecutionError(f"GPIO '{gpio}' not supported by USBSDMuxDriver")
+        cmd = self.mux.command_prefix + [self.tool, self.mux.control_path, "gpio", str(gpio), "get"]
+        proc = subprocess.run(cmd, stdout=subprocess.PIPE, check=True)
+        return proc.stdout.strip().decode()
+
+    @Driver.check_active
+    @step(title="sdmux_gpio_set", args=["gpio", "value"])
+    def set_gpio(self, gpio, value):
+        if gpio not in [0, 1]:
+            raise ExecutionError(f"GPIO '{gpio}' not supported by USBSDMuxDriver")
+        if value.lower() not in ["high", "1", "low", "0"]:
+            raise ExecutionError(f"GPIO value '{value}' not supported by USBSDMuxDriver")
+        cmd = self.mux.command_prefix + [self.tool, self.mux.control_path, "gpio", str(gpio), value.lower()]
+        processwrapper.check_output(cmd)


### PR DESCRIPTION
Add two new methods to `USBSDMuxDriver`:
- `get_gpio(gpio)`: reads the state of a GPIO pin (0 or 1), returns `'high'` or `'low'`
- `set_gpio(gpio, value)`: sets a GPIO pin to `'high'`/`'1'` or `'low'`/`'0'`

Both methods use the `gpio` subcommand of the `usbsdmux` CLI tool,
which is available on hardware revisions that support open-drain GPIO
outputs (e.g. USB-SD-Mux Fast).

Signed-off-by: Hamza TOUIZRAT <hamzatouizrat@yahoo.com>