### PR TITLE
Add QEMUDriver.interact() and qemu-run.py example

### DIFF
--- a/examples/qemu-run.py
+++ b/examples/qemu-run.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+
+import argparse
+import logging
+import os
+
+from labgrid.logging import basicConfig, StepLogger
+from labgrid import Environment
+
+
+def main(args):
+    basicConfig(level=logging.DEBUG if args.verbose else logging.INFO)
+    StepLogger.start()
+
+    env = Environment(config_file=args.config)
+    target = env.get_target()
+    qemu = target.get_driver("QEMUDriver", activate=False)
+
+    if args.state:
+        strategy = target.get_driver("Strategy")
+        strategy.transition(args.state)
+    else:
+        print("No state given, skipping Strategy state transition")
+        target.activate(qemu)
+        qemu.on()
+
+    qemu.interact()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run QEMU, either by activating the QEMUDriver directly or by transitioning into a strategy state first, then start a console."
+    )
+    parser.add_argument(
+        "-c",
+        "--config",
+        default=os.environ.get("LG_ENV"),
+        help="Environment config file to use (alternatively provided via LG_ENV)",
+    )
+    parser.add_argument(
+        "-s",
+        "--state",
+        default=os.environ.get("LG_STATE"),
+        help="State to transition the strategy into (alternatively provided via LG_STATE",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="count",
+        default=0,
+        help="Increase verbosity",
+    )
+
+    args = parser.parse_args()
+
+    if not args.config:
+        parser.error("One of -c, --config or LG_ENV must be specified")
+
+    main(args)

--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -1,4 +1,6 @@
 """The QEMUDriver implements a driver to use a QEMU target"""
+import os
+import pty
 import select
 import shlex
 import shutil
@@ -365,3 +367,34 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
 
     def __str__(self):
         return f"QemuDriver({self.target.name})"
+
+    @Driver.check_active
+    def interact(self):
+        """Start interactive microcom session."""
+        microcom_bin = shutil.which("microcom")
+        if microcom_bin is None:
+            raise ExecutionError("microcom not found")
+
+        # connect microcom to PTY
+        master, slave = pty.openpty()
+        microcom_cmd = [microcom_bin, "-p", os.ttyname(slave)]
+        print(f"connecting to {self} calling {' '.join(microcom_cmd)}")
+        microcom_proc = subprocess.Popen(microcom_cmd)
+
+        # relay serial data to PTY
+        buf_size = 4096
+
+        while microcom_proc.poll() is None:
+            ready, _, _ = select.select([self._clientsocket, master], [], [], 1.0)
+            if self._clientsocket in ready:
+                data = self._read(max_size=buf_size)
+                if not data:
+                    break
+                os.write(master, data)
+            if master in ready:
+                data = os.read(master, buf_size)
+                if not data:
+                    break
+                self._write(data)
+
+        return microcom_proc.wait()


### PR DESCRIPTION
**Description**
Since the QEMUDriver can't be used with labgrid-client (because it does not use labgrid's remote infrastructue), there is currently no good way of accessing its console interactively, e.g. for debugging.

Add a `QEMUDriver.interact()` method that creates a PTY, let microcom open it and relay the QEMUDriver's input and output to that PTY.

Add an example helper to run QEMU, either by activating the QEMUDriver directly or by transitioning into a strategy state first, then start an interactive console.

**Checklist**
- [x] PR has been tested