### PR TITLE
driver/power/poe_netgear_plus: conditional import

### DIFF
--- a/labgrid/driver/power/poe_netgear_plus.py
+++ b/labgrid/driver/power/poe_netgear_plus.py
@@ -21,8 +21,6 @@ NetworkPowerPort:
 
 from urllib.parse import urlparse
 
-from py_netgear_plus import NetgearSwitchConnector
-
 from ..exception import ExecutionError
 
 
@@ -61,6 +59,8 @@ def power_set(host: str, _port: int, index: int, value: bool) -> None:
         value: Whether the port should enable PoE output
 
     """
+    from py_netgear_plus import NetgearSwitchConnector
+
     index = int(index)
     netgear_port_number = index + 1
 
@@ -94,6 +94,8 @@ def power_get(host: str, _port: int, index: int) -> bool:
         ExecutionError: In case the status dictionary contains unexpected PoE status values.
 
     """
+    from py_netgear_plus import NetgearSwitchConnector
+
     index = int(index)
     netgear_port_number = index + 1
 


### PR DESCRIPTION
**Description**
Conditionally import the NetgearSwitchConnector only once power_set and power_get are used, fixes failing tests when the module is not available:
```
  __________________ ERROR collecting tests/test_powerdriver.py __________________
  ImportError while importing test module '/build/source/tests/test_powerdriver.py'.
  Hint: make sure your test modules/packages have valid Python names.
  Traceback:
  /nix/store/60m4rxhg2fldqaak400c0lry96ijrzqn-python3-3.13.13/lib/python3.13/importlib/__init__.py:88: in import_module
      return _bootstrap._gcd_import(name[level:], package, level)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  tests/test_powerdriver.py:6: in <module>
      from labgrid.driver.power.poe_netgear_plus import _get_hostname_and_password
  labgrid/driver/power/poe_netgear_plus.py:24: in <module>
      from py_netgear_plus import NetgearSwitchConnector
  E   ModuleNotFoundError: No module named 'py_netgear_plus'
```
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->


<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested