### PR TITLE
agentwrapper: try labgrid-python3 for agent environment

### DIFF
--- a/labgrid/util/agentwrapper.py
+++ b/labgrid/util/agentwrapper.py
@@ -60,8 +60,14 @@ class AgentWrapper:
                 ['rsync', '-e', ' '.join(ssh_opts), '-tq', agent,
                  f'{host}:{agent_remote}'],
             )
+            agent_python = "labgrid-python3" if not subprocess.call(ssh_opts + [host, '--', 'which', 'labgrid-python3']) else "python3"
+            if agent_python == "python3":
+                self.logger.debug(
+                    "labgrid-python3 on %s not found, using python3 which requires system installed python modules for agents",
+                    host
+                )
             self.agent = subprocess.Popen(
-                ssh_opts + [host, '--', 'python3', agent_remote],
+                ssh_opts + [host, '--', agent_python, agent_remote],
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE,
                 start_new_session=True,

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,6 +1,7 @@
 import os
 import socket
 import subprocess
+import shutil
 
 import pytest
 from py.path import local
@@ -18,7 +19,7 @@ def subprocess_mock(mocker):
     agent = local(labgrid.util.agentwrapper.__file__).dirpath('agent.py')
 
     def run(args, **kwargs):
-        assert args[0] in ['rsync', 'ssh']
+        assert args[0] in ['rsync', 'ssh', 'which']
         if args[0] == 'rsync':
             src = local(args[-2])
             assert src == agent
@@ -32,10 +33,14 @@ def subprocess_mock(mocker):
             assert '--' in args
             args = args[args.index('--')+1:]
             assert len(args) == 2
-            assert args[0] == 'python3'
-            assert args[1].startswith('.labgrid_agent')
-            # we need to use the original here to get the coverage right
-            return original(['python3', str(agent)], **kwargs)
+            assert args[0] in ['labgrid-python3', 'python3', 'which']
+            if args[0] in ['python3', 'labgrid-python3']:
+                assert args[1].startswith('.labgrid_agent')
+                # we need to use the original here to get the coverage right
+                return original(['python3', str(agent)], **kwargs)
+            else:
+                lg_py3_env = 'true' if shutil.which('labgrid-python3') else 'false'
+                return original([lg_py3_env], **kwargs)
 
     mocker.patch('subprocess.Popen', run)
 


### PR DESCRIPTION
**Description**
Similar to the prefix, allow setup of the python interpreter to allow users to use their own python environments.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] PR has been tested
- [x] Man pages have been regenerated
