### PR TITLE
pyproject: raise protobuf version to 5.29.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     "exceptiongroup>=1.3.0",  # TODO: drop if Python >= 3.11 guaranteed
     "grpcio>=1.64.1, <2.0.0",
     "grpcio-reflection>=1.64.1, <2.0.0",
-    "protobuf>=5.27.0",
+    "protobuf>=5.29.6",
     "jinja2>=3.0.2",
     "pexpect>=4.8.0",
     "pyserial-labgrid>=3.4.0.1",


### PR DESCRIPTION
**Description**
Raise protobuf version to fix two security vulnerabilities with severity "High":
- protobuf-python has a potential Denial of Service issue [1]
- protobuf affected by a JSON recursion depth bypass [2]

[1]: https://github.com/labgrid-project/labgrid/security/dependabot/1
[2]: https://github.com/labgrid-project/labgrid/security/dependabot/3
**Checklist**
- [x] PR has been tested