### PR TITLE
doc: Rockchip: fix rk-usb-loader reference

### DIFF
--- a/doc/man/device-config.rst
+++ b/doc/man/device-config.rst
@@ -115,8 +115,9 @@ TOOLS KEYS
     See: https://www.intel.com/content/www/us/en/docs/programmable/683039/22-3/hps-flash-programmer.html
 
 ``rk-usb-loader``
-    Path to the rk-usb-loader binary, used by the RKUSBDriver.
-    See: https://git.pengutronix.de/cgit/barebox/tree/scripts/rk-usb-loader.c
+    Path to the rkdeveloptool binary, used by the RKUSBDriver. The driver
+    invokes it with rkdeveloptool's ``db`` and ``wl`` subcommands.
+    See: https://github.com/rockchip-linux/rkdeveloptool
 
 ``rsync``
     Path to the rsync binary, used by the SSHDriver.

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -130,8 +130,9 @@ Path to the quartus_hps binary, used by the QuartusHPSDriver.
 See: \X'tty: link https://www.intel.com/content/www/us/en/docs/programmable/683039/22-3/hps-flash-programmer.html'\fI\%https://www.intel.com/content/www/us/en/docs/programmable/683039/22\-3/hps\-flash\-programmer.html\fP\X'tty: link'
 .TP
 .B \fBrk\-usb\-loader\fP
-Path to the rk\-usb\-loader binary, used by the RKUSBDriver.
-See: \X'tty: link https://git.pengutronix.de/cgit/barebox/tree/scripts/rk-usb-loader.c'\fI\%https://git.pengutronix.de/cgit/barebox/tree/scripts/rk\-usb\-loader.c\fP\X'tty: link'
+Path to the rkdeveloptool binary, used by the RKUSBDriver. The driver
+invokes it with rkdeveloptool\(aqs \fBdb\fP and \fBwl\fP subcommands.
+See: \X'tty: link https://github.com/rockchip-linux/rkdeveloptool'\fI\%https://github.com/rockchip\-linux/rkdeveloptool\fP\X'tty: link'
 .TP
 .B \fBrsync\fP
 Path to the rsync binary, used by the SSHDriver.


### PR DESCRIPTION
The rk-usb-loader option incorrectly references the barebox rk-usb-loader tool. The RKUSBDriver is not compatible with the barebox tool and instead works with the rkdeveloptool. Update the reference accordingly.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [x] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
