### PR TITLE
new RKBootstrapDriver, use rk-usb-loader to bootstrap Rockchip SoCs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,13 @@ New Features in 26.0
 - Labgrid has gained support for network namespace forwarding from exporters
   to clients. This allows accessing a network as if it is locally connected.
 - HTTPVideoDrivers now optionally allow the specification of a port.
+- The new `RKBootstrapDriver` uploads a combined barebox image into a Rockchip
+  SoC in MaskROM mode using barebox's ``rk-usb-loader`` tool, loading it into
+  RAM and executing it. In contrast, the existing `RKUSBDriver` uses
+  ``rkdeveloptool`` to write a bootloader to the target's storage. The
+  ``rkdeveloptool`` binary is now configured under the ``rkdeveloptool`` tools
+  key; the previously used ``rk-usb-loader`` key is deprecated but still honored
+  for backward compatibility.
 
 Breaking changes in 26.0
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -818,6 +818,7 @@ Arguments:
 
 Used by:
   - `RKUSBDriver`_
+  - `RKBootstrapDriver`_
 
 NetworkMXSUSBLoader
 ~~~~~~~~~~~~~~~~~~~
@@ -2856,9 +2857,14 @@ Arguments:
 
 RKUSBDriver
 ~~~~~~~~~~~
-An :any:`RKUSBDriver` is used to upload an image into a device in the *Rockchip
-USB loader state*.
-This is useful to bootstrap a bootloader onto a device.
+An :any:`RKUSBDriver` is used to write a bootloader onto a device in the
+*Rockchip USB loader state* using the ``rkdeveloptool`` tool.
+It runs ``rkdeveloptool db`` to load a first-stage bootloader into RAM,
+followed by ``rkdeveloptool wl`` to write the bootloader image to the target's
+storage (e.g. eMMC/SD).
+
+To load and execute a barebox image directly in RAM instead, use the
+`RKBootstrapDriver`_.
 
 Binds to:
   loader:
@@ -2883,9 +2889,46 @@ Implements:
 
 Arguments:
   - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
-    of an image to bootstrap onto the target
+    of an image to write to the target's storage
   - usb_loader (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
-    of a first-stage bootloader image to write
+    of a first-stage bootloader image to load into RAM
+
+.. note::
+   The ``rkdeveloptool`` binary is configured under the ``rkdeveloptool`` tools
+   key. For backward compatibility, the previously used (and misnamed)
+   ``rk-usb-loader`` tools key is still honored if ``rkdeveloptool`` is not set,
+   but its use is deprecated.
+
+RKBootstrapDriver
+~~~~~~~~~~~~~~~~~
+An :any:`RKBootstrapDriver` is used to upload a combined barebox image into a
+device in the *Rockchip USB loader state* (MaskROM mode) using barebox's
+``rk-usb-loader`` tool.
+In contrast to the `RKUSBDriver`_, it loads the image into RAM and executes it,
+i.e. it performs a true bootstrap and does not modify the target's storage.
+
+Binds to:
+  loader:
+    - `RKUSBLoader`_
+    - `NetworkRKUSBLoader`_
+
+Implements:
+  - :any:`BootstrapProtocol`
+
+.. code-block:: yaml
+
+   targets:
+     main:
+       drivers:
+         RKBootstrapDriver:
+           image: 'mybootloaderkey'
+
+   images:
+     mybootloaderkey: 'path/to/barebox.img'
+
+Arguments:
+  - image (str): optional, key in :ref:`images <labgrid-device-config-images>` containing the path
+    of a combined barebox image to load into RAM and execute
 
 UUUDriver
 ~~~~~~~~~

--- a/doc/man/device-config.rst
+++ b/doc/man/device-config.rst
@@ -115,8 +115,15 @@ TOOLS KEYS
     See: https://www.intel.com/content/www/us/en/docs/programmable/683039/22-3/hps-flash-programmer.html
 
 ``rk-usb-loader``
-    Path to the rk-usb-loader binary, used by the RKUSBDriver.
+    Path to the rk-usb-loader binary, used by the RKBootstrapDriver to load a
+    barebox image into RAM and execute it.
     See: https://git.pengutronix.de/cgit/barebox/tree/scripts/rk-usb-loader.c
+
+``rkdeveloptool``
+    Path to the rkdeveloptool binary, used by the RKUSBDriver. The driver
+    invokes it with rkdeveloptool's ``db`` and ``wl`` subcommands to write a
+    bootloader to the target's storage.
+    See: https://github.com/rockchip-linux/rkdeveloptool
 
 ``rsync``
     Path to the rsync binary, used by the SSHDriver.

--- a/labgrid/driver/__init__.py
+++ b/labgrid/driver/__init__.py
@@ -16,7 +16,7 @@ from .powerdriver import ManualPowerDriver, ExternalPowerDriver, \
                          DigitalOutputPowerDriver, YKUSHPowerDriver, \
                          USBPowerDriver, SiSPMPowerDriver, NetworkPowerDriver, \
                          PDUDaemonDriver
-from .usbloader import MXSUSBDriver, IMXUSBDriver, BDIMXUSBDriver, RKUSBDriver, UUUDriver
+from .usbloader import MXSUSBDriver, IMXUSBDriver, BDIMXUSBDriver, RKUSBDriver, RKBootstrapDriver, UUUDriver
 from .usbsdmuxdriver import USBSDMuxDriver
 from .usbsdwiredriver import USBSDWireDriver
 from .usbsdwire3driver import USBSDWire3Driver

--- a/labgrid/driver/dfudriver.py
+++ b/labgrid/driver/dfudriver.py
@@ -16,11 +16,7 @@ class DFUDriver(Driver):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool("dfu-util")
-        else:
-            self.tool = "dfu-util"
+        self.tool = self.target.get_tool("dfu-util")
 
     def _get_dfu_prefix(self):
         return self.dfu.command_prefix + [

--- a/labgrid/driver/fastbootdriver.py
+++ b/labgrid/driver/fastbootdriver.py
@@ -34,11 +34,7 @@ class AndroidFastbootDriver(Driver):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool('fastboot')
-        else:
-            self.tool = 'fastboot'
+        self.tool = self.target.get_tool('fastboot')
 
     def _get_fastboot_prefix(self):
         if isinstance(self.fastboot, (AndroidUSBFastboot, RemoteAndroidUSBFastboot)):

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -35,13 +35,11 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
-        # FIXME make sure we always have an environment or config
+        self.tool = self.target.get_tool("openocd")
         if self.target.env:
-            self.tool = self.target.env.config.get_tool("openocd")
             self.config = self.target.env.config.resolve_path_str_or_list(self.config)
             self.search = self.target.env.config.resolve_path_str_or_list(self.search)
         else:
-            self.tool = "openocd"
             if isinstance(self.config, str):
                 self.config = [self.config]
             if isinstance(self.search, str):

--- a/labgrid/driver/quartushpsdriver.py
+++ b/labgrid/driver/quartushpsdriver.py
@@ -25,13 +25,8 @@ class QuartusHPSDriver(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
 
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool("quartus_hps")
-            self.jtag_tool = self.target.env.config.get_tool("jtagconfig")
-        else:
-            self.tool = "quartus_hps"
-            self.jtag_tool = "jtagconfig"
+        self.tool = self.target.get_tool("quartus_hps")
+        self.jtag_tool = self.target.get_tool("jtagconfig")
 
     def _get_cable_number(self):
         """

--- a/labgrid/driver/sigrokdriver.py
+++ b/labgrid/driver/sigrokdriver.py
@@ -28,13 +28,7 @@ from ..util import Timeout
 class SigrokCommon(Driver):
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool(
-                'sigrok-cli'
-            ) or 'sigrok-cli'
-        else:
-            self.tool = 'sigrok-cli'
+        self.tool = self.target.get_tool('sigrok-cli') or 'sigrok-cli'
         self._running = False
 
     def _create_tmpdir(self):

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -1,4 +1,5 @@
 import subprocess
+import warnings
 import attr
 
 from ..factory import target_factory
@@ -94,11 +95,21 @@ class RKUSBDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
+        tools = {}
         if self.target.env:
-            self.tool = self.target.env.config.get_tool('rk-usb-loader')
+            tools = self.target.env.config.data.get('tools') or {}
+        if 'rkdeveloptool' not in tools and 'rk-usb-loader' in tools:
+            # Backward compatibility: the rkdeveloptool binary used to be
+            # configured under the (misnamed) 'rk-usb-loader' tools key, which
+            # is now used by the RKBootstrapDriver instead.
+            warnings.warn(
+                "Configuring rkdeveloptool under the 'rk-usb-loader' tools key is "
+                "deprecated, use the 'rkdeveloptool' key instead",
+                DeprecationWarning,
+            )
+            self.tool = self.target.get_tool('rk-usb-loader')
         else:
-            self.tool = 'rk-usb-loader'
+            self.tool = self.target.get_tool('rkdeveloptool')
 
     def on_activate(self):
         pass
@@ -138,6 +149,54 @@ class RKUSBDriver(Driver, BootstrapProtocol):
                 processwrapper.check_output(
                     self.loader.command_prefix +
                     [self.tool, 'wl', '0x40', mf.get_remote_path()],
+                    print_on_silent_log=True
+                )
+                break
+            except subprocess.CalledProcessError:
+                if timeout.expired:
+                    raise
+
+
+@target_factory.reg_driver
+@attr.s(eq=False)
+class RKBootstrapDriver(Driver, BootstrapProtocol):
+    """The RKBootstrapDriver uploads a combined barebox image into a Rockchip
+    SoC in MaskROM mode using barebox's ``rk-usb-loader`` tool.
+
+    In contrast to the :any:`RKUSBDriver` (which uses rkdeveloptool's ``db`` and
+    ``wl`` commands to flash a bootloader to storage), this driver loads the
+    image into RAM and executes it, i.e. it performs a true bootstrap.
+    """
+    bindings = {
+        "loader": {"RKUSBLoader", "NetworkRKUSBLoader"},
+    }
+
+    image = attr.ib(default=None)
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        self.tool = self.target.get_tool('rk-usb-loader')
+
+    def on_activate(self):
+        pass
+
+    def on_deactivate(self):
+        pass
+
+    @Driver.check_active
+    @step(args=['filename'])
+    def load(self, filename=None):
+        if filename is None and self.image is not None:
+            filename = self.target.env.config.get_image_path(self.image)
+        mf = ManagedFile(filename, self.loader)
+        mf.sync_to_resource()
+
+        timeout = Timeout(3.0)
+        while True:
+            try:
+                processwrapper.check_output(
+                    self.loader.command_prefix +
+                    [self.tool, mf.get_remote_path()],
                     print_on_silent_log=True
                 )
                 break

--- a/labgrid/driver/usbloader.py
+++ b/labgrid/driver/usbloader.py
@@ -21,11 +21,7 @@ class MXSUSBDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool('mxs-usb-loader')
-        else:
-            self.tool = 'mxs-usb-loader'
+        self.tool = self.target.get_tool('mxs-usb-loader')
 
     def on_activate(self):
         pass
@@ -59,11 +55,7 @@ class IMXUSBDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool('imx-usb-loader')
-        else:
-            self.tool = 'imx-usb-loader'
+        self.tool = self.target.get_tool('imx-usb-loader')
 
     def on_activate(self):
         pass
@@ -166,11 +158,7 @@ class UUUDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool('uuu-loader')
-        else:
-            self.tool = 'uuu-loader'
+        self.tool = self.target.get_tool('uuu-loader')
 
     def on_activate(self):
         pass
@@ -211,11 +199,7 @@ class BDIMXUSBDriver(Driver, BootstrapProtocol):
 
     def __attrs_post_init__(self):
         super().__attrs_post_init__()
-        # FIXME make sure we always have an environment or config
-        if self.target.env:
-            self.tool = self.target.env.config.get_tool('imx_usb')
-        else:
-            self.tool = 'imx_usb'
+        self.tool = self.target.get_tool('imx_usb')
 
     def on_activate(self):
         pass

--- a/labgrid/target.py
+++ b/labgrid/target.py
@@ -41,6 +41,16 @@ class Target:
         else:
             input(msg)
 
+    def get_tool(self, tool):
+        """Return the path configured for ``tool`` in the environment.
+
+        Falls back to the bare tool name if the target has no environment (and
+        thus no configuration), so it can still be resolved via ``$PATH``.
+        """
+        if self.env:
+            return self.env.config.get_tool(tool)
+        return tool
+
     def update_resources(self):
         """
         Iterate over this target's resources, deactivate any active but

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -130,8 +130,15 @@ Path to the quartus_hps binary, used by the QuartusHPSDriver.
 See: \X'tty: link https://www.intel.com/content/www/us/en/docs/programmable/683039/22-3/hps-flash-programmer.html'\fI\%https://www.intel.com/content/www/us/en/docs/programmable/683039/22\-3/hps\-flash\-programmer.html\fP\X'tty: link'
 .TP
 .B \fBrk\-usb\-loader\fP
-Path to the rk\-usb\-loader binary, used by the RKUSBDriver.
+Path to the rk\-usb\-loader binary, used by the RKBootstrapDriver to load a
+barebox image into RAM and execute it.
 See: \X'tty: link https://git.pengutronix.de/cgit/barebox/tree/scripts/rk-usb-loader.c'\fI\%https://git.pengutronix.de/cgit/barebox/tree/scripts/rk\-usb\-loader.c\fP\X'tty: link'
+.TP
+.B \fBrkdeveloptool\fP
+Path to the rkdeveloptool binary, used by the RKUSBDriver. The driver
+invokes it with rkdeveloptool\(aqs \fBdb\fP and \fBwl\fP subcommands to write a
+bootloader to the target\(aqs storage.
+See: \X'tty: link https://github.com/rockchip-linux/rkdeveloptool'\fI\%https://github.com/rockchip\-linux/rkdeveloptool\fP\X'tty: link'
 .TP
 .B \fBrsync\fP
 Path to the rsync binary, used by the SSHDriver.


### PR DESCRIPTION
Labgrid currently has a ``RKUSBDriver`` which uses ``rkdeveloptool`` to write a bootloader image to a SD/MMC card connected to a Rockchip SoC. There currently is no driver to just upload and start a bootloader image without modifying the device storage. This PR adds exactly that. As the obvious name for this driver is already used by the existing driver, the driver is named ``RKBootstrapDriver``.

Some confusion exists in the ``rk-usb-loader`` tool. The documentation wrongly states that this should point to equally named ``rk-usb-loader`` tool from barebox when it really expects a ``rkdeveloptool`` in that key. This is cleaned up in a way that the existing ``RKUSBDriver`` now expects a ``rkdevelop`` key to find the ``rkdeveloptool`` and the new ``RKBootstrapDriver`` now expects a barebox ``rk-usb-loader`` tool under the ``rk-usb-loader`` key (as the documentation already states). For compatibility ``RKBootstrapDriver`` still falls back to the ``rk-usb-loader`` key, but a warning is printed when it's actually used.


<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
