### PR TITLE
util/proxy: allow overriding LG_PROXY from the environment config

### DIFF
--- a/doc/man/device-config.rst
+++ b/doc/man/device-config.rst
@@ -32,6 +32,8 @@ previous driver.
 For a list of available resources and drivers refer to
 https://labgrid.readthedocs.io/en/latest/configuration.html.
 
+.. _labgrid-device-config-options:
+
 OPTIONS
 -------
 The ``options:`` top key configures various options such as the coordinator_address.
@@ -42,6 +44,14 @@ OPTIONS KEYS
 ``coordinator_address``
   takes as parameter the coordinator ``HOST[:PORT]`` to connect to.
   Defaults to ``127.0.0.1:20408``.
+  Overrides the ``LG_COORDINATOR`` environment variable.
+
+``proxy``
+  takes as parameter the SSH proxy host used to tunnel connections to the
+  coordinator and to network resources.
+  Overrides the ``LG_PROXY`` environment variable.
+  Set it to an empty value (e.g. ``proxy:``) to force a direct connection
+  without a proxy, even when ``LG_PROXY`` is set.
 
 .. _labgrid-device-config-images:
 

--- a/doc/overview.rst
+++ b/doc/overview.rst
@@ -397,6 +397,13 @@ respective proxies. This means that with :code:`LG_PROXY` and
 :code:`LG_COORDINATOR` labgrid can be used fully remotely with only a SSH
 connection as a requirement.
 
+Instead of the environment variables, the :code:`proxy` and
+:code:`coordinator_address` options can be set in the environment config (see
+:ref:`labgrid-device-config-options`). The config options take precedence over
+the corresponding environment variables. Setting the :code:`proxy` option to an
+empty value forces a direct connection without a proxy, even when
+:code:`LG_PROXY` is set.
+
 .. note::
   Labgrid prefers to connect to an exporter-defined proxy over using the
   LG_PROXY variable. This means that a correct entry for the exporter needs to

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -479,6 +479,10 @@ Specifies a SSH proxy host to be used for port forwards to access the
 coordinator. Network resources made available by the exporter will prefer their
 own proxy, and only fallback to LG_PROXY.
 
+This can be overridden by the ``proxy`` option in the environment config (see
+:ref:`labgrid-device-config-options`). Setting that option to an empty value
+forces a direct connection without a proxy, even when ``LG_PROXY`` is set.
+
 See also :ref:`overview-proxy-mechanism`.
 
 

--- a/labgrid/pytestplugin/hooks.py
+++ b/labgrid/pytestplugin/hooks.py
@@ -6,6 +6,7 @@ import pytest
 from .. import Environment
 from ..consoleloggingreporter import ConsoleLoggingReporter
 from ..util.helper import processwrapper
+from ..util.proxy import proxymanager
 from ..logging import StepFormatter, StepLogger
 from ..exceptions import NoStrategyFoundError
 
@@ -89,6 +90,12 @@ def pytest_configure(config):
         env = Environment(config_file=lg_env)
         if lg_coordinator is not None:
             env.config.set_option('coordinator_address', lg_coordinator)
+        # Let the 'proxy' config option override the LG_PROXY environment
+        # variable; a present but empty/false value disables proxying.
+        try:
+            proxymanager.force_proxy(env.config.get_option("proxy"))
+        except KeyError:
+            pass  # no 'proxy' option: keep the LG_PROXY default
     config.stash[LABGRID_ENV_KEY] = env
 
     processwrapper.enable_logging()

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -2302,12 +2302,21 @@ def main():
         print("Setting the initial state requires a desired state", file=sys.stderr)
         exit(1)
 
-    if args.proxy:
-        proxymanager.force_proxy(args.proxy)
-
     env = None
     if args.config:
         env = Environment(config_file=args.config)
+
+    # Proxy precedence: --proxy command line argument > 'proxy' config option >
+    # LG_PROXY environment variable (the latter is the proxymanager's default).
+    # A 'proxy' config option that is present but empty/false explicitly
+    # disables proxying, even when LG_PROXY is set.
+    if args.proxy:
+        proxymanager.force_proxy(args.proxy)
+    elif env:
+        try:
+            proxymanager.force_proxy(env.config.get_option("proxy"))
+        except KeyError:
+            pass  # no 'proxy' option: keep the LG_PROXY default
 
     role = None
     if args.command != "reserve" and env and env.config.get_targets():

--- a/labgrid/util/proxy.py
+++ b/labgrid/util/proxy.py
@@ -22,6 +22,11 @@ class ProxyManager:
 
     @classmethod
     def force_proxy(cls, force_proxy):
+        # A falsy value (empty string, None, False) disables proxying, even if
+        # the LG_PROXY environment variable is set.
+        if not force_proxy:
+            cls._force_proxy = None
+            return
         assert isinstance(force_proxy, str)
         cls._force_proxy = force_proxy
 

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -60,6 +60,14 @@ The \fBoptions:\fP top key configures various options such as the coordinator_ad
 .B \fBcoordinator_address\fP
 takes as parameter the coordinator \fBHOST[:PORT]\fP to connect to.
 Defaults to \fB127.0.0.1:20408\fP\&.
+Overrides the \fBLG_COORDINATOR\fP environment variable.
+.TP
+.B \fBproxy\fP
+takes as parameter the SSH proxy host used to tunnel connections to the
+coordinator and to network resources.
+Overrides the \fBLG_PROXY\fP environment variable.
+Set it to an empty value (e.g. \fBproxy:\fP) to force a direct connection
+without a proxy, even when \fBLG_PROXY\fP is set.
 .UNINDENT
 .SS IMAGES
 .sp


### PR DESCRIPTION
The coordinator_address can already be set in the environment config, overriding the LG_COORDINATOR environment variable. But LG_COORDINATOR is only one part of the connection settings needed to reach a coordinator: the LG_PROXY variable, used to tunnel that connection over SSH, had no config counterpart and could only be set from the environment or the --proxy command line argument.

Add a 'proxy' option to the environment config that overrides LG_PROXY, mirroring coordinator_address. The precedence is --proxy command line argument > 'proxy' config option > LG_PROXY environment variable.

A present but empty/false 'proxy' option forces a direct connection without a proxy, even when LG_PROXY is set, which previously was not possible at all.

Assisted-by: Claude Opus 4.8

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
