### PR TITLE
util/managedfile: fix symlink creation for local case

### DIFF
--- a/labgrid/util/managedfile.py
+++ b/labgrid/util/managedfile.py
@@ -81,7 +81,9 @@ class ManagedFile:
                 # --symbolic --force --no-dereference
                 conn.run_check(f"ln -sfn {self.rpath}{os.path.basename(self.local_path)} {symlink}")
             else:
-                if os.path.exists(symlink) and not os.path.islink(symlink):
+                if os.path.islink(symlink):
+                    os.unlink(symlink)
+                elif os.path.exists(symlink):
                     raise ManagedFileError(f"Path {symlink} exists but is not a symlink.")
                 os.symlink(f"{self.rpath}{os.path.basename(self.local_path)}", symlink)
 


### PR DESCRIPTION
When a HTTPProvider driver is used a second time the link to the file already exists, so instead of just creating it we must replace it as done with the ln -f flag in the remote case. In the local case we currently get a FileExistsError when creating the link over an already existing one. Fix this by removing the old link before re-creating it.

Fixes: 18646f74 ("util/managedfile: replace ssh usage for local case")

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
