### PR TITLE
util/helper: fix process output getting truncated

### DIFF
--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -124,7 +124,7 @@ class ProcessWrapper:
                     stdin_w = None
 
             process.poll()
-            if process.returncode is not None:
+            if process.returncode is not None and len(ready_r) == 0:
                 break
 
         if stdin_w is not None:


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

A process that logs a lot of data before exiting could have its output truncated because ProcessWrapper used to stop reading the pipe once the process exits, but instead should always read to the end of the pipe.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
