### PR TITLE
logging: fix accidental tailing CR LF on certain SerialLoggingReporter messages

### DIFF
--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -78,7 +78,7 @@ class SerialLoggingReporter:
         return string
 
     def _create_message(self, event, data):
-        return "{source} {dirind} {data}␍␤".format(
+        return "{source} {dirind} {data}".format(
             source=event.step.source,
             dirind="<" if event.step.title == "read" else ">",
             data=data,
@@ -105,6 +105,7 @@ class SerialLoggingReporter:
                 self.lastevent = event
 
                 for part in parts:
+                    part += b"\r\n"
                     data = self.vt100_replace_cr_nl(part)
                     logger.log(logging.CONSOLE, self._create_message(event, data), extra=extra)
 


### PR DESCRIPTION
**Description**
`SerialLoggingReporter._create_message()` appends the representations for `\r\n` to each log message unconditionally. But `\r\n` must only be appended when splitting serial input on `\r\n` in `SerialLoggingReporter.notify()`.

Fix that by appending actual `\r\n` to the data to be logged. Do that before its representation is generated. A future commit can then add that data to the `extra` data in the log message allowing reconstruction of the serial data sent/received from the logs.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested

Fixes #1155

