### PR TITLE
tests: disable gRPC fork handlers to fix flaky fork() abort

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from signal import SIGTERM
 import sys
 import threading
@@ -12,6 +13,15 @@ from labgrid.resource import RawSerialPort, NetworkSerialPort
 from labgrid.driver.fake import FakeConsoleDriver
 
 psutil = pytest.importorskip("psutil")
+
+# gRPC is only safe to fork() if gRPC objects are created in the child after the fork. The tests do
+# the opposite: the pytest process spawns labgrid-client via pexpect (forkpty) while gRPC is
+# already initialized in it, so gRPC's pthread_atfork handler can lose a race and abort the child
+# before it execs. Set GRPC_ENABLE_FORK_SUPPORT=0 to disable the handler; the spawned clients
+# fork+exec and never reuse an inherited channel, so it is not needed anyway.
+# See also https://github.com/grpc/grpc/blob/master/doc/fork_support.md
+os.environ.setdefault("GRPC_ENABLE_FORK_SUPPORT", "0")
+
 
 @pytest.fixture(scope="session")
 def curses_init():


### PR DESCRIPTION
**Description**
The test suite intermittently fails in CI due to (pexpect spawned) labgrid-client being killed during teardown by SIGABRT and gRPC C-core aborting after a fork:

```
fork_posix.cc:71] Other threads are currently calling into gRPC, skipping fork() handlers
ev_epoll1_linux.cc:1125] Check failed: next_worker->state == KICKED
```

gRPC documents that fork() is only safe if gRPC objects are created in the child after the fork [1]. The tests do the opposite: the pytest process spawns the labgrid-client commands via pexpect (using forkpty) while gRPC is already initialized in it (imported at collection, and used in-process by the coordinator tests). To partially support this, gRPC installs a pthread_atfork handler that tries to quiesce its poller across the fork. When another thread is in the C-core at fork time the handler loses that race, skips the reset, and the forked child aborts on the inconsistent poller before it can exec the client.

The problem could never be reproduced locally; it likely occurs more often in CI because scheduling pressure makes the race more likely to trigger.

Set GRPC_ENABLE_FORK_SUPPORT=0 to disable the handler. This is the documented remedy for callers that always exec() after fork() and never reuse a channel across fork(), which is what the test suite does. Set it in conftest.py before pytest's collection imports grpc.

[1] https://github.com/grpc/grpc/blob/master/doc/fork_support.md

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] PR has been tested