### PR TITLE
tests: enable subprocess coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit =
     labgrid/remote/generated/*
+patch = subprocess
 
 [report]
 exclude_lines =


### PR DESCRIPTION
Subprocess coverage used to be provided by default by pytest-cov, however that was removed in newer versions in favor of using the coverage patch functionality. Use the coverage patch functionality to re-enable coverage of subprocesses, re-enabling coverage for the remote tests.

**Checklist**
- [x] PR has been tested

