### PR TITLE
remote/coordinator: fix scheduling for missing allocated places

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -986,6 +986,7 @@ class Coordinator(labgrid_coordinator_pb2_grpc.CoordinatorServicer):
                         res.allocations.clear()
                         res.refresh(300)
                         print(f"reservation ({res.owner}/{res.token}) is now {res.state.name}")
+                        break
                     if place.acquired is not None:
                         acquired_places.add(name)
                     assert name not in allocated_places, "conflicting allocation"


### PR DESCRIPTION
Fix a coordinator crash during reservation scheduling when a reservation still references a place which no longer exists. When `_schedule_reservations()` finds an allocated place missing, it marks the reservation invalid and clears its allocations. The loop now stops processing that allocation immediately, avoiding a later access to place.acquired while place is None. This was seen when `AcquirePlace` triggered reservation scheduling after a stale/missing allocated place existed in coordinator state.

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
