### PR TITLE
remote/coordinator: use correct response comparison in ExporterStream

### DIFF
--- a/labgrid/remote/coordinator.py
+++ b/labgrid/remote/coordinator.py
@@ -417,7 +417,7 @@ class Coordinator(labgrid_coordinator_pb2_grpc.CoordinatorServicer):
                     in_msg: labgrid_coordinator_pb2.ExporterInMessage
                     logging.debug("exporter in_msg %s", in_msg)
                     kind = in_msg.WhichOneof("kind")
-                    if kind in "response":
+                    if kind == "response":
                         cmd = pending_commands.pop(0)
                         cmd.complete(in_msg.response)
                         logging.debug("Command %s is done", cmd)


### PR DESCRIPTION
**Description**
`kind` is a string. Do not use a substring comparison to determine whether this is a response. Probably a remain of a tuple/list comparison during development.

Happens to behave correctly as long as the other message kinds aren't substrings of "response".

**Checklist**
- [ ] PR has been tested

Fixes #1469
