### PR TITLE
driver/usbvideodriver: fix USB VID typos

### DIFF
--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -129,7 +129,7 @@ class USBVideoDriver(Driver, VideoProtocol):
         elif match == (0x0c45, 0x636b):  # LogiLink UA0379 / Microdia
             controls = controls or "focus_auto=1"
             inner = None  # just forward the jpeg frames
-        elif match == (0x0c54, 0x636d):
+        elif match == (0x0c45, 0x636d):  # AUKEY PC-LM1E
             controls = controls or "focus_auto=1"
             inner = None  # just forward the jpeg frames
         else: # fallback pipeline

--- a/labgrid/driver/usbvideodriver.py
+++ b/labgrid/driver/usbvideodriver.py
@@ -126,7 +126,7 @@ class USBVideoDriver(Driver, VideoProtocol):
         elif match == (0x1d6c, 0x0103):
             controls = controls or "focus_auto=1"
             inner = "h264parse"
-        elif match == (0x0c54, 0x636b):
+        elif match == (0x0c45, 0x636b):  # LogiLink UA0379 / Microdia
             controls = controls or "focus_auto=1"
             inner = None  # just forward the jpeg frames
         elif match == (0x0c54, 0x636d):


### PR DESCRIPTION
**Description**
Fixes two USB VID typos in `get_pipeline()`.

**Checklist**
- [ ] PR has been tested

Fixes #937
Fixes #1486

/cc @tksc and @gsc-eag