### PR TITLE
util/helper: fix appending \n to unterminated final streamed chunks in ProcessWrapper

### DIFF
--- a/labgrid/util/helper.py
+++ b/labgrid/util/helper.py
@@ -135,7 +135,7 @@ class ProcessWrapper:
         if buf:
             # process incomplete line
             res.append(buf)
-            if buf[-1] != b'\n':
+            if not buf.endswith(b'\n'):
                 buf += b'\n'
             for callback in self.callbacks:
                 callback(buf, process)


### PR DESCRIPTION
**Description**
Addressing bytes by index returns an integer:

```python
In [1]: b"foo\n"[-1]
Out[1]: 10
```

This means the condition is accidentally always true. Fix that by using `endswith()`.

Found by Claude Opus 4.8.

**Checklist**
- [ ] PR has been tested

Fixes #567