### PR TITLE
driver/rawnetworkinterfacedriver: raise when tcpdump fails to start listening

### DIFF
--- a/labgrid/driver/rawnetworkinterfacedriver.py
+++ b/labgrid/driver/rawnetworkinterfacedriver.py
@@ -237,6 +237,8 @@ class RawNetworkInterfaceDriver(Driver):
                     e.stderr = stderr
                     raise
 
+                raise ExecutionError(f"tcpdump exited before emitting 'tcpdump: listening on': {stderr}")
+
             if line.startswith(b"tcpdump: listening on"):
                 break
 


### PR DESCRIPTION
**Description**
If tcpdump exits cleanly without emitting "tcpdump: listening on" (possibly due to the message being changed), `readline()` is called on a closed stderr stream, resulting in confusing exceptions. Fix that by raising a proper exception in that case.

**Checklist**
- [ ] PR has been tested
