### PR TITLE
power/mfi_mpower: Fix url handling in get_credentials

### DIFF
--- a/labgrid/driver/power/mfi_mpower.py
+++ b/labgrid/driver/power/mfi_mpower.py
@@ -43,7 +43,7 @@ def get_credentials(base_url: str) -> Tuple[str, dict]:
         credentials = dict(username='ubnt', password='ubnt')
     else:
         credentials = dict(username=base_url.username, password=base_url.password)
-        base_url._replace(netloc=base_url.netloc.replace(f'{base_url.username}:{base_url.password}@', ''))
+        base_url = base_url._replace(netloc=base_url.netloc.replace(f'{base_url.username}:{base_url.password}@', ''))
 
     base_url = base_url.geturl()
     return (base_url, credentials)


### PR DESCRIPTION
**Description**

Before:

```
>>> url
'http://login:password@hostname:port/path;params?query=query#fragment'
>>> def get_credentials(base_url: str) -> Tuple[str, dict]:
...     base_url = urlparse(base_url)
...     if base_url.username is None or base_url.password is None:
...         credentials = dict(username='ubnt', password='ubnt')
...     else:
...         credentials = dict(username=base_url.username, password=base_url.password)
...         base_url._replace(netloc=base_url.netloc.replace(f'{base_url.username}:{base_url.password}@', ''))
...     base_url = base_url.geturl()
...     return (base_url, credentials)
... 
>>> get_credentials(url)
('http://login:password@hostname:port/path;params?query=query#fragment', {'username': 'login', 'password': 'password'})
```


After:

```
>>> url
'http://login:password@hostname:port/path;params?query=query#fragment'
>>> def get_credentials(base_url: str) -> Tuple[str, dict]:
...     base_url = urlparse(base_url)
...     if base_url.username is None or base_url.password is None:
...         credentials = dict(username='ubnt', password='ubnt')
...     else:
...         credentials = dict(username=base_url.username, password=base_url.password)
...         base_url = base_url._replace(netloc=base_url.netloc.replace(f'{base_url.username}:{base_url.password}@', ''))
...     base_url = base_url.geturl()
...     return (base_url, credentials)
... 
>>> get_credentials(url)
('http://hostname:port/path;params?query=query#fragment', {'username': 'login', 'password': 'password'})
```

**Checklist**
- [X] PR has been tested