### PR TITLE
labgrid-suggest: add support for WCH CH34x

### DIFF
--- a/labgrid/resource/udev.py
+++ b/labgrid/resource/udev.py
@@ -107,6 +107,20 @@ class USBResource(ManagedResource):
                 else:
                     suggestions.append({'@ID_SERIAL_SHORT': serial})
 
+        # Multi-port USB serial adapters (e.g. WCH CH34x, FTDI multi) expose
+        # several ports under one USB interface, so ID_PATH / ID_SERIAL_SHORT /
+        # ID_USB_INTERFACE_NUM are identical for every port and the suggestions
+        # above are ambiguous. The kernel's per-port `port_number` sysfs attr on
+        # an ancestor is stable across re-enumeration; fold it into each
+        # suggestion (as an `@` ancestor match) so every port is unique.
+        for ancestor in self.device.ancestors:
+            if ancestor.attributes.get('port_number') is not None:
+                port_number = ancestor.attributes.asstring('port_number')
+                for suggestion in suggestions:
+                    suggestion['@port_number'] = port_number
+                meta['port_number'] = port_number
+                break
+
         return meta, suggestions
 
     def try_match(self, device):


### PR DESCRIPTION
**Description**

If a serial device connects as a single USB interface but offers multiple ports, labgrid-suggest does not enumerate the ports, making the suggest match rules unusable. With this patch, the specific port is added.

Current behaviour:
```shell
=== existing device ===
  USBSerialPort for /devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb4/4-2/4-2:1.0/ttyUSB7/tty/ttyUSB7
  === device properties ===
  device node: /dev/ttyUSB7
  udev tags: systemd
  vendor: wch.cn
  vendor (DB): QinHeng Electronics
  model: USB2.0_To_Multi_Serial_Ports
  revision: 0137
  === suggested matches ===
  USBSerialPort:
    match:
      ID_PATH: platform-xhci-hcd.1-usb-0:2:1.0
  ---
```

New output;

```shell
=== existing device ===
  USBSerialPort for /devices/platform/axi/1000120000.pcie/1f00300000.usb/xhci-hcd.1/usb4/4-2/4-2:1.0/ttyUSB7/tty/ttyUSB7
  === device properties ===
  device node: /dev/ttyUSB7
  udev tags: systemd
  vendor: wch.cn
  vendor (DB): QinHeng Electronics
  model: USB2.0_To_Multi_Serial_Ports
  revision: 0137
  port_number: 7
  === suggested matches ===
  USBSerialPort:
    match:
      '@port_number': '7'
      ID_PATH: platform-xhci-hcd.1-usb-0:2:1.0
  ---
```

**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
