### PR TITLE
driver/power: Add RPM1521 support

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -229,6 +229,13 @@ Currently available are:
   <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/rest.py>`__
   for details.
 
+``rpm1521``
+  Controls *Minuteman RPM1521* series networked power switches (2, 4 and 8 port
+  variants) via an HTTP CGI interface.
+  See the `docstring in the module
+  <https://github.com/labgrid-project/labgrid/blob/master/labgrid/driver/power/rpm1521.py>`__
+  for details.
+
 ``sentry``
   Controls *Sentry PDUs* via SNMP using Sentry3-MIB.
   It was tested on *CW-24VDD* and *4805-XLS-16*.

--- a/labgrid/driver/power/rpm1521.py
+++ b/labgrid/driver/power/rpm1521.py
@@ -1,0 +1,58 @@
+"""Power backend for the Minuteman RPM1521 networked power controller.
+
+The RPM1521 is controlled via an HTTP CGI endpoint using HTTP basic auth::
+
+    curl --user user:pwd \\
+        "http://192.168.1.100/nagios_powerctrl.csp?slave_id=1&port=<PORT>&ctrl_kind=<KIND>"
+
+where ``ctrl_kind=1`` turns the outlet on and ``ctrl_kind=2`` turns it off.
+
+The outlet state is read back from a separate status CGI::
+
+    curl --user user:pwd "http://192.168.1.100/nagios_power_status.csp"
+
+which returns a list whose second to last element holds the on/off state of each
+outlet (0 = off, 1 = on).
+
+    NetworkPowerPort:
+        model: rpm1521
+        host: 'http://admin:secret@192.168.1.10'
+        index: 1
+"""
+
+import json
+
+import requests
+
+SLAVE_ID = 1
+CTRL_KIND_ON = 1
+CTRL_KIND_OFF = 2
+
+
+def power_set(host, port, index, value):
+    index = int(index)
+    ctrl_kind = CTRL_KIND_ON if value else CTRL_KIND_OFF
+    params = {
+        "slave_id": SLAVE_ID,
+        "port": index,
+        "ctrl_kind": ctrl_kind,
+    }
+    r = requests.get(f"{host}/nagios_powerctrl.csp", params=params)
+    r.raise_for_status()
+
+
+def power_get(host, port, index):
+    index = int(index)
+    params = {
+        "slave_id": SLAVE_ID,
+    }
+    r = requests.get(f"{host}/nagios_power_status.csp", params=params)
+    r.raise_for_status()
+
+    # The status CGI returns a list literal, e.g.
+    #   ['RPM1521E','0.0','NULL','1','1','109.9',['1','0'],['0','1'],['0.0','0.0']]
+    # It contains several bracketed sub-lists; the second to last one holds the
+    # on/off status of each outlet.
+    data = json.loads(r.text.replace("'", '"'))
+    socket_states = data[-2]
+    return int(socket_states[index - 1]) == 1

--- a/tests/test_powerdriver.py
+++ b/tests/test_powerdriver.py
@@ -295,6 +295,7 @@ class TestNetworkPowerDriver:
         import labgrid.driver.power.pe6216
         import labgrid.driver.power.poe_netgear_plus
         import labgrid.driver.power.rest
+        import labgrid.driver.power.rpm1521
         import labgrid.driver.power.sentry
         import labgrid.driver.power.eg_pms2_network
         import labgrid.driver.power.shelly_gen1


### PR DESCRIPTION
Add power driver support for the Minuteman RPM1521 series which comes in 2, 4 and 8 port configurations. This driver should also work for the Amberry IP2,4,8 series as they are based on the same hardware.

Tested locally on an RPM1521E.

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [x] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
