### PR TITLE
tests/test_netns: define test dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ dev = [
     "pylint>=3.0.0",
     "ruff>=0.5.7",
     "pystuck",
+    "requests[socks]>=2.26.0",
 
     # GRPC Channelz support
     "grpcio-channelz>=1.64.1, <2.0.0",

--- a/tests/test_netns.py
+++ b/tests/test_netns.py
@@ -4,6 +4,7 @@ import os
 import socket
 import subprocess
 import time
+from shutil import which
 
 import pytest
 
@@ -136,7 +137,11 @@ def test_detach(netns):
     assert netns._agent.list_sockets() == []
 
 
+@pytest.mark.skipif(not which("microsocks"), reason="microsocks not available")
 def test_socks(netns, tmp_path):
+    # installed via requests[socks]
+    pytest.importorskip("socks")
+
     with contextlib.ExitStack() as stack:
         (port, password) = stack.enter_context(netns.socks_proxy())
 


### PR DESCRIPTION
**Description**
Instead of letting the tests fail, define what is required to run them. Skip if the requirements are not met.

Also add `requests[socks]` to the `labgrid[dev]` extra to allow `tests/test_netns.py::test_socks` to run.

**Checklist**
- [x] PR has been tested (on top of #1887 to prevent the "Operation not permitted" error, but this PR does not depend on that)