### PR TITLE
driver: don't assume target is set in __str__

### DIFF
--- a/labgrid/driver/qemudriver.py
+++ b/labgrid/driver/qemudriver.py
@@ -367,7 +367,10 @@ class QEMUDriver(ConsoleExpectMixin, Driver, PowerProtocol, ConsoleProtocol):
         return self._clientsocket.send(data)
 
     def __str__(self):
-        return f"QemuDriver({self.target.name})"
+        # self.target is None while binding is still in progress, so error
+        # messages raised during bind must not assume it is set
+        target_name = self.target.name if self.target is not None else None
+        return f"QemuDriver({target_name})"
 
     @Driver.check_active
     def interact(self):

--- a/labgrid/driver/serialdriver.py
+++ b/labgrid/driver/serialdriver.py
@@ -115,4 +115,7 @@ class SerialDriver(ConsoleExpectMixin, Driver, ConsoleProtocol):
             self.status = 0
 
     def __str__(self):
-        return f"SerialDriver({self.target.name})"
+        # self.target is None while binding is still in progress, so error
+        # messages raised during bind must not assume it is set
+        target_name = self.target.name if self.target is not None else None
+        return f"SerialDriver({target_name})"

--- a/tests/test_serialdriver.py
+++ b/tests/test_serialdriver.py
@@ -1,5 +1,6 @@
 import pytest
 
+from labgrid.binding import BindingError
 from labgrid.driver import SerialDriver
 from labgrid.exceptions import NoSupplierFoundError
 
@@ -8,6 +9,12 @@ class TestSerialDriver:
     def test_instanziation_fail_missing_port(self, target):
         with pytest.raises(NoSupplierFoundError):
             SerialDriver(target, "serial")
+
+    def test_unexpected_binding_reports_binding_error(self, target, serial_port):
+        target.set_binding_map({"port": "serial", "unexpected": "foo"})
+        with pytest.raises(BindingError) as excinfo:
+            SerialDriver(target, "serial")
+        assert "got unexpected bindings" in excinfo.value.msg
 
     def test_instanziation(self, target, serial_port, mocker):
         serial_mock = mocker.patch("serial.Serial")


### PR DESCRIPTION
**Description**

`Driver.__attrs_post_init__` temporarily sets `self.target = None` while binding is in progress, so a driver's `__str__` must not dereference it. When `Target.bind_driver` raised `BindingError(f"{client} got unexpected bindings: ...")`, formatting that message called `SerialDriver.__str__` and blew up with `AttributeError: 'NoneType' object has no attribute 'name'`, hiding the real cause. `QemuDriver.__str__` had the same pattern, so both were fixed (as suggested in the issue).

Tested locally: the new `test_unexpected_binding_reports_binding_error` fails with the reported `AttributeError` without the source change and passes with it; `tests/test_serialdriver.py` and `tests/test_target.py` are green (52 passed).

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] PR has been tested
- [ ] Man pages have been regenerated

Fixes #1414
