### PR TITLE
remote/client: let -p restrict env-wide acquire/release

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -506,6 +506,17 @@ class ClientSession:
 
         return places
 
+    def get_place_names_to_operate_on(self):
+        """Returns the place names acquire/release should operate on.
+
+        An explicitly requested place (via -p/--place, LG_PLACE or PLACE) always
+        wins, even when an environment config is given. Only without one do we
+        operate on every RemotePlace of the environment.
+        """
+        if self.env and not getattr(self.args, "explicit_place", False):
+            return self.get_place_names_from_env()
+        return [self.args.place]
+
     def get_idle_place(self, place=None):
         place = self.get_place(place)
         if place.acquired:
@@ -710,7 +721,7 @@ class ClientSession:
 
     async def acquire(self):
         errors = []
-        places = self.get_place_names_from_env() if self.env else [self.args.place]
+        places = self.get_place_names_to_operate_on()
         for place in places:
             try:
                 await self._acquire_place(place)
@@ -770,7 +781,7 @@ class ClientSession:
 
     async def release(self):
         errors = []
-        places = self.get_place_names_from_env() if self.env else [self.args.place]
+        places = self.get_place_names_to_operate_on()
         for place in places:
             try:
                 await self._release_place(place)
@@ -2274,6 +2285,10 @@ def main():
 
     if args.place is None:
         args.place = place
+
+    # remember whether the user explicitly selected a place, so that env-wide
+    # commands can be restricted to it
+    args.explicit_place = args.place is not None
 
     if args.state is None:
         args.state = state

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -205,6 +205,41 @@ def test_place_acquire_multiple(create_place, tmpdir):
         spawn.expect('User.*Host.*Place.*Changed\r\n')
     assert not spawn.before, spawn.before
 
+def test_place_acquire_with_env_and_place(create_place, tmpdir):
+    # create multiple places
+    place_names = ['test1', 'test2']
+    for place_name in place_names:
+        create_place(place_name)
+
+    # create env config with multiple RemotePlaces
+    p = tmpdir.join('config.yaml')
+    p.write('targets:')
+    for place_name in place_names:
+        p.write(
+            f"""
+        {place_name}:
+          resources:
+            RemotePlace:
+              name: {place_name}
+        """,
+            mode='a',
+        )
+
+    # -p must restrict the env-wide acquire to that single place
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} -p test2 acquire') as spawn:
+        spawn.expect(pexpect.EOF)
+    assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client who') as spawn:
+        spawn.expect(pexpect.EOF)
+        assert b'test2' in spawn.before
+        assert b'test1' not in spawn.before
+    assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn(f'python -m labgrid.remote.client -c {p} -p test2 release') as spawn:
+        spawn.expect(pexpect.EOF)
+    assert spawn.exitstatus == 0, spawn.before.strip()
+
 def test_place_acquire_enforce(place):
     with pexpect.spawn('python -m labgrid.remote.client -p test add-match does/not/exist') as spawn:
         spawn.expect(pexpect.EOF)


### PR DESCRIPTION
**Description**

Since `acquire`/`release` started operating on all `RemotePlace`s in the environment config, passing both `-c env.yaml` and `-p NAME` silently ignored `-p` and acquired every place in the env — contending with other users and CI jobs that historically used that combination to manage one device at a time.

An explicitly requested place (`-p`/`--place`, `LG_PLACE`, or the legacy `PLACE` variable) now restricts `acquire`/`release` to that single place. Without one, the env-wide behaviour is unchanged.

**Checklist**
- [ ] Documentation for the feature
- [x] Tests for the feature
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] PR has been tested
- [ ] Man pages have been regenerated

Tested locally: the new `test_place_acquire_with_env_and_place` fails on master (both places acquired) and passes with the fix; `test_place_acquire`, `test_place_acquire_multiple` and `test_place_acquire_enforce` still pass.

Fixes #1868
