### PR TITLE
driver: add initial type hints for common driver code

### DIFF
--- a/labgrid/driver/common.py
+++ b/labgrid/driver/common.py
@@ -1,8 +1,11 @@
 import logging
 import subprocess
+from typing import cast
+
 import attr
 
 from ..binding import BindingError, BindingMixin
+from ..resource import Resource
 from .exception import ExecutionError
 
 
@@ -21,7 +24,7 @@ class Driver(BindingMixin):
     - deactivate
     """
 
-    def __attrs_post_init__(self):
+    def __attrs_post_init__(self) -> None:
         super().__attrs_post_init__()
         if self.target is None:
             raise BindingError("Drivers can only be created on a valid target")
@@ -31,7 +34,7 @@ class Driver(BindingMixin):
             logger_name += f":{self.name}"
         self.logger = logging.getLogger(logger_name)
 
-    def get_priority(self, protocol):
+    def get_priority(self, protocol) -> int:
         """Retrieve the priority for a given protocol
 
         Arguments:
@@ -41,17 +44,17 @@ class Driver(BindingMixin):
             Int: value of the priority if it is found, 0 otherwise.
         """
         for cls in self.__class__.__mro__:
-            prios = getattr(cls, 'priorities', {})
+            prios = getattr(cls, "priorities", {})
             # we found a matching parent priorities attribute with the matching protocol
             if prios and protocol in prios:
-                return prios.get(protocol)
+                return cast(int, prios[protocol])
             # If we find the parent protocol, set the priority to 0
             if cls.__name__ == protocol.__name__:
                 return 0
 
         return 0
 
-    def get_export_name(self):
+    def get_export_name(self) -> str:
         """Get the name to be used for exported variables.
 
         Falls back to the class name if the driver has no name.
@@ -60,12 +63,12 @@ class Driver(BindingMixin):
             return self.name
         return self.__class__.__name__
 
-    def get_export_vars(self):
+    def get_export_vars(self) -> dict[str, str]:
         """Get a dictionary of variables to be exported."""
         return {}
 
     @property
-    def skip_deactivate_on_export(self):
+    def skip_deactivate_on_export(self) -> bool:
         """Drivers are deactivated on export by default.
 
         If the driver can handle external accesses even while active, it can
@@ -73,16 +76,17 @@ class Driver(BindingMixin):
         """
         return False
 
-    def get_bound_resources(self):
+    def get_bound_resources(self) -> set[Resource]:
         """Return the bound resources for a driver
 
         This recursively calls all suppliers and combines the sets of returned resources.
         """
-        res = set()
+        res: set[Resource] = set()
         for supplier in self.suppliers:
             res |= supplier.get_bound_resources()
         return res
 
-def check_file(filename, *, command_prefix=[]):
-    if subprocess.call(command_prefix + ['test', '-r', filename]) != 0:
+
+def check_file(filename, *, command_prefix: list[str] | None = None) -> None:
+    if subprocess.call((command_prefix or []) + ["test", "-r", filename]) != 0:
         raise ExecutionError(f"File {filename} is not readable")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,6 +224,7 @@ include = [
   "examples/**/*.py",
   "labgrid/driver/httpvideodriver.py",
   "labgrid/driver/manualswitchdriver.py",
+  "labgrid/driver/common.py",
   "labgrid/driver/power/gude8031.py",
   "labgrid/driver/power/pe6216.py",
   "labgrid/driver/power/poe_netgear_plus.py",

--- a/tests/test_driver_common.py
+++ b/tests/test_driver_common.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock
+
+import pytest
+
+from labgrid import Target
+from labgrid.binding import BindingError
+from labgrid.driver.common import Driver, check_file
+from labgrid.driver.exception import ExecutionError
+
+
+def test_driver_requires_target() -> None:
+    with pytest.raises(BindingError):
+        Driver(None, None)
+
+
+def test_driver_get_priority_returns_zero_for_unknown_protocol(target: Target) -> None:
+    class Protocol:
+        pass
+
+    driver = Driver(target, None)
+
+    assert driver.get_priority(Protocol) == 0
+
+
+def test_driver_get_export_vars_returns_empty_dict(target: Target) -> None:
+    driver = Driver(target, None)
+
+    assert driver.get_export_vars() == {}
+
+
+def test_check_file_uses_default_command_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    call = Mock(return_value=0)
+    monkeypatch.setattr("labgrid.driver.common.subprocess.call", call)
+
+    check_file("/tmp/file")
+
+    call.assert_called_once_with(["test", "-r", "/tmp/file"])
+
+
+def test_check_file_raises_execution_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    call = Mock(return_value=1)
+    monkeypatch.setattr("labgrid.driver.common.subprocess.call", call)
+
+    with pytest.raises(ExecutionError, match="File /tmp/file is not readable"):
+        check_file("/tmp/file")


### PR DESCRIPTION
**Description**

This PR starts adding type annotations incrementally, as discussed in #1945.

In later PRs, the [ty](https://docs.astral.sh/ty/) type checker will be added and activated for CI runs of this project.

Verified locally with:

``` shell
uv run --extra dev pytest tests/test_driver_common.py
uv run ruff check labgrid/driver/common.py tests/test_driver_common.py
uv run ruff format --check --diff labgrid/driver/common.py tests/test_driver_common.py
uv run ty check
```

**Checklist**

- [ ] Documentation for the feature
- [ ] Tests for the feature
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] PR has been tested
- [ ] Man pages have been regenerated
