### PR TITLE
driver/rawnetworkinterfacedriver: fix ethtool argument order in get_ethtool_eee_settings()

### DIFF
--- a/labgrid/driver/rawnetworkinterfacedriver.py
+++ b/labgrid/driver/rawnetworkinterfacedriver.py
@@ -140,7 +140,7 @@ class RawNetworkInterfaceDriver(Driver):
         Returns Energy-Efficient Ethernet settings via ethtool of the bound network interface
         resource.
         """
-        cmd = self.iface.command_prefix + ["ethtool", "--show-eee", "--json", self.iface.ifname]
+        cmd = self.iface.command_prefix + ["ethtool", "--json", "--show-eee", self.iface.ifname]
         output = subprocess.check_output(cmd, encoding="utf-8")
         return json.loads(output)[0]
 


### PR DESCRIPTION
**Description**
ethtool's `--show-eee` expects the device name next. Fix that by moving `--json` to the front.

**Checklist**
- [x] PR has been tested

Fixes #1525
