### PR TITLE
Improve Structured Logging of Serial and Step Data

### DIFF
--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -89,6 +89,7 @@ class SerialLoggingReporter:
         state = event.data.get("state")
         extra = {
             "step": step,
+            "method": event.step.title,
         }
         if step.tag == "console":
             self.loggers[step.source] = logging.getLogger(
@@ -121,6 +122,7 @@ class SerialLoggingReporter:
 
         extra = {
             "step": self.lastevent.step,
+            "method": self.lastevent.step.title,
         }
         for source, logger in self.loggers.items():
             data = self.vt100_replace_cr_nl(self.bufs[source])

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -1,4 +1,5 @@
 import logging
+import copy
 
 import attr
 
@@ -88,7 +89,7 @@ class SerialLoggingReporter:
         step = event.step
         state = event.data.get("state")
         extra = {
-            "step": step,
+            "step": copy.copy(step),
             "method": event.step.title,
         }
         if step.tag == "console":
@@ -121,7 +122,7 @@ class SerialLoggingReporter:
             return
 
         extra = {
-            "step": self.lastevent.step,
+            "step": copy.copy(self.lastevent.step),
             "method": self.lastevent.step.title,
         }
         for source, logger in self.loggers.items():
@@ -251,7 +252,7 @@ class StepLogger:
         level = logging.INFO
         extra = {
             "indent_level": event.step.level,
-            "step": event.step,
+            "step": copy.copy(event.step),
             "next_indent_level": cls.get_next_indent(event),
         }
         cls._logger.log(level, message, extra=extra)

--- a/labgrid/logging.py
+++ b/labgrid/logging.py
@@ -107,10 +107,12 @@ class SerialLoggingReporter:
                 for part in parts:
                     part += b"\r\n"
                     data = self.vt100_replace_cr_nl(part)
+                    extra["data"] = part.decode()
                     logger.log(logging.CONSOLE, self._create_message(event, data), extra=extra)
 
             elif state == "start" and step.args and "data" in step.args:
                 data = self.vt100_replace_cr_nl(step.args["data"])
+                extra["data"] = step.args["data"].decode()
                 logger.log(logging.CONSOLE, self._create_message(event, data), extra=extra)
 
     def flush(self):
@@ -123,6 +125,7 @@ class SerialLoggingReporter:
         for source, logger in self.loggers.items():
             data = self.vt100_replace_cr_nl(self.bufs[source])
             if data:
+                extra["data"] = self.bufs[source].decode()
                 logger.log(logging.CONSOLE, self._create_message(self.lastevent, data), extra=extra)
             self.bufs[source] = b""
 

--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -111,6 +111,7 @@ class Step:
         self._start_ts = None
         self._stop_ts = None
         self._skipped = False
+        self._is_copy = False
 
     def __repr__(self):
         result = [f"Step(title={self.title!r}, level={self.level}, status={self.status}"]
@@ -131,6 +132,8 @@ class Step:
         if self._start_ts is None:
             return 0.0
         if self._stop_ts is None:
+            if self._is_copy:
+                return 0.0
             return monotonic() - self._start_ts
 
         return self._stop_ts - self._start_ts
@@ -157,6 +160,7 @@ class Step:
         steps.notify(event)
 
     def start(self):
+        assert not self._is_copy, "calling start() on a copy is not allowed"
         assert self._start_ts is None
         self._start_ts = monotonic()
         steps.push(self)
@@ -171,10 +175,12 @@ class Step:
         )
 
     def skip(self, reason):
+        assert not self._is_copy, "calling skip() on a copy is not allowed"
         assert self._start_ts is not None
         self._notify(StepEvent(self, {"skip": reason}))
 
     def stop(self):
+        assert not self._is_copy, "calling stop() on a copy is not allowed"
         assert self._start_ts is not None
         assert self._stop_ts is None
         self._stop_ts = monotonic()
@@ -190,8 +196,15 @@ class Step:
         steps.pop(self)
 
     def __del__(self):
-        if not self.is_done:
+        if not self.is_done and not self._is_copy:
             warnings.warn(f"__del__ called before {self} was done")
+
+    def __copy__(self):
+        cls = self.__class__
+        new = cls.__new__(cls)
+        new.__dict__.update(self.__dict__)
+        new._is_copy = True
+        return new
 
 
 def step(*, title=None, args=[], result=False, tag=None):

--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -191,7 +191,7 @@ class Step:
 
     def __del__(self):
         if not self.is_done:
-            warnings.warn(f"__del__ called before {step} was done")
+            warnings.warn(f"__del__ called before {self} was done")
 
 
 def step(*, title=None, args=[], result=False, tag=None):


### PR DESCRIPTION
**Description**
- Store raw serial data and read/write method in log records for structured, machine-readable logging.
- Store Step objects in SerialLoggingReporter log records in their current rather than afterwards mutated state.

**Checklist**
- [x] PR has been tested