### PR TITLE
client: fix header row placement in 'who' output

### DIFF
--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -419,7 +419,7 @@ class ClientSession:
             if self.args.show_exporters:
                 exporters = {resource_path[0] for resource_path in place.acquired_resources}
                 result[-1].append(", ".join(sorted(exporters)))
-        result.sort()
+        result[1:] = sorted(result[1:])
 
         widths = [max(map(len, c)) for c in zip(*result)]
         layout = []

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -162,6 +162,32 @@ def test_place_acquire(place):
         spawn.close()
         assert spawn.exitstatus == 0, spawn.before.strip()
 
+def test_place_who_header_stays_first(monkeypatch, place):
+    # A user name starting with an uppercase letter sorts before the "User"
+    # header when comparing strings (uppercase letters have lower code points
+    # than lowercase ones). Ensure the header still stays on the first line.
+    user = "Alice"
+    host = "test-host"
+    monkeypatch.setenv("LG_USERNAME", user)
+    monkeypatch.setenv("LG_HOSTNAME", host)
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test acquire') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
+    with pexpect.spawn('python -m labgrid.remote.client who') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+        lines = spawn.before.decode("utf-8").strip().splitlines()
+        assert lines[0].split()[:4] == ["User", "Host", "Place", "Changed"], lines
+
+    with pexpect.spawn('python -m labgrid.remote.client -p test release') as spawn:
+        spawn.expect(pexpect.EOF)
+        spawn.close()
+        assert spawn.exitstatus == 0, spawn.before.strip()
+
 def test_place_acquire_multiple(create_place, tmpdir):
     # create multiple places
     place_names = ['test1', 'test2']


### PR DESCRIPTION
The 'who' command stored the header row as the first element of the result list and then called result.sort(), which sorted the header together with the data rows. Because string comparison is case sensitive (uppercase letters sort before lowercase), the 'User' header could end up between uppercase and lowercase user names instead of staying on top.

Sort only the data rows (result[1:]) so the header always remains the first line.

**Description**

Currently:
```
$ labgrid-client who
Freenix   nxa18884-linux-1                 imx8qm-mek-bu07               2026-07-28 21:48:50.118257
User      Host                             Place                         Changed
bamboo    lsv052263.swis.nl-cdc01.nxp.com  imx8qm-mek-bu06               2026-07-27 18:06:45.687974
```

After:
```
$ labgrid-client who
User      Host                             Place                         Changed
Freenix   nxa18884-linux-1                 imx8qm-mek-bu07               2026-07-28 21:48:50.118257
bamboo    lsv052263.swis.nl-cdc01.nxp.com  imx8qm-mek-bu06               2026-07-27 18:06:45.687974
```

**Checklist**
- [✓] PR has been tested