### PR TITLE
pyproject.toml: migrate to PEP 639 license expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ authors = [
 ]
 description = "embedded systems control library for development, testing and installation"
 readme = "README.rst"
-license = { file="LICENSE" }
+license = "LGPL-2.1-or-later"
+license-files = [ "LICENSE" ]
 requires-python = ">=3.10"
 classifiers = [
     "Intended Audience :: Developers",
@@ -29,7 +30,6 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)",
 ]
 dependencies = [
     "attrs>=21.4.0",


### PR DESCRIPTION
**Description**

Make `license` a proper SDPX license expression.
Use `license-files` for license files.
Replace the also-deprecated `License ::` classifier.

See https://setuptools.pypa.io/en/latest/userguide/license_migration.html

Fixes:

```
SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
  !!

  ********************************************************************************
  Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

  By 2027-Feb-18, you need to update your project and remove deprecated calls
  or your builds will no longer be supported.

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ********************************************************************************
```
```
SetuptoolsDeprecationWarning: License classifiers are deprecated.
  !!

  ********************************************************************************
  Please consider removing the following classifiers in favor of a SPDX license expression:

  License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)

  See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
  ********************************************************************************
```

<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
