### PR TITLE
OpenOCDDriver: disable default server ports

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -2318,6 +2318,12 @@ OpenOCDDriver
 An :any:`OpenOCDDriver` controls *OpenOCD* to bootstrap a target with a
 bootloader.
 
+The driver disables OpenOCD's GDB, telnet and TCL server ports. It does not
+provide a lifecycle to expose or stop these server interfaces, and disabling
+them allows multiple bootstrap operations to run concurrently on one exporter.
+Configurations which require a server interface can re-enable it with an
+appropriate command before ``init``.
+
 Note that OpenOCD supports specifying USB paths since
 `a1b308ab <https://sourceforge.net/p/openocd/code/ci/a1b308ab/>`_ which was released with v0.11.
 The OpenOCDDriver passes the resource's USB path.

--- a/labgrid/driver/openocddriver.py
+++ b/labgrid/driver/openocddriver.py
@@ -55,6 +55,14 @@ class OpenOCDDriver(Driver, BootstrapProtocol):
         cmd = [self.tool]
         cmd += chain.from_iterable(("--search", path) for path in self.search)
         cmd += self._get_usb_path_cmd()
+        cmd += [
+            "--command",
+            "gdb_port disabled",
+            "--command",
+            "telnet_port disabled",
+            "--command",
+            "tcl_port disabled",
+        ]
 
         managed_configs = []
         for config in self.config:


### PR DESCRIPTION
**Description**

OpenOCD starts GDB, telnet, and TCL servers on fixed default ports. When
multiple boards on the same exporter bootstrap concurrently, the second
OpenOCD instance fails to bind these ports.

Disable the server ports before loading OpenOCD configuration files.
OpenOCDDriver does not provide a lifecycle for using or stopping these
servers, while disabling them allows parallel bootstrap operations.

Configurations that intentionally require a server interface can re-enable
the required port before `init`.

**Checklist**

- [x] Documentation for the feature
- [ ] Tests for the feature
- [ ] The arguments and description in doc/configuration.rst have been updated
- [ ] Add a section on how to use the feature to doc/usage.rst
- [ ] Add a section on how to use the feature to doc/development.rst
- [x] PR has been tested
- [ ] Man pages have been regenerated

Tested with:

```
pytest -q tests/test_openocd.py
ruff check labgrid/driver/openocddriver.py
ruff format --check labgrid/driver/openocddriver.py
```