### PR TITLE
resource/remote: handle unknown resource

### DIFF
--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -3,6 +3,7 @@ import os
 import attr
 
 from ..factory import target_factory
+from ..exceptions import InvalidConfigError
 from .common import NetworkResource, ManagedResource, ResourceManager
 
 
@@ -47,8 +48,13 @@ class RemotePlaceManager(ResourceManager):
         resource_entries = self.session.get_target_resources(place)  # pylint: disable=no-member
         expanded = []
         for (resource_name, _), resource_entry in resource_entries.items():
-            new = target_factory.make_resource(
-                remote_place.target, resource_entry.cls, resource_name, resource_entry.args)
+            try:
+                new = target_factory.make_resource(
+                    remote_place.target, resource_entry.cls, resource_name, resource_entry.args)
+            except InvalidConfigError:
+                self.logger.warning("unknown resource cls: %s, name: %s", resource_entry.cls, resource_name)
+                continue
+
             new.parent = remote_place
             new.avail = resource_entry.avail
             new.extra = resource_entry.extra


### PR DESCRIPTION
**Description**

Instead of failing to create a RemotePlaceManager print out a warning on unknown remote resources and continue.

This will allow use of standard tools like labgrid-client's console together with a remote place where some of its resources are unknown/custom.

This will add value for projects using not yet upstreamed resources or if they're simply too custom for upstream. So useful labgrid-client tools can still be used without any workarounds.

Current workaround is importing labgrid client main in custom project where the custom resources are registered and create custom command to run labgrid-client.


**Checklist**

- [x] PR has been tested locally

It was tested by adding an unknown resource to an exporter and adding it to a place with a serial connection like
```yaml
# Exporter yaml
DUT-X:
  linux:
    cls: 'USBSerialPort'
    match:
      ID_PATH: 'X'
    speed: 115200
  wifi:
    cls: 'WifiService'
    address: 'x'
    username: 'root'
    ssid: 'ssidX'
```