### PR TITLE
step: make Steps._stack thread-local for thread safety

### DIFF
--- a/labgrid/step.py
+++ b/labgrid/step.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import threading
 import warnings
 from functools import wraps
 from time import monotonic
@@ -9,8 +10,14 @@ from time import monotonic
 # after some time
 class Steps:
     def __init__(self):
-        self._stack = []
+        self._local = threading.local()
         self._subscribers = []
+
+    @property
+    def _stack(self):
+        if not hasattr(self._local, 'stack'):
+            self._local.stack = []
+        return self._local.stack
 
     def get_current(self):
         return self._stack[-1] if self._stack else None


### PR DESCRIPTION
Replace the shared stack list with a threading.local()-backed property so that each thread maintains its own step stack, preventing a fatal race condition in multi-threaded usage. 

I first surfaced this issue when attempting to boot two QEMU targets in parallel using the `QEMUDriver`.
Essentially doing this:

```
import threading

def _run(target):
    driver = target.get_driver(QEMUDriver)
    driver.on()   # @step-decorated -- pushes/pops onto the shared Steps._stack

threads = [threading.Thread(target=_run, args=(t,)) for t in targets.values()]
for t in threads:
    t.start()
for t in threads:
    t.join()

```

When I tried running qemu boot - each on one thread - it crashed since the threads were modifying the same stack list at the same time for separate targets. This applies to all `@step` decorated functions throughout the repo.

By applying this patch we will essentially have a stack-per-thread setup and the concurrently executing threads do not step on eachother via `@step`. Current single threaded behavior remains unaffected.







<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->

<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [ ] Documentation for the feature
- [ ] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [ ] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
