### PR TITLE
pyproject.toml: drop wheel build requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 # Minimum requirements for the build system to execute.
 requires = [
     "setuptools>=77.0.0",
-    "wheel",
     "setuptools_scm[toml]",
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
**Description**
setuptools >= v70.1.0 implements the `build_wheel` command itself [1][2]. This was provided by the wheel dependency before.

Now that #1687 is merged, an even newer setuptools version is required, drop the wheel requirement.

[1] https://github.com/pypa/setuptools/commit/52d732434377dac92df9b50a93eb78fe743b9e24
[2] https://github.com/pypa/setuptools/commit/b3d3e93a834426f1bef8712e1405495084eb3b7f

**Checklist**
- [x] PR has been tested