### PR TITLE
remote/exporter: fix `AttributeError` when exporting `NFSProvider` resources

### DIFF
--- a/labgrid/remote/exporter.py
+++ b/labgrid/remote/exporter.py
@@ -619,8 +619,27 @@ class ProviderGenericExport(ResourceExport):
 
 
 exports["TFTPProvider"] = ProviderGenericExport
-exports["NFSProvider"] = ProviderGenericExport
 exports["HTTPProvider"] = ProviderGenericExport
+
+
+@attr.s(eq=False)
+class NFSProviderExport(ResourceExport):
+    """ResourceExport for the NFSProvider (no internal/external paths)"""
+
+    def __attrs_post_init__(self):
+        super().__attrs_post_init__()
+        from ..resource import provider
+
+        self.data["cls"] = "RemoteNFSProvider"
+        self.local = provider.NFSProvider(target=None, name=None, **self.local_params)
+
+    def _get_params(self):
+        return {
+            "host": self.host,
+        }
+
+
+exports["NFSProvider"] = NFSProviderExport
 
 
 @attr.s

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -58,6 +58,22 @@ def test_exporter_coordinator_becomes_unreachable(coordinator, exporter):
     coordinator.resume_tree()
 
 
+def test_exporter_nfs_provider_export():
+    # Regression test: NFSProvider has no internal/external attrs (unlike
+    # TFTPProvider/HTTPProvider), so it must not be mapped to
+    # ProviderGenericExport or _get_params() raises an AttributeError.
+    from labgrid.remote.exporter import exports
+
+    export_cls = exports["NFSProvider"]
+    resource = export_cls({"cls": "NFSProvider", "params": {}}, host="exporterhost")
+
+    resource.poll()
+
+    assert resource.params["host"] == "exporterhost"
+    assert "internal" not in resource.params
+    assert "external" not in resource.params
+
+
 def setup_tmp_cert_key(tmpdir):
     cert = "cert.pem"
     cert_file = tmpdir.join(cert)


### PR DESCRIPTION
As opposed to `TFTPProvider` and `HTTPProvider,` which are `BaseProvider` subclasses, `NFSProvider` does not have any internal/external parameters. However, `ProviderGenericExport._get_params()` unconditionally reads these parameters. This raises an `AttributeError` on every poll cycle and the NFS resource never becomes available to clients.

Add a dedicated `NFSProviderExport` that only reports 'host' and map it to `NFSProvider.`