### PR TITLE
fix: parse LG_COORDINATOR_TLS value explicitly

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -451,9 +451,10 @@ certificates to verify the coordinator certificate. Use ``--cacert`` to provide
 a specific CA certificate or CA bundle instead.
 Refer to the ``labgrid-client`` and ``labgrid-exporter`` man pages for details.
 For ``RemotePlace`` connections from an environment config, set the
-``coordinator_tls`` option or ``LG_COORDINATOR_TLS``. If ``coordinator_cacert``
-is not set, labgrid uses the host CA certificates. Set ``coordinator_cacert``
-to provide a specific CA certificate or CA bundle instead.
+``coordinator_tls`` option or set ``LG_COORDINATOR_TLS=true`` (or ``1``). If
+``coordinator_cacert`` is not set, labgrid uses the host CA certificates. Set
+``coordinator_cacert`` to provide a specific CA certificate or CA bundle
+instead.
 
 Using a Strategy
 ----------------

--- a/doc/man/client.rst
+++ b/doc/man/client.rst
@@ -56,8 +56,8 @@ This variable can be used to set the default coordinator in the format
 
 LG_COORDINATOR_TLS
 ~~~~~~~~~~~~~~~~~~
-This variable can be set to enable TLS gRPC channels without using the
-``--tls`` option.
+Set this variable to ``true`` or ``1`` to enable TLS gRPC channels without
+using the ``--tls`` option.
 
 LG_PROXY
 ~~~~~~~~

--- a/doc/man/device-config.rst
+++ b/doc/man/device-config.rst
@@ -45,7 +45,7 @@ OPTIONS KEYS
 
 ``coordinator_tls``
   enables a TLS gRPC channel for ``RemotePlace`` connections.
-  Defaults to whether ``LG_COORDINATOR_TLS`` is set.
+  Defaults to whether ``LG_COORDINATOR_TLS`` is set to ``true`` or ``1``.
 
 ``coordinator_cacert``
   path to a CA certificate or CA bundle in PEM format for verifying the

--- a/labgrid/remote/client.py
+++ b/labgrid/remote/client.py
@@ -1972,7 +1972,7 @@ def get_parser(auto_doc_mode=False) -> "argparse.ArgumentParser | AutoProgramArg
     parser.add_argument(
         "--tls",
         action="store_true",
-        default=os.environ.get("LG_COORDINATOR_TLS") is not None,
+        default=os.environ.get("LG_COORDINATOR_TLS", "").strip().lower() in {"1", "true"},
         help="enable TLS gRPC channel",
     )
     parser.add_argument(

--- a/labgrid/resource/remote.py
+++ b/labgrid/resource/remote.py
@@ -19,7 +19,7 @@ class RemotePlaceManager(ResourceManager):
     def _get_credentials(self):
         from ..remote.common import get_client_credentials
 
-        tls = os.environ.get("LG_COORDINATOR_TLS") is not None
+        tls = os.environ.get("LG_COORDINATOR_TLS", "").strip().lower() in {"1", "true"}
         cacert = None
 
         if self.env:

--- a/man/labgrid-client.1
+++ b/man/labgrid-client.1
@@ -1199,8 +1199,8 @@ This variable can be used to set the default coordinator in the format
 \fBHOST[:PORT]\fP (instead of using the \fB\-x\fP option).
 .SS LG_COORDINATOR_TLS
 .sp
-This variable can be set to enable TLS gRPC channels without using the
-\fB\-\-tls\fP option.
+Set this variable to \fBtrue\fP or \fB1\fP to enable TLS gRPC channels without
+using the \fB\-\-tls\fP option.
 .SS LG_PROXY
 .sp
 This variable can be used to specify a SSH proxy hostname which should be used

--- a/man/labgrid-device-config.5
+++ b/man/labgrid-device-config.5
@@ -63,7 +63,7 @@ Defaults to \fB127.0.0.1:20408\fP\&.
 .TP
 .B \fBcoordinator_tls\fP
 enables a TLS gRPC channel for \fBRemotePlace\fP connections.
-Defaults to whether \fBLG_COORDINATOR_TLS\fP is set.
+Defaults to whether \fBLG_COORDINATOR_TLS\fP is set to \fBtrue\fP or \fB1\fP\&.
 .TP
 .B \fBcoordinator_cacert\fP
 path to a CA certificate or CA bundle in PEM format for verifying the

--- a/tests/test_remote.py
+++ b/tests/test_remote.py
@@ -291,12 +291,12 @@ def _make_remote_place_config(tmpdir, options=None):
     return config
 
 
-def _capture_remote_place_credentials(monkeypatch, tmpdir, *, options=None, tls_env=False):
+def _capture_remote_place_credentials(monkeypatch, tmpdir, *, options=None, tls_env=None):
     monkeypatch.setattr(ResourceManager, "instances", {})
     monkeypatch.delenv("LG_COORDINATOR_TLS", raising=False)
 
-    if tls_env:
-        monkeypatch.setenv("LG_COORDINATOR_TLS", "true")
+    if tls_env is not None:
+        monkeypatch.setenv("LG_COORDINATOR_TLS", tls_env)
 
     class DummySession:
         loop = None
@@ -332,18 +332,22 @@ def _capture_remote_place_credentials(monkeypatch, tmpdir, *, options=None, tls_
 @pytest.mark.parametrize(
     ("options", "tls_env", "expected_tls", "expected_cacert"),
     [
-        pytest.param({}, False, False, None, id="default-no-tls"),
-        pytest.param({}, True, True, None, id="tls-env"),
+        pytest.param({}, None, False, None, id="default-no-tls"),
+        pytest.param({}, "true", True, None, id="tls-env-true"),
+        pytest.param({}, "1", True, None, id="tls-env-1"),
+        pytest.param({}, "false", False, None, id="tls-env-false"),
+        pytest.param({}, "0", False, None, id="tls-env-0"),
+        pytest.param({}, "", False, None, id="tls-env-empty"),
         pytest.param(
             {"coordinator_tls": True, "coordinator_cacert": "cert.pem"},
-            False,
+            None,
             True,
             "cert.pem",
             id="tls-config",
         ),
-        pytest.param({"coordinator_tls": "TRUE"}, False, True, None, id="tls-config-string"),
-        pytest.param({"coordinator_tls": False}, True, False, None, id="config-overrides-env"),
-        pytest.param({"coordinator_tls": "false"}, True, False, None, id="config-string-overrides-env"),
+        pytest.param({"coordinator_tls": "TRUE"}, None, True, None, id="tls-config-string"),
+        pytest.param({"coordinator_tls": False}, "true", False, None, id="config-overrides-env"),
+        pytest.param({"coordinator_tls": "false"}, "true", False, None, id="config-string-overrides-env"),
     ],
 )
 def test_remote_place_client_credentials(monkeypatch, tmpdir, options, tls_env, expected_tls, expected_cacert):
@@ -357,3 +361,35 @@ def test_remote_place_client_credentials(monkeypatch, tmpdir, options, tls_env, 
     assert captured["tls"] is expected_tls
     assert captured["cacert"] == expected_cacert
     assert captured["credentials"] == ("credentials" if expected_tls else None)
+
+
+@pytest.mark.parametrize(
+    ("tls_env", "expected_tls"),
+    [
+        pytest.param(None, False, id="tls-env-unset"),
+        pytest.param("true", True, id="tls-env-true"),
+        pytest.param("1", True, id="tls-env-1"),
+        pytest.param("false", False, id="tls-env-false"),
+        pytest.param("0", False, id="tls-env-0"),
+        pytest.param("", False, id="tls-env-empty"),
+    ],
+)
+def test_client_parser_tls_env_default(monkeypatch, tls_env, expected_tls):
+    from labgrid.remote.client import get_parser
+
+    monkeypatch.delenv("LG_COORDINATOR_TLS", raising=False)
+    if tls_env is not None:
+        monkeypatch.setenv("LG_COORDINATOR_TLS", tls_env)
+
+    args = get_parser().parse_args(["places"])
+
+    assert args.tls is expected_tls
+
+
+def test_client_parser_tls_flag_overrides_false_env(monkeypatch):
+    from labgrid.remote.client import get_parser
+
+    monkeypatch.setenv("LG_COORDINATOR_TLS", "false")
+    args = get_parser().parse_args(["--tls", "places"])
+
+    assert args.tls is True


### PR DESCRIPTION
<!---
Describe what your pull request does,
i.e. fix this bug and how, add a feature, fix documentation…
If you add a feature, please answer these questions:
- what do you use the feature for?
- how does labgrid benefit as a testing library from the feature?
- how did you verify the feature works?
- if hardware is needed for the feature, which hardware is supported and which
  hardware did you test with?
--->
**Description**
Parse LG_COORDINATOR_TLS explicitly so only true enables TLS. Values such as false, 0, or an empty string now correctly leave TLS disabled.
Updates documentation and adds regression tests for both labgrid-client and RemotePlace.
<!---
This checklist roughly outlines the steps for new features, remove and add tasks as needed:
--->
**Checklist**
- [x] Documentation for the feature
- [x] Tests for the feature 
<!---
If you add a driver/resource or modify one:
--->
- [ ] The arguments and description in doc/configuration.rst have been updated
<!---
If you add a feature other drivers/resources can benefit from:
--->
- [ ] Add a section on how to use the feature to doc/usage.rst
<!---
A library feature which other developers can use:
--->
- [ ] Add a section on how to use the feature to doc/development.rst
<!---
Did you test the change locally? If yes, best to mention how you did it in the description section.
--->
- [x] PR has been tested
<!---
If your PR touched the man pages in doc/man, or an argparse struct from which manpages are generated, they have to be regenerated by calling make in the man subdirectory of the project. sphinx with our themes and extensions is required for this, see the README for more information,
--->
- [ ] Man pages have been regenerated

<!---
In case your PR fixes a bug, please reference it in the next line, i.e.
Fixes #[insert number without brackets here]
--->
